### PR TITLE
Pin mkdocs to 1.x and suppress MkDocs 2.0 warnings

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -5,9 +5,10 @@ description = "About OONI Probe and ASNs finding in Taiwan."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "mkdocs>=1.6,<2",
     "mkdocs-charts-plugin>=0.0.12",
     "mkdocs-git-revision-date-localized-plugin>=1.4.5",
-    "mkdocs-material[imaging]>=9.6.12",
+    "mkdocs-material[imaging]>=9.7,<10",
     "mkdocs-redirects>=1.2.2",
     "mkdocs-rss-plugin>=1.17.1",
 ]

--- a/docs/run.sh
+++ b/docs/run.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
+export DISABLE_MKDOCS_2_WARNING=true
+export NO_MKDOCS_2_WARNING=true
+
 mkdocs build -v -s -d ./output

--- a/docs/run_en.sh
+++ b/docs/run_en.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export DISABLE_MKDOCS_2_WARNING=true
+export NO_MKDOCS_2_WARNING=true
 export DOCS_DIR='en'
 export SITE_NAME='anoni.net Docs — Sinophone Asia-Pacific Networked Freedom Observatory'
 export SITE_URL='https://anoni.net/docs/en/'

--- a/docs/run_zh-cn.sh
+++ b/docs/run_zh-cn.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export DISABLE_MKDOCS_2_WARNING=true
+export NO_MKDOCS_2_WARNING=true
 export DOCS_DIR='zh-CN'
 export SITE_NAME='匿名网络社群 Anoni.net/Docs'
 export SITE_URL='https://anoni.net/docs/zh-cn/'

--- a/docs/run_zh-tw.sh
+++ b/docs/run_zh-tw.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export DISABLE_MKDOCS_2_WARNING=true
+export NO_MKDOCS_2_WARNING=true
 export SITE_URL='https://anoni.net/docs/zh-tw/'
 
 mkdocs build -v -s -d ./output/zh-tw

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -7,6 +7,7 @@ name = "anoni-net-docs"
 version = "2025.12.31"
 source = { virtual = "." }
 dependencies = [
+    { name = "mkdocs" },
     { name = "mkdocs-charts-plugin" },
     { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-material", extra = ["imaging"] },
@@ -21,9 +22,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "mkdocs", specifier = ">=1.6,<2" },
     { name = "mkdocs-charts-plugin", specifier = ">=0.0.12" },
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.4.5" },
-    { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.6.12" },
+    { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.7,<10" },
     { name = "mkdocs-redirects", specifier = ">=1.2.2" },
     { name = "mkdocs-rss-plugin", specifier = ">=1.17.1" },
 ]


### PR DESCRIPTION
## Summary

- Pin `mkdocs>=1.6,<2` and `mkdocs-material[imaging]>=9.7,<10` so a future `pip install mkdocs` cannot pull in 2.0 and silently break the build
- Export `DISABLE_MKDOCS_2_WARNING=true` and `NO_MKDOCS_2_WARNING=true` in all four run scripts to suppress the ProperDocs / Material 2.0 upgrade banners that plugins now inject into build output
- Regenerate `uv.lock` (resolves to mkdocs 1.6.1 + mkdocs-material 9.7.6)

Context: Zensical (the Material team's successor) is not yet at feature parity for this site's plugin/override-heavy setup. Decision is to stay on Material 9.7.x and re-evaluate around 2026-Q3, before Material's 2026-11 security maintenance window ends.

## Test plan

- [x] `uv lock` resolves cleanly (58 packages)
- [x] `uv run bash run_zh-tw.sh` succeeds in strict mode (9.95s, exit 0)
- [x] Build log no longer contains "MkDocs may break" / "ProperDocs" warning text
- [ ] zh-CN and en builds (smoke check after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)