### PR TITLE
build: IPFS pipeline 強化（trap restore、嚴格錯誤、sanity check、IPNS lifetime）

### DIFF
--- a/docs/build_docs_anoni_ipfs.sh
+++ b/docs/build_docs_anoni_ipfs.sh
@@ -1,3 +1,20 @@
+#!/usr/bin/env bash
+# 建置 anoni.net docs 的 IPFS 鏡像版本（zh-TW / en / zh-CN）並 publish 到 IPNS
+#
+# Usage:
+#   ./build_docs_anoni_ipfs.sh              # build + upload + publish IPNS
+#   ./build_docs_anoni_ipfs.sh --no-upload  # 只 build 不 upload，產物在 ./anoni-net-docs-ipfs/
+#
+# 流程：
+#   1. 確認 working tree clean（避免 replace_sitename in-place 改動污染未提交修改）
+#   2. 設 trap，任何狀況退出都 git restore 還原 source
+#   3. 跑 replace_sitename_anoni_ipfs.sh 把 source URL 改成 IPFS URL（in-place）
+#   4. mkdocs build 三語 + 主站，產物匯到 ./anoni-net-docs-ipfs/
+#   5. sanity check 確認鏡像內無殘留 https://anoni.net/docs URL
+#   6. (預設) 跑 upload_to_ipfs.sh 上傳 + publish IPNS
+
+set -euo pipefail
+
 # macOS 本地建置前置：
 # - gnu-sed：BSD sed 不接受 `sed -i 's|x|y|g'` 格式
 # - DYLD_FALLBACK_LIBRARY_PATH：cairosvg 需 libcairo.2.dylib，SIP 會 strip 子 sh 的 DYLD_*
@@ -24,6 +41,25 @@ else
   RUN() { sh "./$1"; }
 fi
 
