### PR TITLE
docs: 把 IPFS 鏡像 URL 切到 anoni-net.ipns.dweb.link

### DIFF
--- a/docs/overrides/partials/copyright.html
+++ b/docs/overrides/partials/copyright.html
@@ -8,8 +8,8 @@
     ><br />
     IPFS/IPNS:
     <a
-      href="https://ipfs.io/ipns/k51qzi5uqu5dlfm2jj0f70ex3r3babmwy8qh071inwknttr7wqa3uhdwvlmrmw/{{page.url}}"
-      >/ipns/k51qzi5uqu5dlfm2jj0f70ex3r3babmwy8qh071inwknttr7wqa3uhdwvlmrmw/{{page.url}}</a
+      href="https://anoni-net.ipns.dweb.link/{{page.url}}"
+      >anoni-net.ipns.dweb.link/{{page.url}}</a
     >
   </div>
   {% endif %} {% if not config.extra.generator == false %} Made with

--- a/docs/overrides_cn/partials/copyright.html
+++ b/docs/overrides_cn/partials/copyright.html
@@ -8,8 +8,8 @@
     ><br />
     IPFS/IPNS:
     <a
-      href="https://ipfs.io/ipns/k51qzi5uqu5dlfm2jj0f70ex3r3babmwy8qh071inwknttr7wqa3uhdwvlmrmw/zh-cn/{{page.url}}"
-      >/ipns/k51qzi5uqu5dlfm2jj0f70ex3r3babmwy8qh071inwknttr7wqa3uhdwvlmrmw/zh-cn/{{page.url}}</a
+      href="https://anoni-net.ipns.dweb.link/zh-cn/{{page.url}}"
+      >anoni-net.ipns.dweb.link/zh-cn/{{page.url}}</a
     >
   </div>
   {% endif %} {% if not config.extra.generator == false %} Made with

--- a/docs/overrides_en/partials/copyright.html
+++ b/docs/overrides_en/partials/copyright.html
@@ -8,8 +8,8 @@
     ><br />
     IPFS/IPNS:
     <a
-      href="https://ipfs.io/ipns/k51qzi5uqu5dlfm2jj0f70ex3r3babmwy8qh071inwknttr7wqa3uhdwvlmrmw/en/{{page.url}}"
-      >/ipns/k51qzi5uqu5dlfm2jj0f70ex3r3babmwy8qh071inwknttr7wqa3uhdwvlmrmw/en/{{page.url}}</a
+      href="https://anoni-net.ipns.dweb.link/en/{{page.url}}"
+      >anoni-net.ipns.dweb.link/en/{{page.url}}</a
     >
   </div>
   {% endif %} {% if not config.extra.generator == false %} Made with

--- a/docs/replace_sitename_anoni_ipfs.sh
+++ b/docs/replace_sitename_anoni_ipfs.sh
@@ -6,22 +6,22 @@ find ./output -path './onion' -prune -o \
 find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename_anoni_ipfs.sh' \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \
-	-exec sed -i 's|https://anoni.net/docs|https://ipfs.io/ipns/k51qzi5uqu5dlfm2jj0f70ex3r3babmwy8qh071inwknttr7wqa3uhdwvlmrmw|g' {} +
+	-exec sed -i 's|https://anoni.net/docs|https://anoni-net.ipns.dweb.link|g' {} +
 
 find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename_anoni_ipfs.sh' \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \
-	-exec sed -i 's|link: /docs/zh-tw/|link: /ipns/k51qzi5uqu5dlfm2jj0f70ex3r3babmwy8qh071inwknttr7wqa3uhdwvlmrmw/zh-tw/|g' {} +
+	-exec sed -i 's|link: /docs/zh-tw/|link: https://anoni-net.ipns.dweb.link/zh-tw/|g' {} +
 
 find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename_anoni_ipfs.sh' \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \
-	-exec sed -i 's|link: /docs/zh-cn/|link: /ipns/k51qzi5uqu5dlfm2jj0f70ex3r3babmwy8qh071inwknttr7wqa3uhdwvlmrmw/zh-cn/|g' {} +
+	-exec sed -i 's|link: /docs/zh-cn/|link: https://anoni-net.ipns.dweb.link/zh-cn/|g' {} +
 
 find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename_anoni_ipfs.sh' \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \
-	-exec sed -i 's|link: /docs/en/|link: /ipns/k51qzi5uqu5dlfm2jj0f70ex3r3babmwy8qh071inwknttr7wqa3uhdwvlmrmw/en/|g' {} +
+	-exec sed -i 's|link: /docs/en/|link: https://anoni-net.ipns.dweb.link/en/|g' {} +
 
 find ./output \
 	-type f ! -name 'replace_sitename_anoni_ipfs.sh' \


### PR DESCRIPTION
## Summary

- DNSLink `_dnslink.anoni.net TXT "dnslink=/ipns/k51..."` 2026-05-27 部署後，主推 subdomain-style 的 `https://anoni-net.ipns.dweb.link/` 為對外 IPFS 鏡像入口（origin 隔離較安全、URL 短好記、DNSLink 自動跟新 CID）。
- footer copyright 三份 + IPFS build 流程的替換腳本同步切到 dweb.link。

## Changes

| 檔案 | 變更 |
|---|---|
| `docs/overrides/partials/copyright.html` | footer IPFS/IPNS 連結改 dweb.link（zh-TW） |
| `docs/overrides_en/partials/copyright.html` | footer IPFS/IPNS 連結改 dweb.link（en） |
| `docs/overrides_cn/partials/copyright.html` | footer IPFS/IPNS 連結改 dweb.link（zh-CN） |
| `docs/replace_sitename_anoni_ipfs.sh` | IPFS build 流程 4 處 sed target 改 dweb.link |

`replace_sitename_anoni_ipfs.sh` 細部：

- 主 URL 替換：`https://anoni.net/docs` → `https://anoni-net.ipns.dweb.link`（去掉尾巴 `/`，避免雙斜線）
- alternate 語言切換三條：path-relative `/ipns/<hash>/{LANG}/` 改成完整 URL `https://anoni-net.ipns.dweb.link/{LANG}/`，任何 gateway 看 IPFS 版切語言都跳到 dweb.link

## 不動

- Onion 鏡像連結（另一條鏡像，不在本次範圍）
- `docs/mkdocs.yml`、`docs/overrides/main.html` 等 source：source 本來就是 `https://anoni.net/docs/`，是 IPFS build 動態替換，source 不需要動（main repo 上看到的 `ipfs.io/ipns/...` 是 IPFS build 跑完留下的 dirty state）

## Test plan

- [ ] `mkdocs serve` 開三語首頁，scroll 到 footer，確認 IPFS/IPNS 連結顯示為 `anoni-net.ipns.dweb.link/...`
- [ ] `curl -sI https://anoni-net.ipns.dweb.link/` 確認 IPNS 解析正常（200；偶發 504 是 dweb.link 端 DHT timeout，重試即可）
- [ ] 跑 `sh build_docs_anoni_ipfs.sh --no-upload`，確認 IPFS build 出來的 `./anoni-net-docs-ipfs/` 內部 link 都對齊 dweb.link
- [ ] `grep -r "ipfs.io/ipns/k51" ./anoni-net-docs-ipfs/` 確認 build 後沒有殘留舊 URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
