### PR TITLE
fix(docs): mkdir anoni-net-docs-ipfs/ before cp in build_docs_anoni_ipfs.sh

### DIFF
--- a/docs/build_docs_anoni_ipfs.sh
+++ b/docs/build_docs_anoni_ipfs.sh
@@ -30,6 +30,7 @@ RUN run.sh
 RUN run_en.sh
 RUN run_zh-tw.sh
 RUN run_zh-cn.sh
+mkdir -p ./anoni-net-docs-ipfs
 rm -rf ./anoni-net-docs-ipfs/*
 cp -r ./output/* ./anoni-net-docs-ipfs/
 


### PR DESCRIPTION
## Summary

- `docs/build_docs_anoni_ipfs.sh` 在第 33-34 行假設 `./anoni-net-docs-ipfs/` 已存在。第一次在 fresh checkout / CI / 新 worktree 跑時，`cp -r ./output/* ./anoni-net-docs-ipfs/` 在多 source + dest 不存在的情境會失敗（cp errors out with "is not a directory"），導致接下來的 `upload_to_ipfs.sh` 在 `ipfs add -r anoni-net-docs-ipfs/` 噴 `lstat: no such file or directory` 退出。
- 在 `rm -rf ./anoni-net-docs-ipfs/*` 之前加一行 `mkdir -p ./anoni-net-docs-ipfs`，讓 build 在任何環境第一次跑都會通過。
- onion 變體（`build_docs_anoni_onion.sh`）cp 到絕對路徑 `/srv/ooni-docs-output/`，那是部署機固定目錄、不會有同樣問題，本 PR 不動。

## Repro before fix

在 fresh worktree 跑 `sh ./build_docs_anoni_ipfs.sh`，4 個 mkdocs build 都成功，但接著：

\`\`\`
[upload] 上傳 .../anoni-net-docs-ipfs/ ...
Error: lstat .../anoni-net-docs-ipfs: no such file or directory
\`\`\`

之後手動 `mkdir -p anoni-net-docs-ipfs && cp -r output/* anoni-net-docs-ipfs/ && sh upload_to_ipfs.sh` 才能繞過。

## Test plan

- [x] 與既有 build flow 行為一致（dir 已存在時 mkdir -p 是 no-op）
- [ ] 下次 fresh checkout / CI 環境第一次跑 IPFS build 時驗證能直接走完

🤖 Generated with [Claude Code](https://claude.com/claude-code)