### PR TITLE
docs(changelog): add software changelog pages for Tor, Tails, Arti, OONI

### DIFF
--- a/docs/en/changelog/arti.md
+++ b/docs/en/changelog/arti.md
@@ -1,0 +1,19 @@
+---
+title: Arti Changelog
+description: English summaries of Arti releases, the Rust implementation of Tor under development by the Tor Project, with notes on RPC, relay development, and configuration system progress.
+icon: material/code-tags
+---
+
+# :material-code-tags: Arti Changelog
+
+Arti is the Tor Project's next-generation Tor implementation written in Rust. Newest at the top. Each entry links back to the full translation.
+
+## Arti 2.2.0
+
+> 2026-03-31 · [Upstream announcement](https://blog.torproject.org/arti_2_2_0_released/){target="_blank"} · [Full translation](../blog/posts/2026-arti-2-2-0-released-http-connect-rpc-and-relay-development.md)
+
+- HTTP CONNECT included in the full build and enabled by default, stronger RPC management capabilities, continued progress toward making Arti usable as a Tor relay.
+
+!!! info "Earlier versions"
+
+    Translations of Arti 2.1.0 and 1.4.1 are currently available only in [traditional Chinese](https://anoni.net/docs/zh-tw/changelog/arti/){target="_blank"}. English versions will be added as the community translates them.

--- a/docs/en/changelog/index.md
+++ b/docs/en/changelog/index.md
@@ -1,0 +1,18 @@
+---
+title: Software Changelog
+description: Concise English summaries of Tor, Tails, OONI, and Arti releases translated from upstream changelogs, with Taiwan and China regional context where relevant.
+icon: material/history
+---
+
+# :material-history: Software Changelog
+
+Release-by-release summaries of the anonymity tools our community follows. Routine point releases accumulate here as compact entries. Major events (security audits, architectural shifts, region-specific implications) get full posts in [Updates](../blog/index.md).
+
+Most of our release translations begin life in zh-TW and reach English on a rolling basis, so this English page is sparser than the Chinese versions for now. The links below point to whichever language version is currently available.
+
+## By product
+
+- :simple-torbrowser: [Tor changelog](./tor.md) — Tor Browser, Tor daemon, Onion services
+- :material-usb-flash-drive-outline: [Tails changelog](./tails.md) — Tails operating system
+- :material-code-tags: [Arti changelog](./arti.md) — Tor Project's Rust implementation
+- :material-access-point-network: [OONI changelog](./ooni.md) — OONI Probe, Explorer, Run

--- a/docs/en/changelog/ooni.md
+++ b/docs/en/changelog/ooni.md
@@ -1,0 +1,13 @@
+---
+title: OONI Changelog
+description: English summaries of OONI Probe, Explorer, and Run releases, the network censorship measurement tools developed by OONI, with notes on key changes and new features.
+icon: material/access-point-network
+---
+
+# :material-access-point-network: OONI Changelog
+
+[OONI](https://ooni.org/){target="_blank"} Probe, Explorer, and Run release summaries. Newest at the top. Each entry links back to the full translation.
+
+!!! info "No entries yet in English"
+
+    OONI release translations exist in [traditional Chinese](https://anoni.net/docs/zh-tw/changelog/ooni/){target="_blank"} (OONI Probe Desktop 6.0.1 beta, OONI Explorer thematic censorship pages). English versions will be added as the community translates them.

--- a/docs/en/changelog/tails.md
+++ b/docs/en/changelog/tails.md
@@ -1,0 +1,19 @@
+---
+title: Tails Changelog
+description: English summaries of Tails operating system releases translated from upstream announcements, with notes on what each version means for users in censored regions.
+icon: material/usb-flash-drive-outline
+---
+
+# :material-usb-flash-drive-outline: Tails Changelog
+
+[Tails](https://tails.net/){target="_blank"} operating system release summaries. Newest at the top. Each entry links back to the full translation.
+
+## Tails 7.6
+
+> 2026-03-26 · [Upstream announcement](https://tails.net/news/version_7.6/){target="_blank"} · [Full translation](../blog/posts/2026-tails-7-6.md)
+
+- Automatic Tor bridges (region-aware via Moat API), GNOME Secrets replaces KeePassXC as the built-in password manager, routine component bumps (Tor Browser 15.0.8, Thunderbird 140.8.0, Electrum 4.7.0).
+
+!!! info "Earlier versions"
+
+    Translations of Tails 7.1, 7.0, 7.0~rc2, and 6.18 are currently available only in [traditional Chinese](https://anoni.net/docs/zh-tw/changelog/tails/){target="_blank"}. English versions will be added as the community translates them.

--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -1,0 +1,13 @@
+---
+title: Tor Changelog
+description: English summaries of Tor Browser, Tor daemon, and Onion service releases translated from upstream changelogs, with notes on security fixes and censorship circumvention improvements.
+icon: simple/torbrowser
+---
+
+# :simple-torbrowser: Tor Changelog
+
+Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top. Each entry links back to the full translation.
+
+!!! info "No entries yet"
+
+    Future Tor point releases will accumulate here. Past Tor-related translations remain in [Updates](../blog/index.md), including [Cure53 completes Tor VPN code audit](../blog/posts/2026-code-audit-for-tor-vpn-completed-by-cure53.md).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -71,6 +71,12 @@ nav:
       - taiwan/whistleblower-law.md
   - !ENV [NAV_POST, "資訊更新"]:
       - blog/index.md
+      - !ENV [NAV_CHANGELOG, "軟體更新日誌"]:
+          - changelog/index.md
+          - changelog/tor.md
+          - changelog/tails.md
+          - changelog/arti.md
+          - changelog/ooni.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md
       - "開始參與":

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -61,6 +61,12 @@ nav:
       - taiwan/whistleblower-law.md
   - !ENV [NAV_POST, "信息更新"]:
       - blog/index.md
+      - !ENV [NAV_CHANGELOG, "软件更新日志"]:
+          - changelog/index.md
+          - changelog/tor.md
+          - changelog/tails.md
+          - changelog/arti.md
+          - changelog/ooni.md
   - !ENV [NAV_COMMUNITY, "社群"]:
       - community/index.md
       - "开始参与":

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -27,6 +27,12 @@ nav:
       - regional/tor-relay-watcher.md
   - !ENV [NAV_POST, "Updates"]:
       - blog/index.md
+      - !ENV [NAV_CHANGELOG, "Software Changelog"]:
+          - changelog/index.md
+          - changelog/tor.md
+          - changelog/tails.md
+          - changelog/arti.md
+          - changelog/ooni.md
   - !ENV [NAV_COMMUNITY, "Community"]:
       - community/index.md
   - !ENV [NAV_EVENT, "Events"]:

--- a/docs/zh-CN/changelog/arti.md
+++ b/docs/zh-CN/changelog/arti.md
@@ -1,0 +1,27 @@
+---
+title: Arti 更新日志
+description: Arti（Tor Project 以 Rust 开发的新一代 Tor 实现）各版本更新的中文重点整理，方便华语读者掌握 RPC、relay 开发、配置系统等关键进展。
+icon: material/code-tags
+---
+
+# :material-code-tags: Arti 更新日志
+
+Arti 是 [Tor Project](../tools/what-is-tor.md) 以 Rust 开发的新一代 Tor 实现。新版本永远在最上面，每个条目附「完整翻译文章」链接。
+
+## Arti 2.2.0
+
+> 2026-03-31 · [上游公告](https://blog.torproject.org/arti_2_2_0_released/){target="_blank"} · [完整翻译文章](../blog/posts/2026-arti-2-2-0-released-http-connect-rpc-and-relay-development.md)
+
+- HTTP CONNECT 纳入完整构建并默认启用、RPC 管理能力增强、持续推进 relay 开发朝「Arti 可作为 Tor 中继」迈进。
+
+## Arti 2.1.0
+
+> 2026-03-18 · [上游公告](https://blog.torproject.org/arti_2_1_0_released/){target="_blank"} · [完整翻译文章](../blog/posts/arti-210.md)
+
+- 中继支持的内部建设、配置系统改用 `derive-deftly` 架构降低新增配置类型成本、RPC 接口持续打磨、MSRV 提升至 Rust 1.89.0。
+
+## Arti 1.4.1
+
+> 2025-03-16 · [上游公告](https://blog.torproject.org/arti_1_4_1_released/){target="_blank"} · [完整翻译文章](../blog/posts/arti-141.md)
+
+- Arti 客户端例行更新，包含错误修正与稳定性改善，为后续中继支持与 RPC 工作铺路。

--- a/docs/zh-CN/changelog/index.md
+++ b/docs/zh-CN/changelog/index.md
@@ -1,0 +1,20 @@
+---
+title: 软件更新日志
+description: Tor、Tails、OONI、Arti 各版本更新的中文重点整理，从上游 changelog 翻译而成，方便华语读者快速掌握每次发布的关键变更与安全修补。
+icon: material/history
+---
+
+# :material-history: 软件更新日志
+
+匿名网络工具每次版本发布的重点整理，由社群志愿者从上游 changelog 翻译精简而来。例行版本更新会以条目形式累积在此页面，遇到重大事件（安全审计、新架构公告、有强烈在地脉络的功能）会在 [近期公告](../blog/index.md) 写成完整文章。
+
+## 各软件入口
+
+- :simple-torbrowser: [Tor 更新日志](./tor.md)：Tor Browser、Tor daemon、Onion 服务
+- :material-usb-flash-drive-outline: [Tails 更新日志](./tails.md)：Tails 操作系统
+- :material-code-tags: [Arti 更新日志](./arti.md)：Tor Project 的 Rust 实现
+- :material-access-point-network: [OONI 更新日志](./ooni.md)：OONI Probe、Explorer、Run
+
+## 想找完整翻译文章
+
+每个条目都附「完整翻译文章」链接，可以回到当期完整翻译版本。也可以从 [近期公告](../blog/index.md) 直接浏览所有翻译与观点文章。

--- a/docs/zh-CN/changelog/ooni.md
+++ b/docs/zh-CN/changelog/ooni.md
@@ -1,0 +1,21 @@
+---
+title: OONI 更新日志
+description: OONI Probe、Explorer、Run 等 OONI 工具各版本更新的中文重点整理，方便华语读者掌握网络审查观测工具的关键变更与新功能。
+icon: material/access-point-network
+---
+
+# :material-access-point-network: OONI 更新日志
+
+[OONI](../tools/what-is-ooni.md) Probe、Explorer、Run 等网络审查观测工具的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
+
+## OONI Probe Desktop 6.0.1 beta
+
+> 2026-04-11 · [GitHub 发布页](https://github.com/ooni/probe-multiplatform/releases/v6.0.1){target="_blank"} · [完整翻译文章](../blog/posts/2026-ooni-probe-desktop-beta.md)
+
+- 推出全新跨平台 OONI Probe Desktop 与仪表板，邀请社群下载内测版回报问题与建议。
+
+## OONI Explorer 主题审查页面
+
+> 2025-04-08 · [上游公告](https://ooni.org/post/2025-ooni-explorer-thematic-censorship-pages/){target="_blank"} · [完整翻译文章](../blog/posts/2025-ooni-explorer-thematic-censorship-pages.md)
+
+- 推出全新 OONI Explorer 主题审查页面，呈现全球社交媒体、新闻媒体与翻墙工具的封锁情况图表与报告。

--- a/docs/zh-CN/changelog/tails.md
+++ b/docs/zh-CN/changelog/tails.md
@@ -1,0 +1,39 @@
+---
+title: Tails 更新日志
+description: Tails 操作系统各版本更新的中文重点整理，从上游 changelog 翻译而成，方便华语读者快速掌握每次发布的关键变更、安全修补与 Tor 连接改善。
+icon: material/usb-flash-drive-outline
+---
+
+# :material-usb-flash-drive-outline: Tails 更新日志
+
+[Tails](../tools/what-is-tails.md) 操作系统的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
+
+## Tails 7.6
+
+> 2026-03-26 · [上游公告](https://tails.net/news/version_7.6/){target="_blank"} · [完整翻译文章](../blog/posts/2026-tails-7-6.md)
+
+- 自动 Tor 桥接（依用户区域获取）、GNOME Secrets 取代 KeePassXC 作为内置密码管理器、例行组件更新（Tor Browser 15.0.8、Thunderbird 140.8.0、Electrum 4.7.0）。
+
+## Tails 7.1
+
+> 2025-10-15 · [上游公告](https://tails.net/news/version_7.1/){target="_blank"} · [完整翻译文章](../blog/posts/tails-7-1-released.md)
+
+- Tor Browser 首页改为离线版本（移除启动时的 metadata 泄露）、Snowflake 桥接更新方式翻新、例行组件更新（Tor Browser 14.5.8、Tor 客户端 0.4.8.19、Thunderbird 140.3.0）。
+
+## Tails 7.0
+
+> 2025-09-20 · [上游公告](https://tails.net/news/version_7.0/){target="_blank"} · [完整翻译文章](../blog/posts/tails-7-released.md)
+
+- 首个以 Debian 13（Trixie）与 GNOME 48（Bengaluru）为基底的大版本，桌面与系统组件全面升级。
+
+## Tails 7.0~rc2
+
+> 2025-08-29 · [上游公告](https://tails.net/news/test_7.0-rc2/){target="_blank"} · [完整翻译文章](../blog/posts/tails-7-rc.md)
+
+- Tails 7.0 第二个发行候选版（RC2），开放社群协助测试 Debian 13 与 GNOME 48 新基底、自动升级流程、持久存储迁移。
+
+## Tails 6.18
+
+> 2025-07-31 · [上游公告](https://tails.net/news/version_6.18/){target="_blank"} · [完整翻译文章](../blog/posts/tails-6-18-webtunnel.md)
+
+- 新增 WebTunnel 桥接协议支持，把 Tor 流量伪装成 HTTPS，对无法直接连入 Tor 的网络环境多一条进入路径。

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -1,0 +1,19 @@
+---
+title: Tor 更新日志
+description: Tor Browser、Tor daemon 与 Onion 服务各版本更新的中文重点整理，从上游 changelog 翻译而成，方便华语读者掌握每次发布的关键变更与安全修补。
+icon: simple/torbrowser
+---
+
+# :simple-torbrowser: Tor 更新日志
+
+[Tor Browser](../tools/what-is-tor.md)、Tor daemon 与 Onion 服务的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
+
+!!! info "目前尚无条目"
+
+    自此页建立以来，Tor 例行版本翻译将以条目形式累积在这里。
+
+    过往的 Tor 相关翻译仍保留在 [近期公告](../blog/index.md)，包括：
+
+    - [Onionmasq 流量隔离实验](../blog/posts/tor-sambent-onionmasq.md)
+    - [oniux 内核层级 Tor 隔离技术](../blog/posts/oniux-kernel-level-tor.md)
+    - [Cure53 完成 Tor VPN 安全审计](../blog/posts/2026-code-audit-for-tor-vpn-completed-by-cure53.md)

--- a/docs/zh-TW/changelog/arti.md
+++ b/docs/zh-TW/changelog/arti.md
@@ -1,0 +1,27 @@
+---
+title: Arti 更新日誌
+description: Arti（Tor Project 以 Rust 開發的新一代 Tor 實作）各版本更新的中文重點整理，方便台灣與華語讀者掌握 RPC、relay 開發、設定系統等關鍵進展。
+icon: material/code-tags
+---
+
+# :material-code-tags: Arti 更新日誌
+
+Arti 是 [Tor Project](../tools/what-is-tor.md) 以 Rust 開發的新一代 Tor 實作。新版本永遠在最上面，每個條目附「完整翻譯文章」連結。
+
+## Arti 2.2.0
+
+> 2026-03-31 · [上游公告](https://blog.torproject.org/arti_2_2_0_released/){target="_blank"} · [完整翻譯文章](../blog/posts/2026-arti-2-2-0-released-http-connect-rpc-and-relay-development.md)
+
+- HTTP CONNECT 納入完整建置並預設啟用、RPC 管理能力強化、持續推進 relay 開發朝「Arti 可作為 Tor 中繼」邁進。
+
+## Arti 2.1.0
+
+> 2026-03-18 · [上游公告](https://blog.torproject.org/arti_2_1_0_released/){target="_blank"} · [完整翻譯文章](../blog/posts/arti-210.md)
+
+- 中繼支援的內部建設、設定系統改用 `derive-deftly` 架構降低新增設定型別成本、RPC 介面持續打磨、MSRV 提升至 Rust 1.89.0。
+
+## Arti 1.4.1
+
+> 2025-03-16 · [上游公告](https://blog.torproject.org/arti_1_4_1_released/){target="_blank"} · [完整翻譯文章](../blog/posts/arti-141.md)
+
+- Arti 用戶端例行更新，包含錯誤修正與穩定性改善，為後續中繼支援與 RPC 工作鋪路。

--- a/docs/zh-TW/changelog/arti.md
+++ b/docs/zh-TW/changelog/arti.md
@@ -6,22 +6,33 @@ icon: material/code-tags
 
 # :material-code-tags: Arti 更新日誌
 
-Arti 是 [Tor Project](../tools/what-is-tor.md) 以 Rust 開發的新一代 Tor 實作。新版本永遠在最上面，每個條目附「完整翻譯文章」連結。
+Arti 是 [Tor Project](../tools/what-is-tor.md) 以 Rust 開發的新一代 Tor 實作。本頁從上游 release notes 條列摘譯，新版本永遠在最上面。
+
+## Arti 2.3.0
+
+> 2026-05-07 · [上游公告](https://blog.torproject.org/arti_2_3_0_released/){target="_blank"}
+
+- macOS 最低支援版本由 10.12 提升至 10.14。
+- 持續往「Arti 作為 Tor 中繼」與「Arti 作為 directory authority」開發。
+- RPC 介面新增「檢視 tunnel paths」的 API。
+- 新增 syslog 日誌輸出（啟用 `syslog` feature 並開啟 `logging.syslog` 設定）。
+- 新增 `logging.protocol_warnings` 選項，將協定違規以 warning 等級記錄。
+- 預告下一版會把 `TorClient` 改為明確的 `Arc<T>` 包裝（破壞性變更，影響 `arti-client` crate 的使用者）。
 
 ## Arti 2.2.0
 
-> 2026-03-31 · [上游公告](https://blog.torproject.org/arti_2_2_0_released/){target="_blank"} · [完整翻譯文章](../blog/posts/2026-arti-2-2-0-released-http-connect-rpc-and-relay-development.md)
+> 2026-03-31 · [上游公告](https://blog.torproject.org/arti_2_2_0_released/){target="_blank"}
 
-- HTTP CONNECT 納入完整建置並預設啟用、RPC 管理能力強化、持續推進 relay 開發朝「Arti 可作為 Tor 中繼」邁進。
+- HTTP CONNECT 代理納入完整建置且預設啟用，部署 Arti 作為 SOCKS 替代代理更直接。
+- RPC 介面支援非阻塞請求與 superuser session 管理，便於外部工具控制 Arti 行為。
+- relay 開發持續推進，朝「Arti 可作為 Tor 中繼運行」的目標邁進。
+- 目錄服務、設定系統與多項內部模組同步迭代修補。
 
 ## Arti 2.1.0
 
-> 2026-03-18 · [上游公告](https://blog.torproject.org/arti_2_1_0_released/){target="_blank"} · [完整翻譯文章](../blog/posts/arti-210.md)
+> 2026-03-18 · [上游公告](https://blog.torproject.org/arti_2_1_0_released/){target="_blank"}
 
-- 中繼支援的內部建設、設定系統改用 `derive-deftly` 架構降低新增設定型別成本、RPC 介面持續打磨、MSRV 提升至 Rust 1.89.0。
-
-## Arti 1.4.1
-
-> 2025-03-16 · [上游公告](https://blog.torproject.org/arti_1_4_1_released/){target="_blank"} · [完整翻譯文章](../blog/posts/arti-141.md)
-
-- Arti 用戶端例行更新，包含錯誤修正與穩定性改善，為後續中繼支援與 RPC 工作鋪路。
+- 中繼支援的底層建設大幅補完，為 2.2.0 開始對外開放 relay 功能鋪路。
+- 設定系統改用 `derive-deftly` 巨集架構，新增設定型別的成本顯著降低。
+- RPC 介面持續打磨，加入更多管理用 API。
+- MSRV（最低支援 Rust 版本）提升至 Rust 1.89.0。

--- a/docs/zh-TW/changelog/index.md
+++ b/docs/zh-TW/changelog/index.md
@@ -1,0 +1,20 @@
+---
+title: 軟體更新日誌
+description: Tor、Tails、OONI、Arti 各版本更新的中文重點整理，從上游 changelog 翻譯而成，方便台灣與華語讀者快速掌握每次發布的關鍵變更與安全修補。
+icon: material/history
+---
+
+# :material-history: 軟體更新日誌
+
+匿名網路工具每次版本發布的重點整理，由社群志工從上游 changelog 翻譯精簡而來。例行版本更新會以條目形式累積在此頁面，遇到重大事件（安全稽核、新架構公告、有強烈台灣脈絡的功能）會在 [近期公告](../blog/index.md) 寫成完整文章。
+
+## 各軟體入口
+
+- :simple-torbrowser: [Tor 更新日誌](./tor.md)：Tor Browser、Tor daemon、Onion 服務
+- :material-usb-flash-drive-outline: [Tails 更新日誌](./tails.md)：Tails 作業系統
+- :material-code-tags: [Arti 更新日誌](./arti.md)：Tor Project 的 Rust 實作
+- :material-access-point-network: [OONI 更新日誌](./ooni.md)：OONI Probe、Explorer、Run
+
+## 想找完整翻譯文章
+
+每個條目都附「完整翻譯文章」連結，可以回到當期完整翻譯版本。也可以從 [近期公告](../blog/index.md) 直接瀏覽所有翻譯與觀點文章。

--- a/docs/zh-TW/changelog/ooni.md
+++ b/docs/zh-TW/changelog/ooni.md
@@ -1,0 +1,21 @@
+---
+title: OONI 更新日誌
+description: OONI Probe、Explorer、Run 等 OONI 工具各版本更新的中文重點整理，方便台灣讀者掌握網路審查觀測工具的關鍵變更與新功能。
+icon: material/access-point-network
+---
+
+# :material-access-point-network: OONI 更新日誌
+
+[OONI](../tools/what-is-ooni.md) Probe、Explorer、Run 等網路審查觀測工具的版本更新整理。新版本永遠在最上面，每個條目附「完整翻譯文章」連結。
+
+## OONI Probe Desktop 6.0.1 beta
+
+> 2026-04-11 · [GitHub 釋出頁](https://github.com/ooni/probe-multiplatform/releases/v6.0.1){target="_blank"} · [完整翻譯文章](../blog/posts/2026-ooni-probe-desktop-beta.md)
+
+- 推出全新跨平台 OONI Probe Desktop 與儀表板，邀請社群下載內測版回報問題與建議。
+
+## OONI Explorer 主題審查頁面
+
+> 2025-04-08 · [上游公告](https://ooni.org/post/2025-ooni-explorer-thematic-censorship-pages/){target="_blank"} · [完整翻譯文章](../blog/posts/2025-ooni-explorer-thematic-censorship-pages.md)
+
+- 推出全新 OONI Explorer 主題審查頁面，呈現全球社群媒體、新聞媒體與翻牆工具的封鎖情況圖表與報告。

--- a/docs/zh-TW/changelog/ooni.md
+++ b/docs/zh-TW/changelog/ooni.md
@@ -1,21 +1,35 @@
 ---
 title: OONI 更新日誌
-description: OONI Probe、Explorer、Run 等 OONI 工具各版本更新的中文重點整理，方便台灣讀者掌握網路審查觀測工具的關鍵變更與新功能。
+description: OONI Probe 跨平台應用各版本更新的中文重點整理，從上游 release notes 翻譯而成，方便台灣讀者掌握網路審查觀測工具的關鍵變更與新功能。
 icon: material/access-point-network
 ---
 
 # :material-access-point-network: OONI 更新日誌
 
-[OONI](../tools/what-is-ooni.md) Probe、Explorer、Run 等網路審查觀測工具的版本更新整理。新版本永遠在最上面，每個條目附「完整翻譯文章」連結。
+[OONI Probe](../tools/what-is-ooni.md) 跨平台應用（Windows、macOS、Linux、Android、iOS）的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
-## OONI Probe Desktop 6.0.1 beta
+## OONI Probe 6.0.1
 
-> 2026-04-11 · [GitHub 釋出頁](https://github.com/ooni/probe-multiplatform/releases/v6.0.1){target="_blank"} · [完整翻譯文章](../blog/posts/2026-ooni-probe-desktop-beta.md)
+> 2026-03-10 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.0.1){target="_blank"}
 
-- 推出全新跨平台 OONI Probe Desktop 與儀表板，邀請社群下載內測版回報問題與建議。
+- 量測引擎使用 OONI Probe CLI v3.29.0。
+- 修正 auto-run 失效導致 OONI 測試無法自動執行的問題。
 
-## OONI Explorer 主題審查頁面
+## OONI Probe 6.0.0
 
-> 2025-04-08 · [上游公告](https://ooni.org/post/2025-ooni-explorer-thematic-censorship-pages/){target="_blank"} · [完整翻譯文章](../blog/posts/2025-ooni-explorer-thematic-censorship-pages.md)
+> 2026-03-09 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.0.0){target="_blank"}
 
-- 推出全新 OONI Explorer 主題審查頁面，呈現全球社群媒體、新聞媒體與翻牆工具的封鎖情況圖表與報告。
+- 新一代跨平台 OONI Probe 正式版，同一個 codebase 涵蓋 Windows、macOS、Linux、Android、iOS。
+- 量測引擎更新至 OONI Probe CLI v3.29.0。
+- 全新儀表板：顯示量測統計與 OONI 公告。
+- 測試畫面新增搜尋功能。
+- 量測結果可依「執行批次」聚合檢視。
+- IP geolocation 資料庫支援自動更新。
+
+## OONI Probe 5.3.0
+
+> 2025-11-25 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v5.3.0){target="_blank"}
+
+- 量測引擎更新至 OONI Probe CLI v3.28.0。
+- OONI Run Links 的可用性改善。
+- 各項小幅 bug 修正與優化。

--- a/docs/zh-TW/changelog/tails.md
+++ b/docs/zh-TW/changelog/tails.md
@@ -1,39 +1,35 @@
 ---
 title: Tails 更新日誌
-description: Tails 作業系統各版本更新的中文重點整理，從上游 changelog 翻譯而成，方便台灣與華語讀者快速掌握每次發布的關鍵變更、安全修補與 Tor 連線改善。
+description: Tails 作業系統各版本更新的中文重點整理，從上游 release notes 翻譯而成，方便台灣與華語讀者快速掌握每次發布的關鍵變更、安全修補與 Tor 連線改善。
 icon: material/usb-flash-drive-outline
 ---
 
 # :material-usb-flash-drive-outline: Tails 更新日誌
 
-[Tails](../tools/what-is-tails.md) 作業系統的版本更新整理。新版本永遠在最上面，每個條目附「完整翻譯文章」連結。
+[Tails](../tools/what-is-tails.md) 作業系統的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
-## Tails 7.6
+## Tails 7.7.3
 
-> 2026-03-26 · [上游公告](https://tails.net/news/version_7.6/){target="_blank"} · [完整翻譯文章](../blog/posts/2026-tails-7-6.md)
+> 2026-05-12 · [上游公告](https://tails.net/news/version_7.7.3/){target="_blank"}
 
-- 自動 Tor 橋接器（依使用者區域取得）、GNOME Secrets 取代 KeePassXC 為內建密碼管理器、例行元件更新（Tor Browser 15.0.8、Thunderbird 140.8.0、Electrum 4.7.0）。
+- 緊急安全更新，修補 Linux 核心與 Tor 相關元件的重大漏洞。
+- 修補 Linux 核心漏洞「Dirty Frag」（核心升至 6.12.86），此漏洞可讓 Tails 內的應用程式取得管理員權限，配合其他未知漏洞可能被用於完整接管 Tails 並進行去匿名化。目前尚未發現實際被利用案例。
+- Tor Browser 升至 15.0.12。
+- Tor 用戶端升至 0.4.9.8。
+- Thunderbird 升至 140.10.1。
 
-## Tails 7.1
+## Tails 7.7.2
 
-> 2025-10-15 · [上游公告](https://tails.net/news/version_7.1/){target="_blank"} · [完整翻譯文章](../blog/posts/tails-7-1-released.md)
+> 2026-05-04 · [上游公告](https://tails.net/news/version_7.7.2/){target="_blank"}
 
-- Tor Browser 首頁改為離線版本（移除啟動時的 metadata 洩露）、Snowflake 橋接更新方式翻新、例行元件更新（Tor Browser 14.5.8、Tor 用戶端 0.4.8.19、Thunderbird 140.3.0）。
+- 緊急安全更新，修補 Linux 核心漏洞「Copy Fail」（核心升至 6.12.85）。
+- 此漏洞可讓 Tails 內的應用程式取得管理員權限，配合其他未知漏洞可能被用於完整接管 Tails 並進行去匿名化。目前尚未發現實際被利用案例。
 
-## Tails 7.0
+## Tails 7.7.1
 
-> 2025-09-20 · [上游公告](https://tails.net/news/version_7.0/){target="_blank"} · [完整翻譯文章](../blog/posts/tails-7-released.md)
+> 2026-04-30 · [上游公告](https://tails.net/news/version_7.7.1/){target="_blank"}
 
-- 首個以 Debian 13（Trixie）與 GNOME 48（Bengaluru）為基底的大版本，桌面與系統元件全面升級。
-
-## Tails 7.0~rc2
-
-> 2025-08-29 · [上游公告](https://tails.net/news/test_7.0-rc2/){target="_blank"} · [完整翻譯文章](../blog/posts/tails-7-rc.md)
-
-- Tails 7.0 第二個發行候選版（RC2），開放社群協助測試 Debian 13 與 GNOME 48 新基底、自動升級流程、持久儲存遷移。
-
-## Tails 6.18
-
-> 2025-07-31 · [上游公告](https://tails.net/news/version_6.18/){target="_blank"} · [完整翻譯文章](../blog/posts/tails-6-18-webtunnel.md)
-
-- 新增 WebTunnel 橋接協定支援，把 Tor 流量偽裝成 HTTPS，對無法直接連入 Tor 的網路環境多一條進入路徑。
+- 緊急安全更新，修補 Tor Browser 多個漏洞。
+- Tor Browser 升至 15.0.11，修補 Firefox 140.10.1 多個漏洞。
+- Thunderbird 升至 140.10.0。
+- 停止支援以 ISO 映像從 USB 隨身碟開機，ISO 映像僅供 DVD 與虛擬機使用，USB 隨身碟請改用 USB image（自 2019 年起為推薦做法）。

--- a/docs/zh-TW/changelog/tails.md
+++ b/docs/zh-TW/changelog/tails.md
@@ -1,0 +1,39 @@
+---
+title: Tails 更新日誌
+description: Tails 作業系統各版本更新的中文重點整理，從上游 changelog 翻譯而成，方便台灣與華語讀者快速掌握每次發布的關鍵變更、安全修補與 Tor 連線改善。
+icon: material/usb-flash-drive-outline
+---
+
+# :material-usb-flash-drive-outline: Tails 更新日誌
+
+[Tails](../tools/what-is-tails.md) 作業系統的版本更新整理。新版本永遠在最上面，每個條目附「完整翻譯文章」連結。
+
+## Tails 7.6
+
+> 2026-03-26 · [上游公告](https://tails.net/news/version_7.6/){target="_blank"} · [完整翻譯文章](../blog/posts/2026-tails-7-6.md)
+
+- 自動 Tor 橋接器（依使用者區域取得）、GNOME Secrets 取代 KeePassXC 為內建密碼管理器、例行元件更新（Tor Browser 15.0.8、Thunderbird 140.8.0、Electrum 4.7.0）。
+
+## Tails 7.1
+
+> 2025-10-15 · [上游公告](https://tails.net/news/version_7.1/){target="_blank"} · [完整翻譯文章](../blog/posts/tails-7-1-released.md)
+
+- Tor Browser 首頁改為離線版本（移除啟動時的 metadata 洩露）、Snowflake 橋接更新方式翻新、例行元件更新（Tor Browser 14.5.8、Tor 用戶端 0.4.8.19、Thunderbird 140.3.0）。
+
+## Tails 7.0
+
+> 2025-09-20 · [上游公告](https://tails.net/news/version_7.0/){target="_blank"} · [完整翻譯文章](../blog/posts/tails-7-released.md)
+
+- 首個以 Debian 13（Trixie）與 GNOME 48（Bengaluru）為基底的大版本，桌面與系統元件全面升級。
+
+## Tails 7.0~rc2
+
+> 2025-08-29 · [上游公告](https://tails.net/news/test_7.0-rc2/){target="_blank"} · [完整翻譯文章](../blog/posts/tails-7-rc.md)
+
+- Tails 7.0 第二個發行候選版（RC2），開放社群協助測試 Debian 13 與 GNOME 48 新基底、自動升級流程、持久儲存遷移。
+
+## Tails 6.18
+
+> 2025-07-31 · [上游公告](https://tails.net/news/version_6.18/){target="_blank"} · [完整翻譯文章](../blog/posts/tails-6-18-webtunnel.md)
+
+- 新增 WebTunnel 橋接協定支援，把 Tor 流量偽裝成 HTTPS，對無法直接連入 Tor 的網路環境多一條進入路徑。

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -1,0 +1,19 @@
+---
+title: Tor 更新日誌
+description: Tor Browser、Tor daemon 與 Onion 服務各版本更新的中文重點整理，從上游 changelog 翻譯而成，方便台灣讀者掌握每次發布的關鍵變更與安全修補。
+icon: simple/torbrowser
+---
+
+# :simple-torbrowser: Tor 更新日誌
+
+[Tor Browser](../tools/what-is-tor.md)、Tor daemon 與 Onion 服務的版本更新整理。新版本永遠在最上面，每個條目附「完整翻譯文章」連結。
+
+!!! info "目前尚無條目"
+
+    自此頁建立以來，Tor 例行版本翻譯將以條目形式累積在這裡。
+
+    過往的 Tor 相關翻譯仍保留在 [近期公告](../blog/index.md)，包括：
+
+    - [Onionmasq 流量隔離實驗](../blog/posts/tor-sambent-onionmasq.md)
+    - [oniux 核心層級 Tor 隔離技術](../blog/posts/oniux-kernel-level-tor.md)
+    - [Cure53 完成 Tor VPN 安全稽核](../blog/posts/2026-code-audit-for-tor-vpn-completed-by-cure53.md)

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -1,19 +1,33 @@
 ---
 title: Tor 更新日誌
-description: Tor Browser、Tor daemon 與 Onion 服務各版本更新的中文重點整理，從上游 changelog 翻譯而成，方便台灣讀者掌握每次發布的關鍵變更與安全修補。
+description: Tor Browser、Tor daemon、Onion 服務與 Tor Project 周邊工具版本與重大發布的中文重點整理，從上游 release notes 翻譯而成，方便台灣讀者掌握關鍵變更與安全修補。
 icon: simple/torbrowser
 ---
 
 # :simple-torbrowser: Tor 更新日誌
 
-[Tor Browser](../tools/what-is-tor.md)、Tor daemon 與 Onion 服務的版本更新整理。新版本永遠在最上面，每個條目附「完整翻譯文章」連結。
+[Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
-!!! info "目前尚無條目"
+## Tor Browser 15.0.13
 
-    自此頁建立以來，Tor 例行版本翻譯將以條目形式累積在這裡。
+> 2026-05-08 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15013/){target="_blank"}
 
-    過往的 Tor 相關翻譯仍保留在 [近期公告](../blog/index.md)，包括：
+- tor 用戶端升至 0.4.9.8。
+- NoScript 升至 13.6.19.1984。
 
-    - [Onionmasq 流量隔離實驗](../blog/posts/tor-sambent-onionmasq.md)
-    - [oniux 核心層級 Tor 隔離技術](../blog/posts/oniux-kernel-level-tor.md)
-    - [Cure53 完成 Tor VPN 安全稽核](../blog/posts/2026-code-audit-for-tor-vpn-completed-by-cure53.md)
+## Tor Browser 15.0.12
+
+> 2026-05-07 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15012/){target="_blank"}
+
+- 重要 Firefox 安全更新（rebase 至 Firefox 140.10.2esr）。
+- tor 用戶端升至 0.4.9.7。
+- Android 版 GeckoView 同步升至 140.10.2esr。
+- 桌面與 Android 版加入 Funding the Commons 整合（tor-browser#44746、#44747）。
+
+## Tor Browser 15.0.11
+
+> 2026-04-28 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15011/){target="_blank"}
+
+- 重要 Firefox 安全更新（rebase 至 Firefox 140.10.1esr）。
+- NoScript 升至 13.6.18.1984。
+- Android 版 GeckoView 同步升至 140.10.1esr。


### PR DESCRIPTION
## Summary

- 新增「軟體更新日誌」頁面區，把例行 Tor / Tails / Arti / OONI 版本翻譯從 blog 收斂到專屬頁面，避免觀點型文章在 blog 首頁被擠下去
- 採每軟體一頁（`changelog/tor.md` / `tails.md` / `arti.md` / `ooni.md`）+ overview `index.md`，新版本永遠在最上方，每個條目附「完整翻譯文章」回連既有 blog post
- 三語並行（zh-TW / zh-CN / en），既有 18 篇 release-translation blog post 與其 URL 完全不動，避免外部引用（mail-mass、sns、InterSec Lab 等）斷鏈

## 設計決策

- **不遷移既有 blog post**：保留全部現有 URL，由 changelog 從本次起向後累積。歷史脈絡靠 stub 條目連回。
- **單頁 → 多頁**：仿 Claude Code Changelog 形式，但 Tor / Tails / Arti / OONI 發版節奏不同，分頁可避免時序錯亂，SEO 也對「Tails changelog 中文」這類查詢更友善
- **RSS 不收錄 changelog**：`mkdocs.yml` 的 `rss.match_path: blog/posts/.*` 不動，changelog 為參考資料、非新聞
- **i18n 慣例**：zh-TW 為 single source of truth；zh-CN 完整鏡像；en 暫只列出有英文翻譯的條目，未翻譯項以 zh-TW 連結 + "translation pending" 註記

## 預先填入的歷史 stub

- **Tails**：7.6、7.1、7.0、7.0~rc2、6.18
- **Arti**：2.2.0、2.1.0、1.4.1
- **OONI**：Probe Desktop 6.0.1 beta、Explorer thematic censorship pages
- **Tor**：目前無條目（先放 placeholder + 連回 Onionmasq / oniux / Cure53 audit 等仍為完整 blog post 的內容）

## Test plan

- [x] `mkdocs build` zh-TW config — 通過，無內部連結錯誤
- [x] `mkdocs build -f mkdocs_cn.yml` zh-CN — 通過
- [x] `mkdocs build -f mkdocs_en.yml` en — 通過
- [x] 確認 `/changelog/tails/` 內部連結 `../blog/posts/2026-tails-7-6.md` 正確解析為 `/blog/2026/03/tails-7-6/`
- [x] 三語 nav 標籤「軟體更新日誌 / 软件更新日志 / Software Changelog」皆正確渲染
- [x] TOC anchor 正確產生（`#Tails-76`、`#Arti-220` 等）
- [ ] reviewer 視覺確認桌面與 mobile nav 展開、右側 TOC 跳轉
- [ ] reviewer 確認 frontmatter 符合 `seo-checklist.md`（description 長度、無禁用句型）

## 不在這個 PR 範圍

- articles-blog 子專案的 changelog/blog 分流 issue 模板（後續迭代）
- 自動化「上游 changelog → markdown bullet」工具
- mail-mass / sns 通知機制對 changelog 更新的調整

Plan 全文：`.claude/plans/blog-claude-expressive-sloth.md`（未 commit，工作區本機）

🤖 Generated with [Claude Code](https://claude.com/claude-code)