### PR TITLE
fix(build): unblock strict-mode mkdocs build

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -11,7 +11,7 @@ hide:
 
 > A Taiwan-anchored volunteer observatory for networked freedom across the Sinophone Asia-Pacific.
 
-[:material-account-group: About us](./about/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: Newsletter](./contact.md){ .md-button } [:material-chat-processing-outline: Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](./feed_rss_created.xml){ .md-button }
+[:material-account-group: About us](./about/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: Newsletter](./contact.md){ .md-button } [:material-chat-processing-outline: Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](https://anoni.net/docs/en/feed_rss_created.xml){ .md-button }
 
 ## :material-compass-outline: Why this site exists
 

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -11,7 +11,7 @@ hide:
 
 > 推广 Tor、Tails、OONI，串连台湾的网络自由实践与在地观测。
 
-[:material-account-group: 认识社群](./community/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: 订阅电子报](./contact.md){ .md-button } [:material-chat-processing-outline: 加入 Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](./feed_rss_created.xml){ .md-button }
+[:material-account-group: 认识社群](./community/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: 订阅电子报](./contact.md){ .md-button } [:material-chat-processing-outline: 加入 Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](https://anoni.net/docs/zh-cn/feed_rss_created.xml){ .md-button }
 
 ## :material-account-multiple-outline: 我们是谁、为谁写
 

--- a/docs/zh-TW/index.md
+++ b/docs/zh-TW/index.md
@@ -11,7 +11,7 @@ hide:
 
 > 推廣 Tor、Tails、OONI，串連台灣的網路自由實踐與在地觀測。
 
-[:material-account-group: 認識社群](./community/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: 訂閱電子報](./contact.md){ .md-button } [:material-chat-processing-outline: 加入 Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](./feed_rss_created.xml){ .md-button }
+[:material-account-group: 認識社群](./community/index.md){ .md-button .md-button--primary } [:material-email-fast-outline: 訂閱電子報](./contact.md){ .md-button } [:material-chat-processing-outline: 加入 Matrix](https://matrix.to/#/#community:im.anoni.net){ .md-button target="_blank" rel="noopener" } [:material-rss: RSS](https://anoni.net/docs/feed_rss_created.xml){ .md-button }
 
 ## :material-account-multiple-outline: 我們是誰、為誰寫
 


### PR DESCRIPTION
## Summary

CI run [25597643980](https://github.com/anoni-net/docs/actions/runs/25597643980) failed in strict mode on the merged \`2026-layout\` branch:

\`\`\`
WARNING -  Doc file 'index.md' contains a link './feed_rss_created.xml',
  but the target 'feed_rss_created.xml' is not found among documentation files.
Aborted with 1 warnings in strict mode!
\`\`\`

The RSS feed file is generated by \`mkdocs-rss-plugin\` at build time, but mkdocs strict mode only validates against source markdown files.

## Changes

Homepage RSS button on all three locales (\`zh-TW\`, \`zh-CN\`, \`en\`) → absolute \`https://anoni.net/docs[/<locale>]/feed_rss_created.xml\`. Strict mode treats external URLs as out-of-scope. The IPFS/Onion sed rewrites already cover \`https://anoni.net/docs\`, so those variants stay correct.

## Test plan

- [ ] CI \`BuildDocs\` workflow on merge to \`docs\` (production build environment is Ubuntu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)