### PR TITLE
docs(changelog): add Tor Browser 15.0.14 and Tails 7.8

### DIFF
--- a/docs/en/changelog/tails.md
+++ b/docs/en/changelog/tails.md
@@ -8,6 +8,19 @@ icon: material/usb-flash-drive-outline
 
 [Tails](https://tails.net/){target="_blank"} operating system release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tails 7.8
+
+> 2026-05-21 · [Upstream announcement](https://tails.net/news/version_7.8/){target="_blank"}
+
+- Tor Browser updated to 15.0.14 (based on Firefox ESR 140.11).
+- Mitigates the Linux kernel local privilege escalation "Fragnesia" (alongside the earlier "Drity Frag" mitigation). Such flaws let an application inside Tails gain administrator privileges, which combined with other unknown vulnerabilities could fully compromise Tails and deanonymize the user.
+- Mitigates a Flatpak sandbox escape via Yelp; yelp updated to 42.2-4tails1.
+- Patches CVE-2026-46529 (evince), CVE-2026-41989 (libgcrypt20), and CVE-2026-41054 (haveged).
+- Thunderbird is no longer shipped with the image. It can still be installed automatically through Persistent Storage's additional software, pulling the latest version from Debian on each Tails startup. The previously bundled version was often out of date because Debian's Thunderbird update typically lands shortly after each Tails release, both of which follow Firefox's release cadence.
+- Base system upgraded to Debian Trixie 13.5.
+- The Secure Boot CA upgrade prompt now only appears when Secure Boot is enabled, avoiding misleading notifications when it is disabled.
+- WhisperBack error reports now include installed Flatpak applications and runtimes.
+
 ## Tails 7.6
 
 > 2026-03-26 · [Upstream announcement](https://tails.net/news/version_7.6/){target="_blank"} · [Full translation](../blog/posts/2026-tails-7-6.md)
@@ -16,4 +29,4 @@ icon: material/usb-flash-drive-outline
 
 !!! info "Earlier versions"
 
-    Translations of Tails 7.1, 7.0, 7.0~rc2, and 6.18 are currently available only in [traditional Chinese](https://anoni.net/docs/zh-tw/changelog/tails/){target="_blank"}. English versions will be added as the community translates them.
+    Translations of Tails 7.7.3, 7.7.2, 7.7.1, 7.7, 7.1, 7.0, 7.0~rc2, and 6.18 are currently available only in [traditional Chinese](https://anoni.net/docs/zh-tw/changelog/tails/){target="_blank"}. English versions will be added as the community translates them.

--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -8,6 +8,17 @@ icon: simple/torbrowser
 
 Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top. Each entry links back to the full translation.
 
-!!! info "No entries yet"
+## Tor Browser 15.0.14
 
-    Future Tor point releases will accumulate here. Past Tor-related translations remain in [Updates](../blog/index.md), including [Cure53 completes Tor VPN code audit](../blog/posts/2026-code-audit-for-tor-vpn-completed-by-cure53.md).
+> 2026-05-19 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15014/){target="_blank"}
+
+- Important Firefox security update, backporting fixes from Firefox 151 (tor-browser#44958).
+- Rebased onto Firefox 140.11.0esr.
+- GeckoView on Android updated to 140.11.0esr.
+- Build toolchain: Go updated to 1.25.10.
+
+!!! info "Earlier Tor Browser versions"
+
+    Tor Browser 15.0.13, 16.0a6 (alpha), 15.0.12, 15.0.11, and earlier entries are currently available only in [traditional Chinese](https://anoni.net/docs/zh-tw/changelog/tor/){target="_blank"}. English versions will be added as the community translates them.
+
+    Past Tor-related translations also live in [Updates](../blog/index.md), including [Cure53 completes Tor VPN code audit](../blog/posts/2026-code-audit-for-tor-vpn-completed-by-cure53.md).

--- a/docs/zh-CN/changelog/tails.md
+++ b/docs/zh-CN/changelog/tails.md
@@ -8,6 +8,23 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 操作系统的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tails 7.8
+
+> 2026-05-21 · [上游公告](https://tails.net/news/version_7.8/){target="_blank"}
+
+- Tor Browser 升至 15.0.14（基于 Firefox ESR 140.11）。
+- 修补 Linux 内核本地提权漏洞「Fragnesia」（同步缓解「Drity Frag」）。此类漏洞可让 Tails 内的应用程序取得管理员权限，配合其他未知漏洞可能被用于完整接管 Tails 并进行去匿名化。
+- 修补 Flatpak 通过 Yelp 逃逸沙箱的问题，yelp 升至 42.2-4tails1。
+- 修补 CVE-2026-46529（evince）、CVE-2026-41989（libgcrypt20）、CVE-2026-41054（haveged）。
+- 移除内置 Thunderbird。仍可通过持久存储的 additional software 自动安装，每次启动 Tails 时从 Debian 仓库拉取最新版本。原因是 Tails 发布节奏跟着 Firefox，Debian 的 Thunderbird 新版通常稍晚才到，过去导致 Tails 内置版本常带已知漏洞。
+- 底层升级至 Debian Trixie 13.5。
+- Secure Boot CA 升级通知改为只在 Secure Boot 已启用时才显示，避免在停用情境下出现混淆信息。
+- WhisperBack 错误回报加入已安装的 Flatpak 应用程序与 runtimes 清单。
+
+!!! info "Tails 7.7.x 系列"
+
+    Tails 7.7.3、7.7.2、7.7.1、7.7 等条目目前仅在 [正体中文版](https://anoni.net/docs/zh-tw/changelog/tails/){target="_blank"} 提供，简体中文版会随社群翻译滚动补上。
+
 ## Tails 7.6
 
 > 2026-03-26 · [上游公告](https://tails.net/news/version_7.6/){target="_blank"} · [完整翻译文章](../blog/posts/2026-tails-7-6.md)

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -8,11 +8,20 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon 与 Onion 服务的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
-!!! info "目前尚无条目"
+## Tor Browser 15.0.14
 
-    自此页建立以来，Tor 例行版本翻译将以条目形式累积在这里。
+> 2026-05-19 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15014/){target="_blank"}
 
-    过往的 Tor 相关翻译仍保留在 [近期公告](../blog/index.md)，包括：
+- 重要 Firefox 安全更新，backport 自 Firefox 151 的修补（tor-browser#44958）。
+- rebase 至 Firefox 140.11.0esr。
+- Android 版 GeckoView 同步升至 140.11.0esr。
+- 构建工具链的 Go 升至 1.25.10。
+
+!!! info "更早的 Tor Browser 版本"
+
+    Tor Browser 15.0.13、16.0a6（Alpha 测试通道）、15.0.12、15.0.11 等条目目前仅在 [正体中文版](https://anoni.net/docs/zh-tw/changelog/tor/){target="_blank"} 提供，简体中文版会随社群翻译滚动补上。
+
+    更多 Tor 相关翻译保留在 [近期公告](../blog/index.md)，包括：
 
     - [Onionmasq 流量隔离实验](../blog/posts/tor-sambent-onionmasq.md)
     - [oniux 内核层级 Tor 隔离技术](../blog/posts/oniux-kernel-level-tor.md)

--- a/docs/zh-TW/changelog/tails.md
+++ b/docs/zh-TW/changelog/tails.md
@@ -8,6 +8,19 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 作業系統的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
+## Tails 7.8
+
+> 2026-05-21 · [上游公告](https://tails.net/news/version_7.8/){target="_blank"}
+
+- Tor Browser 升至 15.0.14（基於 Firefox ESR 140.11）。
+- 修補 Linux 核心本機提權漏洞「Fragnesia」（同步緩解「Drity Frag」）。此類漏洞可讓 Tails 內的應用程式取得管理員權限，配合其他未知漏洞可能被用於完整接管 Tails 並進行去匿名化。
+- 修補 Flatpak 透過 Yelp 逃逸 sandbox 的問題，yelp 升至 42.2-4tails1。
+- 修補 CVE-2026-46529（evince）、CVE-2026-41989（libgcrypt20）、CVE-2026-41054（haveged）。
+- 移除內建 Thunderbird。仍可透過 Persistent Storage 的 additional software 自動安裝，每次啟動 Tails 時拉取 Debian 倉庫的最新版本。原因是 Tails 釋出節奏跟著 Firefox，Debian 的 Thunderbird 新版通常稍晚才到，過去導致 Tails 內建版本常帶已知漏洞。
+- 底層升級至 Debian Trixie 13.5。
+- Secure Boot CA 升級通知改為只在 Secure Boot 已啟用時才顯示，避免在停用情境下出現混淆訊息。
+- WhisperBack 錯誤回報加入已安裝的 Flatpak 應用程式與 runtimes 清單。
+
 ## Tails 7.7.3
 
 > 2026-05-12 · [上游公告](https://tails.net/news/version_7.7.3/){target="_blank"}

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -8,6 +8,15 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注。
 
+## Tor Browser 15.0.14
+
+> 2026-05-19 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15014/){target="_blank"}
+
+- 重要 Firefox 安全更新，backport 自 Firefox 151 的修補（tor-browser#44958）。
+- rebase 至 Firefox 140.11.0esr。
+- Android 版 GeckoView 同步升至 140.11.0esr。
+- 建置工具鏈的 Go 升至 1.25.10。
+
 ## Tor Browser 15.0.13
 
 > 2026-05-08 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15013/){target="_blank"}


### PR DESCRIPTION
## Summary

- 補入 Tor Browser 15.0.14（2026-05-19）：Firefox 140.11.0esr 安全更新、backport 自 Firefox 151 的修補、GeckoView 同步升級、Go 工具鏈升至 1.25.10
- 補入 Tails 7.8（2026-05-21）：升 Tor Browser 15.0.14、修補 Linux 核心 LPE「Fragnesia」與 Flatpak/Yelp sandbox 逃逸、修補 evince/libgcrypt20/haveged CVE、移除內建 Thunderbird 改走 Persistent Storage 的 additional software、底層升至 Debian Trixie 13.5
- zh-TW、zh-CN、en 三語系都已同步
- zh-CN/en 的 tor.md 原為「尚無條目」狀態，加入此次新版時順手把 admonition 改為「更早版本」並指向 zh-TW；en tails.md 的「Earlier versions」清單也補入 7.7.x 系列

## Test plan

- [ ] `cd docs && sh run_zh-tw.sh` 確認 `/changelog/tor/` 與 `/changelog/tails/` 新條目可正常渲染
- [ ] `cd docs && sh run_zh-cn.sh` 與 `sh run_en.sh` 確認另兩個語系也能渲染
- [ ] 確認外部連結（blog.torproject.org、tails.net）可開啟
- [ ] 標點與寫作風格通過 anoni-docs-style.md 自檢

🤖 Generated with [Claude Code](https://claude.com/claude-code)