### PR TITLE
docs(changelog): add Tor Browser 16.0a6 alpha entry

### DIFF
--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -6,7 +6,7 @@ icon: simple/torbrowser
 
 # :simple-torbrowser: Tor 更新日誌
 
-[Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
+[Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注。
 
 ## Tor Browser 15.0.13
 
@@ -14,6 +14,19 @@ icon: simple/torbrowser
 
 - tor 用戶端升至 0.4.9.8。
 - NoScript 升至 13.6.19.1984。
+
+## Tor Browser 16.0a6（Alpha 測試通道）
+
+> 2026-05-07 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a6/){target="_blank"}
+
+- Alpha 通道僅供測試，可能含影響可用性、安全與隱私的錯誤，一般使用者請繼續用穩定版（15.x）。
+- 自此版起，Tor Browser Alpha 改以 Firefox beta 通道（150.0a1）為基底，過去是以 Firefox ESR 為基底。
+- tor 用戶端升至 0.4.9.7。
+- NoScript 升至 13.6.18.90101984。
+- OpenSSL 升至 3.5.6。
+- 預設橋接設定中的 Snowflake STUN 伺服器清單更新至 2026 版。
+- Linux i686 使用者會收到「不再提供更新」的通知。
+- Android 版 GeckoView 同步升至 150.0a1。
 
 ## Tor Browser 15.0.12
 


### PR DESCRIPTION
## Summary

- 收錄 Tor Browser 16.0a6（Alpha 測試通道，2026-05-07）到 `docs/zh-TW/changelog/tor.md`，置於 15.0.13 之後、15.0.12 之前
- 前言補一句「本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注」，方便只看穩定版的讀者跳過
- 上游來源：[New Alpha Release: Tor Browser 16.0a6](https://blog.torproject.org/new-alpha-release-tor-browser-160a6/)

## 條目重點

- Alpha 通道僅供測試，一般使用者請繼續用穩定版（15.x）
- 自此版起 Tor Browser Alpha 改以 Firefox beta 通道（150.0a1）為基底，過去是以 Firefox ESR 為基底
- tor 0.4.9.7、NoScript 13.6.18.90101984、OpenSSL 3.5.6
- 預設橋接設定中的 Snowflake STUN 伺服器清單更新至 2026 版
- Linux i686 使用者會收到「不再提供更新」的通知
- Android 版 GeckoView 同步升至 150.0a1

## Test plan

- [ ] 本機 `mkdocs serve` 確認 `/zh-TW/changelog/tor/` 渲染正常、新條目在 15.0.13 之後 15.0.12 之前
- [ ] 確認上游連結 `https://blog.torproject.org/new-alpha-release-tor-browser-160a6/` 可開
- [ ] zh-CN/en 兩語系暫不同步（這兩語的 changelog/tor.md 仍是「目前尚無條目」placeholder）

🤖 Generated with [Claude Code](https://claude.com/claude-code)