### PR TITLE
fix(pulse): dedupe hourly snapshots in node_type endpoint

### DIFF
--- a/pulse/backend/routers/vega.py
+++ b/pulse/backend/routers/vega.py
@@ -309,9 +309,9 @@ async def tor_relays_node_type(country: Country, limit: int = 45) -> list[Relays
                 SELECT
                     date(created_at) AS dt,
                     fingerprint,
-                    (CASE WHEN guard_probability > 0 THEN 1 ELSE 0 END) AS guard,
-                    (CASE WHEN middle_probability > 0 THEN 1 ELSE 0 END) AS middle,
-                    (CASE WHEN exit_probability > 0 THEN 1 ELSE 0 END) AS exit
+                    MAX(CASE WHEN guard_probability > 0 THEN 1 ELSE 0 END) AS guard,
+                    MAX(CASE WHEN middle_probability > 0 THEN 1 ELSE 0 END) AS middle,
+                    MAX(CASE WHEN exit_probability > 0 THEN 1 ELSE 0 END) AS exit
                 FROM
                     relay_details
                 WHERE
@@ -320,6 +320,8 @@ async def tor_relays_node_type(country: Country, limit: int = 45) -> list[Relays
                     AND date(created_at)
                         >= (SELECT max_dt FROM max_dt)
                         - (GREATEST(%s::int, 1) - 1) * interval '1 day'
+                GROUP BY
+                    dt, fingerprint
             )
             SELECT
                 dt,


### PR DESCRIPTION
## Summary

- `/api/vega/tor/relays/node_type` 的內層 CTE 沒有對 `(dt, fingerprint)` 去重，外層 `SUM(guard/middle/exit)` 把每個 fingerprint 在當日的 hourly snapshot 重複加總（cron 每小時跑一次，最多 24x）
- 在 CTE 加 `GROUP BY dt, fingerprint`，把 1/0 旗標改用 `MAX(...)` 聚合，語意改為「該 fingerprint 當日是否曾擔任此角色」，跟 `flags` endpoint 的去重模式一致
- 不改 schema、不改 vega-lite 圖表，前端 y 軸數值會自然回到合理量級

## Test plan

- [ ] `cd pulse && docker-compose up -d`
- [ ] `curl 'http://localhost:8000/api/vega/tor/relays/node_type?country=tw&limit=7' | jq .` 確認 guard / middle / exit 數量回到 Tor Metrics 上 TW relay 的同一量級
- [ ] 對照 `curl 'http://localhost:8000/api/vega/tor/relays/running?country=tw&limit=2'` 同一日的 `count(DISTINCT fingerprint)`，確認 node_type 各角色數不超過合理上界
- [ ] 線上部署後重新整理 https://anoni.net/docs/zh-TW/taiwan/tor-relay-watcher/ 的「中繼點類型數量」圖表，確認 y 軸數值合理（_cache TTL 5 分鐘自動過期）

🤖 Generated with [Claude Code](https://claude.com/claude-code)