### PR TITLE
docs(community): WebTunnel 反向代理加固（404 偽裝 + 長連線 timeout）

### DIFF
--- a/docs/en/community/setup-tor-webtunnel.md
+++ b/docs/en/community/setup-tor-webtunnel.md
@@ -98,6 +98,35 @@ location = /$PATH {
 }
 ```
 
+!!! tip "Advanced: two reverse-proxy hardening tweaks the official docs skip"
+
+    The setup above works. Two small adjustments the official docs don't mention make the secret path harder to probe and long-lived connections more stable, and they're well worth adding in practice.
+
+    **Hide the secret path more thoroughly**
+
+    By default, a plain request to the secret path without a WebSocket handshake gets forwarded to the bridge, and the bridge's response may differ from the rest of the site, giving the path away. Add one line so any request without an `Upgrade` header gets a 404, making the path indistinguishable from any non-existent URL on the site:
+
+    ```nginx
+    location = /$PATH {
+        # Only a real WebTunnel handshake gets through; plain probes get a 404
+        if ($http_upgrade = "") { return 404; }
+        proxy_pass http://127.0.0.1:15000;
+        # ...rest of the config as above
+    }
+    ```
+
+    A real WebTunnel connection always carries an `Upgrade` header, so this line won't block legitimate bridge clients.
+
+    **Don't let nginx cut long connections**
+
+    nginx's `proxy_read_timeout` defaults to 60 seconds, so a connection with no data flowing for 60 seconds gets dropped, causing spurious disconnects for the long-lived Tor circuits a bridge carries. Raise the timeouts in the `location` block and enable TCP keepalive:
+
+    ```nginx
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        proxy_socket_keepalive on;
+    ```
+
 Keep the root path `location /` serving a normal web page so the server as a whole looks like an ordinary site; only a Tor client that knows the secret path reaches the bridge. After editing, test the config and reload:
 
 ```bash

--- a/docs/zh-CN/community/setup-tor-webtunnel.md
+++ b/docs/zh-CN/community/setup-tor-webtunnel.md
@@ -98,6 +98,35 @@ location = /$PATH {
 }
 ```
 
+!!! tip "进阶：两个官方没提的反向代理加固"
+
+    上面的设定能正常运作。有两个官方文件没写的小调整，能让秘密路径更难被探测、长连线更稳定，实务上很值得加。
+
+    **把秘密路径藏得更彻底**
+
+    预设情况下，对秘密路径送一个没有 WebSocket 握手的普通请求，会被转发给桥接，而桥接的回应可能跟站上其他路径长得不一样，反而暴露出这个路径的存在。加一行，让没有 Upgrade 标头的请求一律回 404，这个路径就跟站上任何不存在的网址没有两样：
+
+    ```nginx
+    location = /$PATH {
+        # 只有真正的 WebTunnel 握手能通过，普通探测一律回 404
+        if ($http_upgrade = "") { return 404; }
+        proxy_pass http://127.0.0.1:15000;
+        # ……其余设定同上
+    }
+    ```
+
+    真正的 WebTunnel 连线一定带 Upgrade 标头，这行不会挡到正常的桥接客户端。
+
+    **别让 nginx 切断长连线**
+
+    nginx 的 `proxy_read_timeout` 预设只有 60 秒，连线超过 60 秒没有资料流动就会被切掉，对长时间挂着的 Tor 电路会造成莫名的断线。把 `location` 区块里的逾时拉长，并开启 TCP keepalive：
+
+    ```nginx
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        proxy_socket_keepalive on;
+    ```
+
 根路径 `location /` 维持回传一个正常网页，让服务器整体看起来像普通网站，只有知道秘密路径的 Tor 客户端会走到桥接。改完测试设定并重新载入：
 
 ```bash

--- a/docs/zh-TW/community/setup-tor-webtunnel.md
+++ b/docs/zh-TW/community/setup-tor-webtunnel.md
@@ -98,6 +98,35 @@ location = /$PATH {
 }
 ```
 
+!!! tip "進階：兩個官方沒提的反向代理加固"
+
+    上面的設定能正常運作。有兩個官方文件沒寫的小調整，能讓秘密路徑更難被探測、長連線更穩定，實務上很值得加。
+
+    **把秘密路徑藏得更徹底**
+
+    預設情況下，對秘密路徑送一個沒有 WebSocket 握手的普通請求，會被轉發給橋接，而橋接的回應可能跟站上其他路徑長得不一樣，反而暴露出這個路徑的存在。加一行，讓沒有 Upgrade 標頭的請求一律回 404，這個路徑就跟站上任何不存在的網址沒有兩樣：
+
+    ```nginx
+    location = /$PATH {
+        # 只有真正的 WebTunnel 握手能通過，普通探測一律回 404
+        if ($http_upgrade = "") { return 404; }
+        proxy_pass http://127.0.0.1:15000;
+        # ⋯⋯其餘設定同上
+    }
+    ```
+
+    真正的 WebTunnel 連線一定帶 Upgrade 標頭，這行不會擋到正常的橋接客戶端。
+
+    **別讓 nginx 切斷長連線**
+
+    nginx 的 `proxy_read_timeout` 預設只有 60 秒，連線超過 60 秒沒有資料流動就會被切掉，對長時間掛著的 Tor 電路會造成莫名的斷線。把 `location` 區塊裡的逾時拉長，並開啟 TCP keepalive：
+
+    ```nginx
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        proxy_socket_keepalive on;
+    ```
+
 根路徑 `location /` 維持回傳一個正常網頁，讓伺服器整體看起來像普通網站，只有知道秘密路徑的 Tor 客戶端會走到橋接。改完測試設定並重新載入：
 
 ```bash


### PR DESCRIPTION
## 這個 PR 做什麼

在 `setup-tor-webtunnel`（社群教學）的 nginx 設定段之後，補一個進階 `!!! tip`，收錄官方文件沒提、但實務上有感的兩個反向代理調整。zh-TW / zh-CN / en 三語同步。

## 兩個加固

- **404 偽裝**：`if ($http_upgrade = "") { return 404; }`。預設下對秘密路徑送普通 GET 會被轉發給橋接，回應可能洩漏路徑特徵；改成沒帶 Upgrade 標頭就回 404，讓這個路徑跟站上任何不存在的網址沒兩樣。真正的 WebTunnel 連線一定帶 Upgrade，不會擋到正常客戶端。
- **長連線 timeout**：`proxy_read_timeout` / `proxy_send_timeout` 拉到 `86400s` 並開 `proxy_socket_keepalive on`。nginx 預設 60 秒會切掉沒有資料流動的連線，對長時間掛著的 Tor 電路造成莫名斷線。

基本設定維持與官方一致，加固列為進階選項，讀者比對官方文件時不會困惑。

## 注意

- 這是 mkdocs Material 的巢狀寫法（admonition 內縮 4 空格再放 ```nginx fence），合併前建議本機 `mkdocs serve` 確認 tip 內兩個 code block 正常渲染。

🤖 Generated with [Claude Code](https://claude.com/claude-code)