### PR TITLE
blog: Tails 7.5 (zh-TW / zh-CN / en)

### DIFF
--- a/docs/en/blog/posts/2026-tails-7-5.md
+++ b/docs/en/blog/posts/2026-tails-7-5.md
@@ -1,0 +1,47 @@
+---
+date: 2026-02-26
+authors:
+    - toomore
+categories:
+    - Update
+    - Tails
+slug: tails-7-5
+image: "assets/images/tails.png"
+summary: "Why Tails 7.5 matters: fresher Thunderbird via Persistent Storage, plus Tor Browser 15.0.7"
+description: "Why Tails 7.5 matters: fresher Thunderbird via Persistent Storage, plus Tor Browser 15.0.7"
+---
+
+# Tails 7.5: closing the Thunderbird gap (and what it means here)
+
+![Tails](./assets/images/tails.png){style="border-radius: 10px;"}
+
+We track [Tails releases](https://tails.net/news/version_7.5/){target="_blank"} because they are part of the same ecosystem as Tor: a portable OS built for anonymity and censorship circumvention. Version **7.5**, announced 2026-02-26, is worth a closer look—not for flashy features, but for how it addresses a long-running **supply-chain timing** problem with email.
+
+## Why this release is worth covering
+
+Thunderbird ships in Tails for people who need IMAP/SMTP without their everyday OS. Email clients are a **high-value target**: they parse untrusted content, handle attachments, and sit next to your identity workflows. Mozilla’s Thunderbird cadence does not line up with Tails’ image-based releases. Until 7.5, that meant the Thunderbird inside a fresh Tails image was **often already behind** the latest upstream release, sometimes with **known vulnerabilities**, only days after a Tails version shipped.
+
+Tails 7.5 offers a practical mitigation: if you enable both **Thunderbird** and **Additional software** in [Persistent Storage](https://tails.net/doc/persistent_storage/configure/index.en.html){target="_blank"}, Thunderbird is installed as **additional software** so the **latest build is pulled from your Persistent Storage on each boot**. That trades a bit of startup work for **narrower exposure**—a reasonable trade for anyone who actually relies on mail in Tails.
+
+For readers in **Taiwan** and similar contexts: many people use Tails episodically—journalism, legal support, or personal safety planning—rather than daily. When the preinstalled mail client is perpetually “almost current,” it is easy to **assume** the environment is fully patched. This change makes that assumption more realistic **if** you opt in to the Persistent Storage features and understand the migration prompt when Thunderbird starts.
+
+<!-- more -->
+
+## Technical changes (short)
+
+- **Tor Browser** [15.0.7](https://blog.torproject.org/new-release-tor-browser-1507/){target="_blank"}, with a **simplified home page**.
+- **Tor** client **0.4.9.5**.
+- **Thunderbird** [140.7.1](https://www.thunderbird.net/en-US/thunderbird/140.7.1esr/releasenotes/){target="_blank"}.
+- Thunderbird now includes a **Mexican Spanish** language pack alongside **Spanish (Spain)**.
+
+Full details: [upstream changelog](https://gitlab.tails.boum.org/tails/tails/-/blob/master/debian/changelog){target="_blank"}.
+
+## Getting 7.5
+
+**Automatic upgrades** run from **Tails 7.0** onward. If something breaks, use the [manual upgrade](https://tails.net/doc/upgrade/index.en.html#manual){target="_blank"} path. New installs: [Windows](https://tails.net/install/windows/index.en.html){target="_blank"}, [macOS](https://tails.net/install/mac/index.en.html){target="_blank"}, [Linux](https://tails.net/install/linux/index.en.html){target="_blank"}, or [expert / Debian·Ubuntu + GnuPG](https://tails.net/install/expert/index.en.html){target="_blank"}. **Reinstalling** wipes Persistent Storage on that stick—plan accordingly.
+
+Downloads only: [USB image](https://tails.net/install/download/index.en.html){target="_blank"}, [ISO](https://tails.net/install/download-iso/index.en.html){target="_blank"}.
+
+!!! info "Source"
+
+    Based on the official announcement [Tails 7.5](https://tails.net/news/version_7.5/){target="_blank"}.

--- a/docs/zh-CN/blog/posts/2026-tails-7-5.md
+++ b/docs/zh-CN/blog/posts/2026-tails-7-5.md
@@ -1,0 +1,63 @@
+---
+date: 2026-02-26
+authors:
+    - toomore
+categories:
+    - 更新
+    - Tails
+slug: tails-7-5
+image: "assets/images/tails.png"
+summary: "Tails 7.5：Tor 浏览器 15.0.7、Thunderbird 可改为以「附加软件」安装以缩短安全空窗期"
+description: "Tails 7.5：Tor 浏览器 15.0.7、Thunderbird 可改为以「附加软件」安装以缩短安全空窗期"
+---
+
+# Tails 7.5 发布说明
+
+![Tails](./assets/images/tails.png){style="border-radius: 10px;"}
+
+[Tails 7.5](https://tails.net/news/version_7.5/){target="_blank"} 于 2026 年 2 月 26 日公告。此版重点除了例行更新 Tor 组件与 Thunderbird 版本外，也通过**将 Thunderbird 改为以「附加软件」安装**的选项，缓解过去镜像内置版本几乎总是落后上游、带有已知漏洞的问题。
+
+## 变更与更新
+
+- 将 Tor 浏览器更新至 [15.0.7](https://blog.torproject.org/new-release-tor-browser-1507/){target="_blank"}。
+- 简化 Tor 浏览器的首页。
+- 将 Tor 客户端更新至 0.4.9.5。
+- 将 Thunderbird 更新至 [140.7.1](https://www.thunderbird.net/en-US/thunderbird/140.7.1esr/releasenotes/){target="_blank"}。
+
+若你同时启用[持久存储](https://tails.net/doc/persistent_storage/configure/index.en.html){target="_blank"}中的 **[Thunderbird 电子邮件客户端](https://tails.net/doc/persistent_storage/configure/index.en.html#thunderbird)** 与 **[附加软件](https://tails.net/doc/persistent_storage/configure/index.en.html#additional_software)** 功能，Tails 会改为**以附加软件方式安装 Thunderbird**，以强化安全性。
+
+在 7.5 之前，Mozilla 常在 Tails 新版本发布后短短几天内又发布新版 Thunderbird，导致镜像内附的 Thunderbird **几乎总是偏旧**，并带有已知安全问题。改为[以附加软件安装 Thunderbird](https://tails.net/doc/anonymous_internet/thunderbird/additional_software/index.en.html){target="_blank"} 后，每次启动 Tails 时会从你的持久存储**自动安装最新版**。若启动 Thunderbird 时出现迁移对话框，代表 Tails 已成功将 Thunderbird 设为以附加软件安装。
+
+- Thunderbird 除西班牙语（西班牙）语言包外，另纳入**墨西哥西班牙语**语言包。
+
+<!-- more -->
+
+如需完整细节，请参阅官方 [changelog](https://gitlab.tails.boum.org/tails/tails/-/blob/master/debian/changelog){target="_blank"}。
+
+## 获取 Tails 7.5
+
+### 升级现有 Tails USB 并保留持久存储
+
+自 **Tails 7.0** 起可自动升级至 7.5。
+
+若无法自动升级，或自动升级后无法启动，请尝试[手动升级](https://tails.net/doc/upgrade/index.en.html#manual){target="_blank"}。
+
+### 在新 USB 上安装 Tails 7.5
+
+请按官方安装说明操作：
+
+- [从 Windows 安装](https://tails.net/install/windows/index.en.html){target="_blank"}
+- [从 macOS 安装](https://tails.net/install/mac/index.en.html){target="_blank"}
+- [从 Linux 安装](https://tails.net/install/linux/index.en.html){target="_blank"}
+- [从 Debian 或 Ubuntu 使用命令行与 GnuPG 安装](https://tails.net/install/expert/index.en.html){target="_blank"}
+
+若选择**重新安装**而非升级，U 盘上的持久存储将会**被清除**。
+
+### 仅下载镜像
+
+- [USB 镜像](https://tails.net/install/download/index.en.html){target="_blank"}
+- [ISO 镜像（光盘与虚拟机）](https://tails.net/install/download-iso/index.en.html){target="_blank"}
+
+!!! info "参考资料"
+
+    本篇整理自 Tails 官方公告 [Tails 7.5](https://tails.net/news/version_7.5/){target="_blank"}。

--- a/docs/zh-TW/blog/posts/2026-tails-7-5.md
+++ b/docs/zh-TW/blog/posts/2026-tails-7-5.md
@@ -1,0 +1,63 @@
+---
+date: 2026-02-26
+authors:
+    - toomore
+categories:
+    - 更新
+    - Tails
+slug: tails-7-5
+image: "assets/images/tails.png"
+summary: "Tails 7.5：Tor Browser 15.0.7、Thunderbird 可改以「附加軟體」安裝以縮短安全空窗期"
+description: "Tails 7.5：Tor Browser 15.0.7、Thunderbird 可改以「附加軟體」安裝以縮短安全空窗期"
+---
+
+# Tails 7.5 發佈說明
+
+![Tails](./assets/images/tails.png){style="border-radius: 10px;"}
+
+[Tails 7.5](https://tails.net/news/version_7.5/){target="_blank"} 於 2026 年 2 月 26 日公告。此版重點除了例行更新 Tor 元件與 Thunderbird 版本外，也透過**將 Thunderbird 改為以「附加軟體」安裝**的選項，緩解過去映像檔內建版幾乎總是落後上游、帶有已知漏洞的問題。
+
+## 變更與更新
+
+- 將 Tor 瀏覽器更新至 [15.0.7](https://blog.torproject.org/new-release-tor-browser-1507/){target="_blank"}。
+- 簡化 Tor 瀏覽器的首頁。
+- 將 Tor 用戶端更新至 0.4.9.5。
+- 將 Thunderbird 更新至 [140.7.1](https://www.thunderbird.net/en-US/thunderbird/140.7.1esr/releasenotes/){target="_blank"}。
+
+若你同時啟用[持久儲存](https://tails.net/doc/persistent_storage/configure/index.en.html){target="_blank"}中的 **[Thunderbird 電子郵件用戶端](https://tails.net/doc/persistent_storage/configure/index.en.html#thunderbird)** 與 **[附加軟體](https://tails.net/doc/persistent_storage/configure/index.en.html#additional_software)** 功能，Tails 會改為**以附加軟體方式安裝 Thunderbird**，以強化安全性。
+
+在 7.5 之前，Mozilla 常在 Tails 新版本釋出後短短幾天內又發佈新版 Thunderbird，導致映像檔內附的 Thunderbird **幾乎總是偏舊**，並帶有已知安全問題。改為[以附加軟體安裝 Thunderbird](https://tails.net/doc/anonymous_internet/thunderbird/additional_software/index.en.html){target="_blank"} 後，每次啟動 Tails 時會從你的持久儲存**自動安裝最新版**。若啟動 Thunderbird 時出現遷移對話框，代表 Tails 已成功將 Thunderbird 設為以附加軟體安裝。
+
+- Thunderbird 除西班牙（西班牙）語系套件外，另納入**墨西哥西班牙語**語系套件。
+
+<!-- more -->
+
+如需完整細節，請參閱官方 [changelog](https://gitlab.tails.boum.org/tails/tails/-/blob/master/debian/changelog){target="_blank"}。
+
+## 取得 Tails 7.5
+
+### 升級現有 Tails USB 並保留持久儲存
+
+自 **Tails 7.0** 起可自動升級至 7.5。
+
+若無法自動升級，或自動升級後無法開機，請改試[手動升級](https://tails.net/doc/upgrade/index.en.html#manual){target="_blank"}。
+
+### 在新 USB 上安裝 Tails 7.5
+
+請依官方安裝說明：
+
+- [從 Windows 安裝](https://tails.net/install/windows/index.en.html){target="_blank"}
+- [從 macOS 安裝](https://tails.net/install/mac/index.en.html){target="_blank"}
+- [從 Linux 安裝](https://tails.net/install/linux/index.en.html){target="_blank"}
+- [從 Debian 或 Ubuntu 以命令列與 GnuPG 安裝](https://tails.net/install/expert/index.en.html){target="_blank"}
+
+若選擇**重新安裝**而非升級，隨身碟上的持久儲存將會**被清除**。
+
+### 僅下載映像檔
+
+- [USB 映像檔](https://tails.net/install/download/index.en.html){target="_blank"}
+- [ISO 映像檔（光碟與虛擬機）](https://tails.net/install/download-iso/index.en.html){target="_blank"}
+
+!!! info "參考資料"
+
+    本篇整理自 Tails 官方公告 [Tails 7.5](https://tails.net/news/version_7.5/){target="_blank"}。


### PR DESCRIPTION
## Summary

Adds three blog posts for the [Tails 7.5](https://tails.net/news/version_7.5/) release (2026-02-26):

- **zh-TW** / **zh-CN**: Translation of the official announcement, with terminology aligned to existing Tails posts.
- **en**: Contextual piece on why the Thunderbird + Persistent Storage change matters (including a short Taiwan-oriented note on episodic Tails use), not a literal back-translation.

## Files

| Locale | Path |
|--------|------|
| zh-TW | `docs/zh-TW/blog/posts/2026-tails-7-5.md` |
| zh-CN | `docs/zh-CN/blog/posts/2026-tails-7-5.md` |
| en | `docs/en/blog/posts/2026-tails-7-5.md` |

Front matter: `slug: tails-7-5`, categories Update/Tails (or 更新/Tails), `date: 2026-02-26`.

## Checks

- `mkdocs build` succeeded for `mkdocs.yml`, `mkdocs_cn.yml`, and `mkdocs_en.yml`.

## Tracking

- Tracked by [toomore/anoni-net-ws#13](https://github.com/toomore/anoni-net-ws/issues/13).

After merge, published URLs will follow the usual docs site pattern (e.g. under `https://anoni.net/docs/` per locale).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change adding new blog content with no runtime or configuration impact beyond site rendering.
> 
> **Overview**
> Adds three new localized blog posts announcing Tails 7.5 (`en`, `zh-CN`, `zh-TW`) with shared front matter (`slug: tails-7-5`, date 2026-02-26) and the Tails image.
> 
> The English post is a contextual write-up emphasizing the security implications of installing Thunderbird via Persistent Storage/Additional Software to reduce version lag; the Chinese posts provide a release-style summary of the same key updates (Tor Browser 15.0.7, Tor 0.4.9.5, Thunderbird 140.7.1, and the new Mexican Spanish language pack).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e2f87f16757ca5172a3ca037566f952ab2012f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->