### PR TITLE
[2026-05-26] docs(zh-CN): sync miniooni CLI section to OONI Run v2 page

### DIFF
--- a/docs/zh-CN/tools/ooni-run-v2.md
+++ b/docs/zh-CN/tools/ooni-run-v2.md
@@ -130,6 +130,22 @@ The link can be used on multiple devices and will expire in 24 hours.
     <img class="brand-frame" src="https://assets.anoni.net/docs/ooni-run-v2-m2.png" alt="OONI Probe 仪表板上的检测卡片与执行按钮" style="width:50%">
 </figure>
 
+### 用 miniooni CLI 跑检测
+
+移动装置之外，OONI 也有命令行版本 [miniooni](https://github.com/ooni/probe-cli){target="_blank"}，方便在服务器、研究脚本或自动化环境跑检测。把 OONI Run v2 链接喂给 CLI 有个容易踩到的雷，**不能直接把网页版的网址丢给 `-i`**。
+
+```bash
+# 不会 work，CLI 拿到 HTML，JSON 解析就会失败
+miniooni oonirun -i https://run.ooni.org/v2/10328
+
+# 正确用法，直接指向 API 的 descriptor JSON
+miniooni oonirun -i https://api.ooni.org/api/v2/oonirun/links/10328
+```
+
+原因是 miniooni 的 `-i` 会把你给的网址当成 descriptor JSON 端点直接 GET，期望拿到 JSON 回来。`run.ooni.org/v2/<ID>` 是给浏览器看的网页，响应是 HTML，CLI 解析就会失败。实际的 descriptor 由 API 提供，网址格式为 `https://api.ooni.org/api/v2/oonirun/links/<LINK_ID>`，`<LINK_ID>` 直接从网页网址末段获取（社群链接为 `10328`）。
+
+桌面版与移动 App 不受这个限制影响，操作系统会把 `https://run.ooni.org/v2/<ID>` 交给 OONI Probe 自行处理。这个限制目前只影响 miniooni CLI，upstream 已有 [TODO 标注](https://github.com/ooni/probe-cli/blob/master/internal/oonirun/link.go){target="_blank"}，后续可能会补上自动转换。
+
 ## 观察资料
 
 所有的检测资料最后都会上传到 OONI 的公开数据库中，在 [OONI Explorer](https://explorer.ooni.org/zh-Hans/chart/mat?test_name=web_connectivity&axis_x=measurement_start_day&since=2025-09-01&until=2025-10-16&time_grain=day&ooni_run_link_id=10328){target="_blank"} 的搜寻接口中，可以直接在「OONI Run Link ID」栏位输入分享链接的编号，例如范例为 `https://run.ooni.org/v2/10328`，其编码为 `10328`，就可以输入此编码搜寻协助者的检测结果。


### PR DESCRIPTION
## Summary

- 同步 PR #62 (zh-TW) 的「用 miniooni CLI 跑检测」小节到 zh-CN
- 说明 miniooni CLI 不能吃 `https://run.ooni.org/v2/<ID>` 网页网址（回 HTML，JSON 解析失败）
- 给出正确指令：`miniooni oonirun -i https://api.ooni.org/api/v2/oonirun/links/<LINK_ID>`
- 补一句说明桌面/移动 App 不受影响，并标出 upstream TODO 连结

## Test plan

- [x] `mkdocs build -f mkdocs_cn.yml` 成功，新章节正常渲染
- [x] 相对连结与外部连结（GitHub、anchor）正常
- [ ] en 待后续同步

Related: #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)