### PR TITLE
docs(blog): zh-CN + en translations of CryptPad zh_Hant post

### DIFF
--- a/docs/en/blog/posts/2026-cryptpad-zh-hant.md
+++ b/docs/en/blog/posts/2026-cryptpad-zh-hant.md
@@ -1,0 +1,132 @@
+---
+date: 2026-05-25
+authors:
+    - toomore
+categories:
+    - Community
+    - News
+slug: 2026-cryptpad-zh-hant
+image: "assets/images/post-update.png"
+summary: "Two and a half years of upstream community work landed in CryptPad 2026.5.0 (2026/05/13): zh_Hant (Traditional / Orthodox Chinese) is now a built-in locale, zh_Hans was upgraded alongside it, and a new locale alias system migrates older zh_CN / zh_TW settings without surprise. The community-hosted cryptpad.anoni.net is upgraded; readers in Taiwan, Hong Kong, Macau, and across the diaspora can now use one of the few end-to-end encrypted collaboration suites entirely in their own script."
+description: "Two and a half years of upstream community work landed in CryptPad 2026.5.0 (2026/05/13): zh_Hant (Traditional / Orthodox Chinese) is now a built-in locale, zh_Hans was upgraded alongside it, and a new locale alias system migrates older zh_CN / zh_TW settings without surprise. The community-hosted cryptpad.anoni.net is upgraded; readers in Taiwan, Hong Kong, Macau, and across the diaspora can now use one of the few end-to-end encrypted collaboration suites entirely in their own script."
+---
+
+# CryptPad 2026.5.0: zh_Hant Lands as a Built-in Locale After Two and a Half Years Upstream
+
+<figure markdown="span">
+    <a href="https://assets.anoni.net/docs/cryptpad-drive-zh-hant.png" target="_blank">
+        <img src="https://assets.anoni.net/docs/cryptpad-drive-zh-hant.png"
+            alt="CryptPad Drive home in Traditional Chinese (zh_Hant). Left sidebar shows file categories; the +New button reveals Rich Text, Document, Sheet, Slides, Kanban, Whiteboard, Diagram, Forms, Calendar."
+            title="cryptpad.anoni.net Drive home after switching to 中文(正體)"
+            class="brand-frame">
+    </a>
+    <figcaption>cryptpad.anoni.net Drive home after switching to 中文(正體). Every file category and app entry is localised.</figcaption>
+</figure>
+
+For people who want a collaboration tool that does not silently keep a readable copy of their work on the server, the practical options are short. Google Docs, Notion, Microsoft 365 are excellent products, but every paragraph and every revision sits on those vendors’ servers in a form they can read. From there, algorithms, ads, training corpora, and government data requests each have their own path in.
+
+That difference is exactly what matters when a journalist drafts a story that cannot leak, when a campaigner negotiates a strategy that cannot be wiretapped, when an NGO records distress reports from vulnerable users, or when a researcher works on a politically sensitive topic. Whether a first draft can be safely written at all often turns on that one architectural choice.
+
+[CryptPad](https://cryptpad.org/){target="_blank"} is one of the few collaboration suites where the server genuinely cannot read what you wrote. Content is encrypted in your browser, the server only ever sees ciphertext, and yet a single interface covers most of what people normally reach for in Google Docs, Sheets, Slides, kanban boards, whiteboards, forms, and calendars.
+
+Until recently the suite had one obvious gap for one large group of users: the UI shipped in English and Simplified Chinese only, with Traditional Chinese (zh_Hant) missing. From the first upstream PR opened at the end of 2023, through two and a half years of patient string-by-string work in Weblate, to the [CryptPad 2026.5.0 “🌷 Spring release”](https://github.com/cryptpad/cryptpad/releases/tag/2026.5.0){target="_blank"} on 2026/05/13, zh_Hant is now a built-in locale. The community-hosted [cryptpad.anoni.net](https://cryptpad.anoni.net/){target="_blank"} has been upgraded. **Open cryptpad.anoni.net today and the Drive, the document editors, and the share-permission dialog are all in Traditional Chinese. Readers in Taiwan, Hong Kong, Macau, and across the Chinese-reading diaspora can use it without first learning an English menu.**
+
+<!-- more -->
+
+## What CryptPad is
+
+CryptPad is developed by [XWiki SAS](https://xwiki.com/){target="_blank"} in France under the [AGPLv3](https://github.com/cryptpad/cryptpad/blob/main/LICENSE){target="_blank"} licence and is best described as an **end-to-end encrypted (E2EE) online office and collaboration suite**. One account gets you:
+
+- **Rich Text**: a Google-Docs-style WYSIWYG editor
+- **Document**: advanced word processing via OnlyOffice (.docx compatible)
+- **Sheets**: spreadsheets via OnlyOffice (.xlsx compatible)
+- **Presentation**: slides, with both Markdown Slides and OnlyOffice modes
+- **Kanban**: project boards
+- **Whiteboard**: free-form whiteboarding
+- **Diagram**: diagramming via [Drawio](https://www.drawio.com/){target="_blank"} (upgraded to Drawio 29.6.7 in 2026.5.0)
+- **Forms**: surveys and structured data collection
+- **Calendar**: shared calendars
+- **Code/Markdown**: code and Markdown editors
+- **Drive**: cloud storage that ties all of the above together
+
+The core property is that **all content is encrypted in your browser before it ever reaches the server**. The server stores ciphertext; neither CryptPad’s operators nor the anoni.net maintainers hold the keys. This is what is meant by *zero-knowledge*: even if we wanted to read your pads, we couldn’t.
+
+<figure markdown="span">
+    <a href="https://assets.anoni.net/docs/cryptpad-richtext-collab.png" target="_blank">
+        <img src="https://assets.anoni.net/docs/cryptpad-richtext-collab.png"
+            alt="CryptPad Rich Text editor with multi-user collaboration: collaborator avatars and live cursors in the top right, formatting toolbar on the right."
+            title="Rich Text app, multi-user collaboration"
+            class="brand-frame">
+    </a>
+    <figcaption>The Rich Text app in multi-user mode. Every edit is encrypted in the browser; the server only ever sees ciphertext.</figcaption>
+</figure>
+
+## Why the community self-hosts CryptPad
+
+We self-host more than CryptPad. There is also [Etherpad](https://pad.anoni.net/){target="_blank"} for quick shared notes and Matrix for live discussion (the [Community](../../community/index.md) page covers how the three fit together). CryptPad is what we reach for whenever a document needs **long-term storage, end-to-end encryption, and full multi-user collaboration in the same place**. Spending two and a half years on the Traditional Chinese translation made sense for several reasons.
+
+**E2EE and zero-knowledge by design.** Community discussions routinely touch threat models, whistleblower-protection notes, and the back-and-forth of pushing Tor relays onto university campuses. Putting those in Google Docs or Notion is functionally identical to handing every unpublished strategy to a third-party platform and its advertising partners. CryptPad removes “the operator can read your content” at the architectural level — a guarantee that is far stronger than an SLA promise.
+
+**Feature-complete enough to replace mainstream cloud suites.** Etherpad is fine for quick notes but does not cover sheets, slides, or kanban. CryptPad covers most of what people use Google Workspace for, and every pad inherits the same encryption and permission model. There is no need to keep switching tools because “this one needs to stay private and that one doesn’t”.
+
+<figure markdown="span">
+    <a href="https://assets.anoni.net/docs/cryptpad-share-permission.png" target="_blank">
+        <img src="https://assets.anoni.net/docs/cryptpad-share-permission.png"
+            alt="CryptPad share dialog. View-only, Edit, and Embed permissions, with optional password and expiry."
+            title="CryptPad share-permission dialog"
+            class="brand-frame">
+    </a>
+    <figcaption>Every pad uses the same encryption and permission model. Sharing supports view-only / edit / embed, with optional password and expiry.</figcaption>
+</figure>
+
+**AGPLv3 licence, public cryptographic protocol.** Any derived service has to remain open, so when we self-host we can audit the code top to bottom. The cryptographic protocol and data structures are also public — like Tor, Tails, and OONI, this is privacy that is verifiable rather than asserted.
+
+**Governance stays with maintainers and the community.** The same reasoning we wrote up in [why we self-host Matrix](2026-discord-matrix-statement.md) applies here. Retention policy, registration policy, channel rules are decisions we make ourselves; they are predictable, accountable, and can move with the community’s needs.
+
+**Real European public-sector and civil-society deployments.** CryptPad is in use across multiple European government projects, NGOs, and research groups. Compliance, reliability, and long-term maintenance all have a track record. When we recommend it to more Chinese-reading users, we are not pointing them at a demo-grade toy.
+
+## Two and a half years of upstream work, mapped to a timeline
+
+The CryptPad main application, the Accounts plugin, and the User Guide together contain over a thousand strings. Each one has to match the UI context where it appears, stay consistent across contexts (so that *Save* and *Save As* don’t drift into different verbs), and survive the constant trickle of new strings from active development. Every release means another pass over what changed.
+
+**2023/12/05.** [PR #1329](https://github.com/cryptpad/cryptpad/pull/1329){target="_blank"} opened upstream. It corrected the language-menu labels — changing the `zh-Hans` entry to “中文(簡體)” and `zh-Hant` to “中文(正體)” — and used the description to ask CryptPad maintainers what process to follow to add a real zh_Hant translation, since at that point only `zh_Hans` had any content and `zh_Hant` was empty.
+
+**2024–2025.** The CryptPad team opened zh_Hant translation spaces on [Weblate](https://weblate.cryptpad.org/){target="_blank"} across multiple sub-projects: the main [App](https://weblate.cryptpad.org/projects/cryptpad/app/zh_Hant/){target="_blank"}, the [Accounts plugin](https://weblate.cryptpad.org/projects/cryptpad/accounts-plugin/zh_Hant/){target="_blank"}, and the User Guide sections (Drive, FAQ, Application Document, Application General, Application Presentation, Share and Access, Collaboration, and more).
+
+**2026/03/13.** All of the above reached translation completion. The community filed [Issue #2237](https://github.com/cryptpad/cryptpad/issues/2237){target="_blank"} upstream to report the milestone and to ask CryptPad maintainers to enable `zh_Hant` as a built-in selectable locale in the next release.
+
+**2026/05/13.** CryptPad [2026.5.0 “🌷 Spring release”](https://github.com/cryptpad/cryptpad/releases/tag/2026.5.0){target="_blank"} shipped. The Improvements section of the release notes lists, verbatim:
+
+> Enable zh-Hant/zh-Hans locales (#2237) and add alias system for locales [#2254](https://github.com/cryptpad/cryptpad/pull/2254){target="_blank"} by @toomore
+
+That single PR not only turned on `zh_Hant` and `zh_Hans` as official locales, but also added a locale-alias mechanism so that accounts still configured with `zh_CN` or `zh_TW` (the older codes) automatically fall back to the new `zh_Hans` and `zh_Hant`, instead of getting pushed back to English after the upgrade. Existing Simplified Chinese users see their UI carry on as Chinese without having to reset anything.
+
+## A note on “正體” (Orthodox) vs “繁體” (Traditional)
+
+CryptPad’s language menu originally read “中文(繁體)” — *Traditional Chinese* — for the zh_Hant entry. PR #1329 changed it to “中文(正體)” — literally *Orthodox Chinese*. It is a small surface change with a small political point behind it: the community prefers “正體”, because “繁” (*complex*) implies “more complex than Simplified”, but the script as used in Taiwan, Hong Kong, and Macau is simply the historically continuous form of written Chinese — not a more elaborate counterpart to anything. Operating systems and most software still call it *Traditional Chinese*, and we are not asking anyone to change that across the board. But where we are doing the translation work ourselves, we use the name we prefer. How a community names its own script is part of the localisation work, not separate from it.
+
+## Using cryptpad.anoni.net from a censored or restricted network
+
+`cryptpad.anoni.net` and `cryptpad.org` are not specifically hosted to be reachable from inside heavily filtered networks. Readers connecting from mainland China, Iran, Russia, or similar environments may see unstable or blocked connections. Recommended approaches:
+
+- **[Tor Browser](https://www.torproject.org/download/){target="_blank"}** reaches cryptpad.anoni.net over the Tor network, HTTPS by default. If the Tor network itself is blocked from your ISP, use [Snowflake](https://snowflake.torproject.org/){target="_blank"} or request [obfs4 bridges](https://bridges.torproject.org/){target="_blank"}.
+- **A VPN you trust.** The VPN operator can see your connection metadata, but CryptPad’s end-to-end encryption guarantees that no intermediary — VPN, ISP, or server operator — can read your content.
+- **[Tails](https://tails.net/){target="_blank"}** boots an entire operating system that routes all traffic through Tor and leaves no trace on the host machine. A good fit for higher-sensitivity collaboration.
+
+CryptPad is E2EE regardless of how you connect; whether you reach it over Tor, a VPN, or direct, the server cannot read your content. The variable is **whether you can reach** `cryptpad.anoni.net` at all from your local network. For ongoing use in heavily restricted environments, Tor with Snowflake or Tails is the more reliable baseline.
+
+## Getting started on cryptpad.anoni.net
+
+To start:
+
+- **Entry point**: [https://cryptpad.anoni.net/](https://cryptpad.anoni.net/){target="_blank"}
+- **Account requests**: email <whisper@anoni.net> for a registration code. Default quota is 50 MB, adjustable later. Registration does not ask for an email address inside the system and does not bind to a real-name identity, matching the Matrix flow.
+- **Switching locale**: after the upgrade, the top-right settings page offers “中文(正體)” and “中文(簡體)”. The query strings `?lang=zh_Hant` or `?lang=zh_Hans` also work.
+- **Full tooling list**: see [Community](../../community/index.md).
+
+If you spot a typo, awkward wording, or a new string that hasn’t been translated yet, contributions are very welcome — head straight to the [zh_Hant](https://weblate.cryptpad.org/projects/cryptpad/-/zh_Hant/){target="_blank"} or [zh_Hans](https://weblate.cryptpad.org/projects/cryptpad/-/zh_Hans/){target="_blank"} project on Weblate, or email <whisper@anoni.net> to let us know.
+
+## Further reading
+
+- [From Discord’s Age Verification to Why We Self-Host Matrix](2026-discord-matrix-statement.md)
+- [Community](../../community/index.md)

--- a/docs/zh-CN/blog/posts/2026-cryptpad-zh-hant.md
+++ b/docs/zh-CN/blog/posts/2026-cryptpad-zh-hant.md
@@ -1,0 +1,133 @@
+---
+date: 2026-05-25
+authors:
+    - toomore
+categories:
+    - 社区
+    - 公告
+slug: 2026-cryptpad-zh-hant
+image: "assets/images/post-update.png"
+summary: "CryptPad 是少数让服务器看不到内容的在线协作工具。2026/05 随 CryptPad 2026.5.0 上线，正体中文（zh_Hant）正式收进内建语系，简体中文（zh_Hans）一并升级，并加入 locale alias 让旧设定（zh_CN、zh_TW）平滑迁移。社区自架的 cryptpad.anoni.net 已同步升级，对中国大陆使用者，搭配 Tor 或 VPN 即可访问。"
+description: "CryptPad 是少数让服务器看不到内容的在线协作工具。2026/05 随 CryptPad 2026.5.0 上线，正体中文（zh_Hant）正式收进内建语系，简体中文（zh_Hans）一并升级，并加入 locale alias 让旧设定（zh_CN、zh_TW）平滑迁移。社区自架的 cryptpad.anoni.net 已同步升级，对中国大陆使用者，搭配 Tor 或 VPN 即可访问。"
+---
+
+# CryptPad 2026.5.0 上线：正体中文（zh_Hant）正式收进内建语系
+
+<figure markdown="span">
+    <a href="https://assets.anoni.net/docs/cryptpad-drive-zh-hant.png" target="_blank">
+        <img src="https://assets.anoni.net/docs/cryptpad-drive-zh-hant.png"
+            alt="CryptPad Drive 首页切换为正体中文后的界面，左侧为文件分类、顶端 +新增 按钮可看到 Rich Text、文档、电子表格、演示、看板、白板、绘图、表单、日历等 app"
+            title="cryptpad.anoni.net 切换成「中文(正体)」后的 Drive 首页"
+            class="brand-frame">
+    </a>
+    <figcaption>cryptpad.anoni.net 切换成「中文(正体)」后的 Drive 首页，所有文件分类与 app 入口都已本地化</figcaption>
+</figure>
+
+中文使用者要找一套真的不会被第三方平台默默收走内容的协作工具，其实没有想像中容易。Google Docs、Notion、Microsoft 365 都很好用，但每一段文字、每一个改动，都会以可被服务商读取的形式存放在他们的服务器上。在这之上，算法、广告、训练语料、政府调取请求，各有各的取用方式。
+
+这层差异对记者写不能曝光的稿、社运工作者协商不能被监听的策略、NGO 整理脆弱使用者的求助记录、学者研究敏感议题这些情境，往往决定一份草稿能不能安全写得出来。
+
+[CryptPad](https://cryptpad.org/){target="_blank"} 是少数真的让服务器看不到内容的在线协作工具。内容在你浏览器端就完成加密，服务器收到的是密文，但功能完整到一个界面就能取代 Google Docs、Sheets、Slides、看板、白板、表单与日历。
+
+这套工具过去有一个明显的门槛，界面只有英文与简体中文，正体中文是缺的。从 2023 年底在 CryptPad 上游开的第一个 PR 起算，到 2026 年 5 月 13 日 [CryptPad 2026.5.0「🌷 Spring release」](https://github.com/cryptpad/cryptpad/releases/tag/2026.5.0){target="_blank"} 正式把正体中文（zh_Hant）收进内建语系，前后花了两年半。社区自架的 [cryptpad.anoni.net](https://cryptpad.anoni.net/){target="_blank"} 升级完成。**现在打开 cryptpad.anoni.net，从 Drive 界面、文档编辑器到分享权限对话框，整套界面在简体与正体之间都能切换。中港澳台与海外华语使用者可以在同一个工具里无障碍协作。**
+
+<!-- more -->
+
+## CryptPad 是什么
+
+CryptPad 由法国 [XWiki SAS](https://xwiki.com/){target="_blank"} 开发，使用 [AGPLv3](https://github.com/cryptpad/cryptpad/blob/main/LICENSE){target="_blank"} 授权，定位是**端对端加密（E2EE）的在线协作办公套件**。一个帐号可以使用以下应用：
+
+- **Rich Text 文档**：类似 Google Docs 的所见即所得编辑器
+- **Document**：整合 OnlyOffice 的进阶文档处理（.docx 兼容）
+- **Sheets**：电子表格，整合 OnlyOffice（.xlsx 兼容）
+- **Presentation**：演示，含 Markdown Slides 与 OnlyOffice 两种模式
+- **Kanban**：看板，做项目管理用
+- **Whiteboard**：白板
+- **Diagram**：绘图，整合 [Drawio](https://www.drawio.com/){target="_blank"}（2026.5.0 升级到 Drawio 29.6.7）
+- **Forms**：表单，可做问卷与数据收集
+- **Calendar**：日历
+- **Code/Markdown**：代码与 Markdown 编辑器
+- **Drive**：云端硬盘，整合上述所有文件类型
+
+关键在于**所有内容都在你浏览器端就完成加密**，服务器收到的是密文，CryptPad 的运营者、anoni.net 的维护者，都没有解开内容的钥匙。这套架构称为 zero-knowledge（零知识），意思是「即便我们想看，也看不到」。
+
+<figure markdown="span">
+    <a href="https://assets.anoni.net/docs/cryptpad-richtext-collab.png" target="_blank">
+        <img src="https://assets.anoni.net/docs/cryptpad-richtext-collab.png"
+            alt="CryptPad Rich Text 编辑器多人协作画面，右上角显示协作者头像与即时 cursor，右侧为格式化工具栏"
+            title="Rich Text app 的多人即时协作界面"
+            class="brand-frame">
+    </a>
+    <figcaption>Rich Text app 的多人即时协作界面。所有编辑内容在浏览器端就完成加密，服务器只看得到密文</figcaption>
+</figure>
+
+## 为什么社区选择 CryptPad 作为自架的协作平台
+
+社区自架的服务不只 CryptPad，也有 [Etherpad](https://pad.anoni.net/){target="_blank"} 做即时共笔、Matrix 做即时讨论（三者分工见 [沟通与协作工具](../../community/tools.md)）。CryptPad 在我们的选择顺位里，承担的是「需要长期保存、需要加密、需要多人协作完整文档」的场景。愿意花两年半把界面翻成正体中文，理由有几个。
+
+**E2EE 与 zero-knowledge 架构**：社区讨论的内容很常涉及威胁模型、揭弊者保护、Tor Relay 校园推动的协商记录，这些东西放在 Google Docs 或 Notion 上，等于把所有未公开的策略摊在第三方平台与其广告合作对象面前。CryptPad 从架构上把「运营者能看到内容」这件事拿掉，技术保证远强于 SLA 承诺。
+
+**功能完整、可取代主流云端套件**：Etherpad 适合临时共笔，但没办法做表格、演示、看板。CryptPad 一个界面涵盖 Google Workspace 大部分常用情境，而且每个文档都继承同一套加密与权限模型，不必为了「这份要保密、那份不用」在多套工具间切换。
+
+<figure markdown="span">
+    <a href="https://assets.anoni.net/docs/cryptpad-share-permission.png" target="_blank">
+        <img src="https://assets.anoni.net/docs/cryptpad-share-permission.png"
+            alt="CryptPad 分享对话框，可选仅查看、可编辑、嵌入三种权限模式，并可加密码、设定过期时间"
+            title="CryptPad 每份 pad 的分享权限对话框"
+            class="brand-frame">
+    </a>
+    <figcaption>每份 pad 都继承同一套加密与权限模型，分享时可选仅查看、可编辑或嵌入，并可加密码与过期时间</figcaption>
+</figure>
+
+**AGPLv3 授权，加密协议公开可审视**：衍生服务都必须开源，我们自架时可以完整检查代码。加密协议与数据结构也对外公开，跟 Tor、Tails、OONI 一样，是可被验证的隐私。
+
+**由维护者与社区决定如何治理**：自架的好处跟 [自架 Matrix](2026-discord-matrix-statement.md) 的理由一致，记录保存策略、注册政策、频道规则由我们决定，可预期、可问责、可随社区需求调整。
+
+**有欧洲公部门与民间组织的真实部署经验**：CryptPad 在欧洲多个公部门项目、NGO 与研究单位内被采用，合规、可靠性、长期维护三方面都有实际使用记录，把它推给更多中文使用者时不必担心是 demo 漂亮的玩具。
+
+## 正体中文（zh_Hant）翻译：两年半的时间线
+
+CryptPad 主应用、Accounts plugin 与 User Guide 加起来上千条字串，每一条都要对齐它在界面上会出现的情境、顾及上下文、避免在「保存」、「另存为」这类词之间混用。CryptPad 还在持续开发，新功能会带来新字串，每个版本上线前都得回头再校一轮。
+
+**2023/12/05**：在 CryptPad 开 [PR #1329](https://github.com/cryptpad/cryptpad/pull/1329){target="_blank"}，修正当时界面语言选单的用词，把 `zh-Hans` 标签改为「中文(简体)」、`zh-Hant` 改为「中文(正体)」。当时 CryptPad 还只有 `zh_Hans` 的翻译内容，`zh_Hant` 是空的，所以 PR 内也顺便询问 CryptPad 团队「想新增 zh-Hant 语言要走哪个流程」。
+
+**2024–2025**：CryptPad 团队在 [Weblate](https://weblate.cryptpad.org/){target="_blank"} 上为 zh_Hant 开了多个子项目的翻译空间，包含 CryptPad 主应用（[App](https://weblate.cryptpad.org/projects/cryptpad/app/zh_Hant/){target="_blank"}）、[Accounts plugin](https://weblate.cryptpad.org/projects/cryptpad/accounts-plugin/zh_Hant/){target="_blank"}，以及 User Guide 的 Drive、FAQ、Application Document、Application General、Application Presentation、Share and Access、Collaboration 等子段。
+
+**2026/03/13**：所有上述项目的 zh_Hant 字串翻译完成，社区在 CryptPad 仓库开 [Issue #2237](https://github.com/cryptpad/cryptpad/issues/2237){target="_blank"} 回报进度，请 CryptPad 团队评估在下一个 release 启用 `zh_Hant` 为内建可选语系。
+
+**2026/05/13**：CryptPad [2026.5.0「🌷 Spring release」](https://github.com/cryptpad/cryptpad/releases/tag/2026.5.0){target="_blank"} 发布，release notes 在 Improvements 段落明列：
+
+> Enable zh-Hant/zh-Hans locales (#2237) and add alias system for locales [#2254](https://github.com/cryptpad/cryptpad/pull/2254){target="_blank"} by @toomore
+
+这次合并除了把 `zh_Hant` 与 `zh_Hans` 打开为正式语系，也加上了 locale alias 机制，让旧有以 `zh_CN`、`zh_TW` 为设定值的帐号可以自动 fallback 对应到新的 `zh_Hans`、`zh_Hant`，不会在升级后跑回英文。简体中文使用者升级后界面照常显示中文，不需要手动重设语系。
+
+## 关于「正体中文」与「繁体中文」的用字
+
+CryptPad 界面选单最早写的是「中文(繁体)」。我们在 PR #1329 提的修改是改成「中文(正体)」。改字面看起来是小事，背后是社区比较倾向「正体」这个用词。「繁」字暗示「相对于简体比较复杂」，但这套字系在台湾、香港、澳门的使用脉络，本来就是延续汉字源流而来的正统写法，没有「繁」与「简」的对比关系。OS 与多数软件仍写「繁体中文」，我们不要求所有人都改，但在自己贡献的翻译里能改就改。用什么字称呼一个族群使用的字系，是普及工作的一部分。
+
+## 中国大陆使用者怎么访问 cryptpad.anoni.net
+
+`cryptpad.anoni.net` 与 `cryptpad.org` 都没有针对中国大陆使用者做特别托管，在大陆网络环境下访问可能会有连线不稳或被阻断的情况。建议方式：
+
+- **使用 [Tor Browser](https://www.torproject.org/zh-CN/download/){target="_blank"}**：透过 Tor 网络访问 cryptpad.anoni.net，预设走 HTTPS。如果直接连不上 Tor 网络，可使用 [Snowflake](../../tools/tor-snowflake.md) 或 [obfs4 桥接](https://bridges.torproject.org/){target="_blank"}。
+- **使用任何你信任的 VPN**：注意 VPN 服务商本身能看到你的连线 metadata，但 CryptPad 端对端加密的特性确保内容不会被任何中间方读取。
+- **使用 [Tails](../../tools/what-is-tails.md)**：把整个操作环境放进 Tails，所有流量预设走 Tor，关机后不留痕迹。适合敏感度较高的协作场景。
+
+CryptPad 本身是 E2EE 的，无论你的连线管道是 Tor、VPN 或直连，服务器都看不到你的内容。但**能不能稳定连上** cryptpad.anoni.net 与你所处的网络环境有关。如果常态在中国大陆使用，建议优先以 Tor + Snowflake 或 Tails 为基础。
+
+## 怎么开始用 cryptpad.anoni.net
+
+上手方式：
+
+- **入口**：[https://cryptpad.anoni.net/](https://cryptpad.anoni.net/){target="_blank"}
+- **帐号申请**：写信到 <whisper@anoni.net> 申请注册码。预设容量 50 MB，后续可调整。注册时不要求邮箱、不绑定实名，跟 Matrix 的申请流程一致。
+- **切换语系**：升级后右上角设定页可选「中文(正体)」或「中文(简体)」。网址加 `?lang=zh_Hant` 或 `?lang=zh_Hans` 也能切换。
+- **完整工具清单**：见 [沟通与协作工具](../../community/tools.md)。
+
+如果你发现翻译有错字、用词不顺、或是有新版字串还没翻完，欢迎到 Weblate 上的 [zh_Hant](https://weblate.cryptpad.org/projects/cryptpad/-/zh_Hant/){target="_blank"} 或 [zh_Hans](https://weblate.cryptpad.org/projects/cryptpad/-/zh_Hans/){target="_blank"} 项目直接提交修改，或来信 <whisper@anoni.net> 告诉我们。
+
+## 相关阅读
+
+- [从 Discord 年龄验证谈起：我们为什么自架 Matrix](2026-discord-matrix-statement.md)
+- [沟通与协作工具](../../community/tools.md)
+- [中文化与文件翻译](../../community/i18n.md)


### PR DESCRIPTION
Follow-up to #51 (stacked on `post/2026-cryptpad-zh-hant`). Adds the zh-CN and en translations of `docs/zh-TW/blog/posts/2026-cryptpad-zh-hant.md`. Same slug and same three figures from `assets.anoni.net/docs/` across all three languages.

Will auto-rebase to `main` once #51 merges.

## zh-CN adaptations

- Simplified Chinese terminology (服务器 / 帐号 / 界面 / 邮箱 / 默认 / 文档 / 演示)
- Adds **「中国大陆使用者怎么访问 cryptpad.anoni.net」** section covering Tor Browser + Snowflake / obfs4, trusted VPN, and Tails as connection paths. CryptPad is E2EE regardless of the path; the variable is whether the network lets you reach the host
- `summary` highlights the locale alias mechanism so existing `zh_CN` accounts don't fall back to English after the upgrade
- Cross-strait framing 「中港澳台与海外华语使用者」 for the collaboration angle

## en adaptations

- Title and opening emphasise the **two-and-a-half years upstream contribution** narrative (PR #1329 → Weblate → Issue #2237 → 2026.5.0)
- Streamlines the 正體 / 繁體 (Orthodox vs Traditional) wording section for an international audience while keeping the substantive point about who names a script
- Generalises the censored-network access section to mainland China / Iran / Russia. Links Tor Project and tails.net directly (since en/basics/what-is-tails.md isn't ported yet)
- Replaces missing `community/tools.md` and `community/i18n.md` links with `community/index.md` (the en page that exists)

## Test plan

- [x] `mkdocs build -s` clean for `mkdocs_cn.yml` (only pre-existing cairosvg warnings, no content warnings on the new file)
- [x] `mkdocs build -s` clean for `mkdocs_en.yml` (same)
- [x] All three figures (`cryptpad-drive-zh-hant.png`, `cryptpad-richtext-collab.png`, `cryptpad-share-permission.png`) on assets.anoni.net resolve
- [x] Style self-check: no `不是...而是`, no `——`, no `；`, no AI opening phrases, no full-width slash
- [ ] mkdocs serve livereload preview on zh-CN and en (recommend before merge)

## Follow-ups still open from #51

- [ ] `community/i18n.md` add CryptPad zh_Hant as a case study
- [ ] `community/tools.md` confirm CryptPad multilingual status description
- [ ] `tools/what-is-cryptpad.md` evergreen tool intro
- [ ] Weblate-to-release workflow short post
- [ ] Standalone 「為什麼用『正體』而非『繁體』」 statement post

🤖 Generated with [Claude Code](https://claude.com/claude-code)