### PR TITLE
docs(changelog): OONI Probe 6.0.2 三語系新增

### DIFF
--- a/docs/en/changelog/ooni.md
+++ b/docs/en/changelog/ooni.md
@@ -8,6 +8,20 @@ icon: material/access-point-network
 
 [OONI](https://ooni.org/){target="_blank"} Probe, Explorer, and Run release summaries. Newest at the top. Each entry links back to the full translation.
 
-!!! info "No entries yet in English"
+## OONI Probe 6.0.2
 
-    OONI release translations exist in [traditional Chinese](https://anoni.net/docs/changelog/ooni/){target="_blank"} (OONI Probe Desktop 6.0.1 beta, OONI Explorer thematic censorship pages). English versions will be added as the community translates them.
+> 2026-05-25 · [Upstream announcement](https://github.com/ooni/probe-multiplatform/releases/tag/v6.0.2){target="_blank"}
+
+- Measurement engine remains on OONI Probe CLI v3.29.0.
+- Cleaner UI for measurement results that contain errors.
+- Updated translations: Japanese, Greek, Portuguese, German, Chinese.
+- Secure storage implementation rolled out across Android, desktop (macOS, Linux, Windows), and iOS.
+- Desktop adds Windows Store as a distribution channel and refactors the desktop distribution-channel architecture.
+- Desktop tray menu adds a Force Quit option (revealed by holding Alt).
+- Desktop database now uses WAL mode for steadier I/O.
+- Toolchain upgraded to Java 25; Kotlin, Ktor, Sentry SDK, and Compose dependencies bumped accordingly.
+- Various bug fixes and stability improvements.
+
+!!! info "Earlier OONI Probe versions"
+
+    OONI Probe 6.0.1, 6.0.0, and 5.3.0 release notes, plus the OONI Probe Desktop 6.0.1 beta and OONI Explorer thematic censorship pages translations, are currently available only in [traditional Chinese](https://anoni.net/docs/changelog/ooni/){target="_blank"}. English versions will be added as the community translates them.

--- a/docs/zh-CN/changelog/ooni.md
+++ b/docs/zh-CN/changelog/ooni.md
@@ -8,6 +8,24 @@ icon: material/access-point-network
 
 [OONI](../tools/what-is-ooni.md) Probe、Explorer、Run 等网络审查观测工具的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## OONI Probe 6.0.2
+
+> 2026-05-25 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.0.2){target="_blank"}
+
+- 量测引擎维持使用 OONI Probe CLI v3.29.0。
+- 错误量测结果页面 UI 改版，阅读更顺。
+- 翻译更新：日文、希腊文、葡萄牙文、德文、中文。
+- Android、桌面（macOS、Linux、Windows）与 iOS 平台导入 secure storage 机制。
+- 桌面版新增 Windows Store 发行通道，并重构桌面发行通道架构。
+- 桌面版 tray menu 新增 Force Quit 选项（按住 Alt 显示）。
+- 桌面数据库启用 WAL 模式，I/O 表现更稳定。
+- Java 升级至 25，依赖项目（Kotlin、Ktor、Sentry SDK、Compose）同步更新。
+- 多项 bug 修正与稳定性提升。
+
+!!! info "OONI Probe 6.0.1、6.0.0 与 5.3.0"
+
+    OONI Probe 6.0.1、6.0.0、5.3.0 等版本的发布条目目前仅在 [正体中文版](https://anoni.net/docs/changelog/ooni/){target="_blank"} 提供，简体中文版会随社群翻译滚动补上。下方保留早期的策展条目。
+
 ## OONI Probe Desktop 6.0.1 beta
 
 > 2026-04-11 · [GitHub 发布页](https://github.com/ooni/probe-multiplatform/releases/v6.0.1){target="_blank"} · [完整翻译文章](../blog/posts/2026-ooni-probe-desktop-beta.md)

--- a/docs/zh-TW/changelog/ooni.md
+++ b/docs/zh-TW/changelog/ooni.md
@@ -8,6 +8,20 @@ icon: material/access-point-network
 
 [OONI Probe](../tools/what-is-ooni.md) 跨平台應用（Windows、macOS、Linux、Android、iOS）的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
+## OONI Probe 6.0.2
+
+> 2026-05-25 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.0.2){target="_blank"}
+
+- 量測引擎維持使用 OONI Probe CLI v3.29.0。
+- 錯誤量測結果頁面 UI 改版，閱讀更順。
+- 翻譯更新：日文、希臘文、葡萄牙文、德文、中文。
+- Android、桌面（macOS、Linux、Windows）與 iOS 平台導入 secure storage 機制。
+- 桌面版新增 Windows Store 發行通道，並重構桌面發行通道架構。
+- 桌面版 tray menu 新增 Force Quit 選項（按住 Alt 顯示）。
+- 桌面資料庫啟用 WAL 模式，I/O 表現更穩定。
+- Java 升級至 25，依賴項目（Kotlin、Ktor、Sentry SDK、Compose）同步更新。
+- 多項 bug 修正與穩定性提升。
+
 ## OONI Probe 6.0.1
 
 > 2026-03-10 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.0.1){target="_blank"}


### PR DESCRIPTION
## Summary

- 三語系 `changelog/ooni.md` 新增 OONI Probe 6.0.2（2026-05-25 上游釋出）條目。重點：跨平台 secure storage、Windows Store 發行通道、桌面 tray menu Force Quit、WAL 模式、Java 25、UI 與翻譯更新。
- `en/changelog/ooni.md` 從「No entries yet」placeholder 改為「最新版本完整條目 + 早期版本 callout」模式，對齊 `en/tor.md`、`en/tails.md`、`en/arti.md` 既有風格。
- `zh-CN/changelog/ooni.md` 在頂端新增 6.0.2 條目並加 callout 指向正體中文版，保留下方既有策展條目（OONI Probe Desktop 6.0.1 beta、OONI Explorer 主题审查页面）不動。

## 對照檢查（2026-05-27）

| 專案 | 上游最新 | 我們 changelog | 狀態 |
|---|---|---|---|
| Tor Browser | 15.0.14 | 15.0.14 | 已最新 |
| Tor Browser Alpha | 16.0a6 | 16.0a6 | 已最新 |
| Arti | 2.3.0 | 2.3.0 | 已最新 |
| Tails | 7.8 | 7.8 | 已最新 |
| **OONI Probe** | **6.0.2** | 原本只到 6.0.1 | **本 PR 補上** |

## Test plan

- [ ] `mkdocs serve` 確認 zh-TW、zh-CN、en 三語系 `changelog/ooni/` 頁面正常渲染
- [ ] 確認 6.0.2 條目排在最上方
- [ ] 確認 callout（!!! info）渲染樣式正確
- [ ] 確認上游公告連結點擊可達

🤖 Generated with [Claude Code](https://claude.com/claude-code)