### PR TITLE
build: privacy plugin 排除 aa.anoni / cloudflareinsights script

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -211,7 +211,10 @@ plugins:
         font_family: Noto Sans TC
         color: "#ffffff"
         background_color: "#00aeff"
-  - privacy
+  - privacy:
+      assets_exclude:
+        - aa.anoni.net/*
+        - static.cloudflareinsights.com/*
   - git-revision-date-localized:
       type: iso_datetime
       locale: en

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -177,7 +177,10 @@ plugins:
         font_family: Noto Sans SC
         color: "#ffffff"
         background_color: "#00aeff"
-  - privacy
+  - privacy:
+      assets_exclude:
+        - aa.anoni.net/*
+        - static.cloudflareinsights.com/*
   - git-revision-date-localized:
       type: iso_datetime
       locale: en

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -122,7 +122,10 @@ plugins:
         font_family: Public Sans
         color: "#ffffff"
         background_color: "#00aeff"
-  - privacy
+  - privacy:
+      assets_exclude:
+        - aa.anoni.net/*
+        - static.cloudflareinsights.com/*
   - git-revision-date-localized:
       type: iso_datetime
       locale: en


### PR DESCRIPTION
## Summary

- 三支 mkdocs config（`mkdocs.yml`、`mkdocs_cn.yml`、`mkdocs_en.yml`）的 `privacy` plugin 補上 `assets_exclude`，把 `aa.anoni.net/*` 與 `static.cloudflareinsights.com/*` 排除在外部資產下載清單之外
- 這兩支 script 的網路請求行為（Umami 上報 `/api/send`、CF beacon 上報自己的 zone）必須從原本的外部域名載入，被 privacy plugin 抓下來變成 `../assets/external/...` 後分析會失準

## Test plan

- [x] `mkdocs.config.load_config()` 驗證三個 yml 都成功載入，`material/privacy` plugin 帶到 `assets_exclude=['aa.anoni.net/*', 'static.cloudflareinsights.com/*']`
- [ ] CI build 三語 standard 版本不報錯
- [ ] 部署後檢查 standard build 產物，確認 `aa.anoni.net` 與 `static.cloudflareinsights.com` 仍指向外部 URL，沒被搬到 `../assets/external/...`
- [ ] 24h 後到 aa.anoni.net 後台確認 PV 有進來

🤖 Generated with [Claude Code](https://claude.com/claude-code)