+# 跑前確認 working tree clean：replace_sitename_anoni_ipfs.sh 會 in-place 修改 source，
+# 跟使用者 uncommitted 變動混在一起會導致 git restore 階段丟失工作
+if ! git diff --quiet; then
+  echo "[build] ERROR: working tree dirty，請先 commit 或 stash 後再跑" >&2
+  echo "[build] dirty files (前 10 個)：" >&2
+  git diff --name-only | head -10 | sed 's/^/  /' >&2
+  exit 1
+fi
+
+# 任何狀況（正常結束、中途失敗、Ctrl-C）都還原 source
+# 避免 replace_sitename_anoni_ipfs.sh 的 in-place 修改殘留在 working tree
+cleanup_source() {
+  rc=$?
+  echo "[build] 還原 source（清除 replace 留下的 in-place 修改）"
+  git restore . 2>/dev/null || true
+  exit $rc
+}
+trap cleanup_source EXIT
+
 rm -rf ./output/*
 RUN replace_sitename_anoni_ipfs.sh
 RUN run.sh
@@ -33,6 +69,14 @@ RUN run_zh-cn.sh
 mkdir -p ./anoni-net-docs-ipfs
 rm -rf ./anoni-net-docs-ipfs/*
 cp -r ./output/* ./anoni-net-docs-ipfs/
+
+# Sanity check：IPFS 鏡像內不該還有主站 URL
+echo "[build] sanity check：確認 IPFS 鏡像內無殘留 https://anoni.net/docs URL"
+if grep -r "https://anoni.net/docs" ./anoni-net-docs-ipfs/ >/dev/null 2>&1; then
+  echo "[build] ERROR: replace_sitename_anoni_ipfs.sh 沒跑完整，仍有 https://anoni.net/docs 出現於：" >&2
+  grep -rl "https://anoni.net/docs" ./anoni-net-docs-ipfs/ | head -5 | sed 's/^/  /' >&2
+  exit 1
+fi
 
 if [ "${1:-}" != "--no-upload" ]; then
   sh ./upload_to_ipfs.sh

--- a/docs/upload_to_ipfs.sh
+++ b/docs/upload_to_ipfs.sh
@@ -59,7 +59,13 @@ NEW_CID=$(ipfs $IPFS_API add -r --cid-version=1 --quieter "$SCRIPT_DIR/anoni-net
 echo "[upload] 新 CID: $NEW_CID"
 
 echo "[upload] 發布 IPNS ([anoni-net] key)..."
-ipfs $IPFS_API name publish --key=anoni-net "/ipfs/$NEW_CID"
+# --lifetime=720h：DHT 上的 IPNS record 30 天內有效，避免 gateway 解析時找不到（預設 24h 對非每日 deploy 太短）
+# --ttl=5m：客戶端 cache IPNS 解析結果 5 分鐘，平衡解析效能與更新延遲
+ipfs $IPFS_API name publish \
+    --key=anoni-net \
+    --lifetime=720h \
+    --ttl=5m \
+    "/ipfs/$NEW_CID"
 
 if [ -n "$OLD_CID" ]; then
     OLD_HASH="${OLD_CID#/ipfs/}"


### PR DESCRIPTION
## Summary

IPFS build pipeline 四項強化，跟 PR #72（IPFS 鏡像 URL 切到 dweb.link）配套：

- 解決「每跑一次 IPFS build，main repo 就多 50+ dirty 檔要手動還原」的長期痛點
- 加上嚴格錯誤模式跟 sanity check，避免半成品被 publish 到 IPFS
- IPNS lifetime 從預設 24h 拉到 30 天，解決 gateway 偶發 504（DNSLink 解析時 IPNS DHT record 已過期）

## Changes

### `docs/build_docs_anoni_ipfs.sh`

| 變更 | 動機 |
|---|---|
| 加 `#!/usr/bin/env bash` shebang + `set -euo pipefail` | 任一步驟失敗就停，避免半成品被 publish。`pipefail` 抓 pipe 中間失敗 |
| 跑前 `git diff --quiet` 檢查 working tree 是否乾淨，dirty 就 abort | `replace_sitename_anoni_ipfs.sh` 是 in-place 改 source，跟未提交修改混在一起會在 cleanup 階段丟失工作 |
| `trap cleanup_source EXIT` 自動 `git restore .` | 解決 main repo 永遠 dirty 的問題：之前每跑一次 build，main repo 就有 50+ modified 檔要手動 `git restore` |
| Build 完做 sanity check（grep `https://anoni.net/docs`） | 防呆 `replace_sitename_anoni_ipfs.sh` 漏改某個檔，避免 IPFS 版內部 link 跑到主站 |
| 加 Usage 文檔（檔頭 comment）+ `chmod +x` | 新貢獻者看 script 第一行就懂怎麼跑、有什麼選項 |

### `docs/upload_to_ipfs.sh`

| 變更 | 動機 |
|---|---|
| `ipfs name publish` 加 `--lifetime=720h --ttl=5m` | 預設 `lifetime=24h`，非每日 deploy 時 IPNS record 在 DHT 上會過期，造成 gateway 偶發 504（DNSLink 找得到但 IPNS 解不到 CID）。30 天 lifetime 解決；TTL 5m 平衡客戶端 cache 跟更新延遲 |

## Test plan

- [x] `bash -n build_docs_anoni_ipfs.sh` 語法檢查通過
- [x] `sh -n upload_to_ipfs.sh` 語法檢查通過
- [ ] `./build_docs_anoni_ipfs.sh --no-upload` 在 clean repo 上跑：應該 build 成功、sanity check pass、結束後 working tree 自動回到 clean
- [ ] 故意改一個 file（讓 working tree dirty）再跑 `./build_docs_anoni_ipfs.sh --no-upload`：應該在開頭 abort，提示 dirty files
- [ ] 故意改壞 `replace_sitename_anoni_ipfs.sh`（漏掉一行 sed）讓 build 後 `anoni-net-docs-ipfs/` 內仍有 `https://anoni.net/docs`：應該在 sanity check 階段 abort 並列出殘留檔案
- [ ] 正常 deploy（不加 `--no-upload`）跑一次，確認 `ipfs name publish` 帶 lifetime/ttl 參數成功 publish
- [ ] 24h 後 `dig +short TXT _dnslink.anoni.net` + gateway 解析確認 IPNS 沒過期

## 相關

- PR #72：IPFS 鏡像 URL 切到 `anoni-net.ipns.dweb.link`（已 merge 後本 PR 才生效）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
