### PR TITLE
feat(docs): cross-language 404 fallback for en and zh-CN

### DIFF
--- a/docs/overrides_cn/404.html
+++ b/docs/overrides_cn/404.html
@@ -1,0 +1,36 @@
+{% extends "main.html" %}
+
+{% block content %}
+  <h1>404 - 找不到页面</h1>
+
+  <div id="lang-fallback" hidden style="margin-top: 1.5rem; padding: 1rem 1.2rem; border-left: 4px solid var(--md-accent-fg-color, #4051b5); background: var(--md-default-bg-color--lighter, #f5f5f5);">
+    <p style="margin: 0;">
+      此页面暂无简体中文版本，可以前往繁体中文版：
+      <a id="lang-fallback-link" href="#"></a>
+    </p>
+  </div>
+
+  <script>
+    (function () {
+      var langPrefix = '/zh-cn/';
+      var path = window.location.pathname;
+      var idx = path.indexOf(langPrefix);
+      if (idx < 0) { return; }
+      var before = path.substring(0, idx);
+      var after = path.substring(idx + langPrefix.length);
+      var fallback = before + '/' + after;
+      if (fallback === path) { return; }
+      fetch(fallback, { method: 'GET', redirect: 'follow' })
+        .then(function (res) {
+          if (!res.ok) { return; }
+          var box = document.getElementById('lang-fallback');
+          var link = document.getElementById('lang-fallback-link');
+          if (!box || !link) { return; }
+          link.textContent = fallback;
+          link.setAttribute('href', fallback);
+          box.hidden = false;
+        })
+        .catch(function () { /* silent: keep native 404 */ });
+    })();
+  </script>
+{% endblock %}

--- a/docs/overrides_en/404.html
+++ b/docs/overrides_en/404.html
@@ -1,0 +1,36 @@
+{% extends "main.html" %}
+
+{% block content %}
+  <h1>404 - Not found</h1>
+
+  <div id="lang-fallback" hidden style="margin-top: 1.5rem; padding: 1rem 1.2rem; border-left: 4px solid var(--md-accent-fg-color, #4051b5); background: var(--md-default-bg-color--lighter, #f5f5f5);">
+    <p style="margin: 0;">
+      This page is not yet available in English. You can read the Traditional Chinese version here:
+      <a id="lang-fallback-link" href="#"></a>
+    </p>
+  </div>
+
+  <script>
+    (function () {
+      var langPrefix = '/en/';
+      var path = window.location.pathname;
+      var idx = path.indexOf(langPrefix);
+      if (idx < 0) { return; }
+      var before = path.substring(0, idx);
+      var after = path.substring(idx + langPrefix.length);
+      var fallback = before + '/' + after;
+      if (fallback === path) { return; }
+      fetch(fallback, { method: 'GET', redirect: 'follow' })
+        .then(function (res) {
+          if (!res.ok) { return; }
+          var box = document.getElementById('lang-fallback');
+          var link = document.getElementById('lang-fallback-link');
+          if (!box || !link) { return; }
+          link.textContent = fallback;
+          link.setAttribute('href', fallback);
+          box.hidden = false;
+        })
+        .catch(function () { /* silent: keep native 404 */ });
+    })();
+  </script>
+{% endblock %}


### PR DESCRIPTION
## Summary

- 為 `en` 與 `zh-CN` 兩個語系新增客製 404 模板（`overrides_en/404.html`、`overrides_cn/404.html`），落入 404 時 client-side fetch 偵測 zh-TW 是否有同路徑頁面，存在則注入「前往中文版」提示連結。
- 解決 per-page 語言切換（已客製過 `overrides_*/partials/alternate.html`）會把使用者帶到不存在頁面的體驗問題。
- 連結指向 `/docs/<剩餘路徑>/`（zh-TW 在 `/docs/` 根，無 `zh-tw/` prefix）。

## Context

盤點結果：zh-TW 有 119 頁、zh-CN 有 110 頁（缺 9 頁 interseclab 章節）、en 有 42 頁（缺 79 頁）。zh-CN 報告類缺頁的顯式提示已在 `zh-CN/reports/index.md` 處理。en 與 zh-CN 其他缺頁則靠這次的客製 404 補位。

跨語言 redirect 不適合（mkdocs-redirects 跨不了語言，nginx/CF 層強制跳轉會把使用者從預期語言送到別的語言，體驗差），所以選擇客製 404 + client-side fetch 探測。

## Test plan

- [x] 本地 build 三個語言（zh-TW + en + zh-CN）成功
- [x] `curl` 驗證 5 個情境 server response：
  - `/en/taiwan/pdpa-2025/` 404（en 缺）、`/taiwan/pdpa-2025/` 200（zh-TW 有）→ 應顯示 fallback
  - `/en/does-not-exist/` 404、`/does-not-exist/` 404 → 不應顯示 fallback
  - `/zh-cn/reports/interseclab-network-coup/` 404、`/reports/interseclab-network-coup/` 200 → 應顯示 fallback
  - `/zh-cn/about/` 200、`/en/about/` 200 → 不會進 404
- [ ] CI build 後在 production 瀏覽器測上述四個 URL，確認 JS fetch 行為正確（HEAD 改為 GET，CORS same-origin 不會有問題）
- [ ] 確認 404 頁原生樣式（標題、navigation、footer）完整

## Follow-up

`overrides_*/partials/hreflang_alternate_links.html` 對 zh-TW 獨有頁面會生出指向不存在 URL 的 `<link rel="alternate">`，未來考慮加 build hook 過濾。