### PR TITLE
fix: ripe.py ASN 解析改用行尾錨點，修正 RIPE 特殊字元導致的 NotImplementedError

### DIFF
--- a/asn_coverage/ripe.py
+++ b/asn_coverage/ripe.py
@@ -25,7 +25,7 @@ class RIPEData(Session):
             re.compile(
                 r"(?P<no>\d+) (?P<reserved>-Reserved AS-), (?P<location>[A-Z]{2})"),
             re.compile(
-                r"(?P<no>\d+) (?P<org_id>[\w\-]+)? ?(?P<registrar>[\w\ \-\.\&\,\(\)\"|/@:?#*'`!+\]\[]+)?, (?P<location>[A-Z]{2})"),
+                r"(?P<no>\d+) (?P<org_id>[\w\-]+)? ?(?P<registrar>.+?)?, (?P<location>[A-Z]{2})\s*$"),
             re.compile(r"(?P<no>23456) (?P<name>.+)"),
             re.compile(r"(?P<no>\d+) , "),
         )


### PR DESCRIPTION
## 背景

scheduled workflow 「RIPE ASN name lists」失敗（[run 26555058079](https://github.com/anoni-net/docs/actions/runs/26555058079)），`uv run ./ripe.py list` 在解析 RIPE `asn.txt` 時拋 `NotImplementedError` 並 exit 1。

## 根本原因

`asn_coverage/ripe.py` 第二個 regex 用**白名單字元類別**列舉 `registrar` 允許的字元。RIPE 名稱出現白名單外的字元時，四個 pattern 全部比對失敗、落到 `else` 拋 `NotImplementedError`。

觸發行：

```
17963 NET263 - Beijing Capital-online science development Co.,Ltd. ShangHai Branch& # 65289;, CN
```

破壞字元是 HTML entity `&#65289;` 裡的分號 `;`。抓最新 RIPE 全檔（121376 行）跑現行 regex，發現受影響的**不只 1 行，共 9 行**，破壞字元包含分號 `;`、tab `\t`、非 ASCII `§`、mojibake 位元組。白名單法每次 RIPE 加新字元就會再炸。

## 修正

`registrar` 改用 `.+?`（non-greedy）比對到行尾國碼前的任意字元，加上 `\s*$` 錨點，利用 RIPE 固定格式 `<asn> <name>, <CC>`。

```diff
-                r"(?P<no>\d+) (?P<org_id>[\w\-]+)? ?(?P<registrar>[\w\ \-\.\&\,\(\)\"|/@:?#*'`!+\]\[]+)?, (?P<location>[A-Z]{2})"),
+                r"(?P<no>\d+) (?P<org_id>[\w\-]+)? ?(?P<registrar>.+?)?, (?P<location>[A-Z]{2})\s*$"),
```

## 驗證

對 RIPE 全檔 121376 行做新舊 regex 全量比對：

- 舊 regex 失敗 9 行 → 新 regex **0 行失敗**
- 兩者都能解析的行，結果**完全一致**（0 diff），不改變既有 CSV 輸出
- `uv run ./ripe.py list` 與 `list --loc=TW` 實跑：exit code 0、無 stderr

## Test plan

- [x] `uv run ./ripe.py list`（ALL）跑完無 crash、exit 0
- [x] `uv run ./ripe.py list --loc=TW` 正常輸出
- [x] 全檔 121376 行新舊解析結果比對 0 diff
- [ ] merge 後觀察 check-ripe scheduled workflow 轉綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)