### PR TITLE
build: 加入 aa.anoni.net 分析腳本（僅 standard build 生效）

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -70,4 +70,7 @@
   data-cf-beacon='{"token": "f38275e7514d451096b184304b1a7e81"}'
 ></script>
 <!-- End Cloudflare Web Analytics -->
+<!-- anoni-analytics-start (standard build only; stripped by replace_sitename_anoni_ipfs.sh / replace_sitename_anoni_onion.sh) -->
+<script defer src="https://aa.anoni.net/script.js" data-website-id="2b8d98c3-5bc4-45ef-958f-6cd9b770502e"></script>
+<!-- anoni-analytics-end -->
 {% endblock %}

--- a/docs/overrides_cn/main.html
+++ b/docs/overrides_cn/main.html
@@ -65,4 +65,7 @@
   data-cf-beacon='{"token": "f38275e7514d451096b184304b1a7e81"}'
 ></script>
 <!-- End Cloudflare Web Analytics -->
+<!-- anoni-analytics-start (standard build only; stripped by replace_sitename_anoni_ipfs.sh / replace_sitename_anoni_onion.sh) -->
+<script defer src="https://aa.anoni.net/script.js" data-website-id="2b8d98c3-5bc4-45ef-958f-6cd9b770502e"></script>
+<!-- anoni-analytics-end -->
 {% endblock %}

--- a/docs/overrides_en/main.html
+++ b/docs/overrides_en/main.html
@@ -65,4 +65,7 @@
   data-cf-beacon='{"token": "f38275e7514d451096b184304b1a7e81"}'
 ></script>
 <!-- End Cloudflare Web Analytics -->
+<!-- anoni-analytics-start (standard build only; stripped by replace_sitename_anoni_ipfs.sh / replace_sitename_anoni_onion.sh) -->
+<script defer src="https://aa.anoni.net/script.js" data-website-id="2b8d98c3-5bc4-45ef-958f-6cd9b770502e"></script>
+<!-- anoni-analytics-end -->
 {% endblock %}

--- a/docs/replace_sitename_anoni_ipfs.sh
+++ b/docs/replace_sitename_anoni_ipfs.sh
@@ -1,3 +1,10 @@
+# Strip standard-build-only analytics block from overrides before mkdocs build。
+# aa.anoni.net 分析端點僅在 standard 生效，避免 IPFS 使用者連到 clearnet endpoint
+sed -i '/anoni-analytics-start/,/anoni-analytics-end/d' \
+	./overrides/main.html \
+	./overrides_en/main.html \
+	./overrides_cn/main.html
+
 find ./output -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename_anoni_ipfs.sh' \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \

--- a/docs/replace_sitename_anoni_onion.sh
+++ b/docs/replace_sitename_anoni_onion.sh
@@ -1,3 +1,10 @@
+# Strip standard-build-only analytics block from overrides before mkdocs build。
+# aa.anoni.net 分析端點僅在 standard 生效，避免 Onion 使用者連到 clearnet endpoint
+sed -i '/anoni-analytics-start/,/anoni-analytics-end/d' \
+	./overrides/main.html \
+	./overrides_en/main.html \
+	./overrides_cn/main.html
+
 find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename.sh' \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \


### PR DESCRIPTION
## Summary

- 三語 `overrides*/main.html` 在 `{% block scripts %}` 內、Cloudflare beacon 之後加入 `aa.anoni.net` script，並用 marker 註解（`anoni-analytics-start` / `anoni-analytics-end`）包覆。
- `replace_sitename_anoni_ipfs.sh` 與 `replace_sitename_anoni_onion.sh` 在 mkdocs build 前用 `sed` 把整個 marker block 刪掉，IPFS / Onion 產出不含 `aa.anoni.net`。
- IPFS build 既有的 `trap cleanup_source EXIT` + `git restore .` 會把 in-place 變更還原；Onion build 沿用既有不還原的模式（與其他 in-place mutation 一致）。

## 為什麼只在 standard 生效

`aa.anoni.net` 是 clearnet 分析端點，IPFS / Tor Onion 使用者本身偏好不被觀測，不該被引導去連 clearnet beacon。

## Test plan

- [ ] 標準 build：產出 HTML 含 `aa.anoni.net/script.js`
- [ ] IPFS build (`sh build_docs_anoni_ipfs.sh`)：`grep -r "aa.anoni.net" output/` 應為空
- [ ] Onion build (`sh build_docs_anoni_onion.sh`)：`grep -r "aa.anoni.net" /srv/ooni-docs-output/` 應為空
- [ ] IPFS build 結束後 `git status` 應乾淨（`trap cleanup_source EXIT` 還原）

🤖 Generated with [Claude Code](https://claude.com/claude-code)