### PR TITLE
feat(ci): docs 編輯標準掃描器接成 GitHub Action（warn 階段）

### DIFF
--- a/.github/workflows/docs-style-lint.yml
+++ b/.github/workflows/docs-style-lint.yml
@@ -1,0 +1,44 @@
+# 編輯標準掃描器（Tier 1）。只掃這個 PR 變更到的 docs Markdown。
+#
+# 目前是 warn 階段：問題以 annotation 標在 PR 變更行上，但 continue-on-error 讓 job
+# 維持綠燈，不擋 merge。收斂誤報後要改 blocking，只要拿掉下面的 continue-on-error，
+# 並在 repo 設定把這個 check 設為 branch protection 必過即可。
+name: docs-style-lint
+
+on:
+  pull_request:
+    paths:
+      - "docs/**/*.md"
+      - "tools/docs_style_lint.py"
+      - ".github/workflows/docs-style-lint.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: 掃描變更的 Markdown（warn 階段，不擋 merge）
+        continue-on-error: true
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          mapfile -t files < <(git diff --name-only --diff-filter=ACM "$base" HEAD -- docs \
+            | grep -E '\.md$' || true)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "沒有變更的 Markdown，略過。"
+            exit 0
+          fi
+          echo "掃描 ${#files[@]} 個變更檔："
+          printf '  %s\n' "${files[@]}"
+          python3 tools/docs_style_lint.py --format github "${files[@]}"

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,105 @@
+# docs 編輯標準掃描器（docs_style_lint）
+
+把公開[貢獻者百科](https://anoni.net/docs/community/contributor-handbook/)「寫作風格規範」裡可機器判斷的硬規則做成檢查，輸出 `file:line` 與規則代碼。
+
+編輯標準的單一來源是貢獻者百科，這支腳本是它的執法工具。透過 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 在每個 PR 對變更的 Markdown 自動跑，目前為 warn 階段（提醒不擋）。
+
+## 用法
+
+```bash
+# 掃單檔或整個目錄
+python3 tools/docs_style_lint.py ../anoni-net-docs/docs/zh-TW
+
+# 只看會擋 CI 的 error
+python3 tools/docs_style_lint.py --no-warn <path>
+
+# JSON 輸出（給後續聚合或 CI annotation）
+python3 tools/docs_style_lint.py --format json <path>
+```
+
+純 Python 3 標準庫，無外部相依。有任一 error 回 exit code 1，warn 不影響 exit code。
+
+掃描前會剝除 fenced code、inline code、HTML 註解、Markdown 連結的 URL 與裸 URL，避免在程式碼與網址上誤判。front matter 不套用內文標點規則，只做欄位檢查。
+
+## CI：GitHub Action（只掃變更檔）
+
+舊文有不少遺留違規（見下方試跑結果）。CI 不全庫掃，只掃這次 PR 變更到的 Markdown，避免舊文擋住新貢獻。由 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 處理：`pull_request` 觸發、用 `git diff` 算出變更的 `docs/**/*.md`，跑 `--format github` 把問題以 annotation 標在 PR 的變更行上。
+
+目前是 **warn 階段**：問題只提醒，job 維持綠燈，不擋 merge。要改 blocking：拿掉 workflow 裡的 `continue-on-error`，並在 repo 設定把這個 check 設為 branch protection 必過。
+
+本機重現 CI 的掃法：
+
+```bash
+git diff --name-only --diff-filter=ACM origin/main... \
+  | grep -E '\.md$' \
+  | xargs -r python3 tools/docs_style_lint.py
+```
+
+全庫掃描留作選擇性的清理 pass。
+
+## Tier 1：本工具會自動檢查
+
+| 規則代碼 | 嚴重度 | 內容 |
+|---|---|---|
+| `em-dash` | error | 破折號「—」當插入語 |
+| `semicolon` | error | 全形分號「；」 |
+| `fullwidth-slash` | error | 全形「／」 |
+| `bushi-ershi` | error | 「不是…而是…」句型 |
+| `buzhi-ershi` | error | 「不再只是…而是…」句型 |
+| `quote-juxtapose` | error | 並列引號之間缺「、」（`」「`）|
+| `ai-opener` | error | 句首「值得注意的是/總的來說/綜上所述」|
+| `frontmatter-missing` | error | blog post 缺 date/slug/categories/authors |
+| `definition-phrasing` | warn | 「談的是/指的是/涵蓋的是」|
+| `colloquial-jiang` | warn | 口語「講」（已扣除演講/講座等正當詞）|
+| `machine-field` | warn | 機器欄位名直接出現在內文（如 `web_connectivity`）|
+| `title-missing` / `frontmatter-summary` | warn | blog 無 H1 標題 / 無 summary |
+
+## Tier 2：本工具「不」檢查，需 AI 或人工複審
+
+這些規則需要語意判斷，正則做不準，刻意不在此掃，避免假裝涵蓋了。校稿或 review 時仍要靠人或 AI 輔助：
+
+- 去 AI 味：開場鋪陳句（meta scaffolding）、「這…」開頭、抽象改具體、去誇飾
+- 過度對稱的三段結構
+- 安全寫作：不提供可被濫用的全量枚舉、逐一抓取等操作配方
+- 隱私：不揭露個別操作者的個人帳號 / handle，用地區或角色代稱
+
+未來可加一個 `--ai` 模式，把 Tier 2 交給 LLM 逐段判斷。
+
+## 已知邊界（會誤報或需人判斷）
+
+- `em-dash`：若破折號出現在外部專有名詞的連結文字（例 `[Cloudflare Radar — Iran](...)`），會被標記。必要時改寫標籤或人工放行。
+- `colloquial-jiang`、`definition-phrasing`：列為 warn 而非 error，因為「講清楚」、「指的是什麼呢」等仍有正當用法，只當提醒。
+
+## 關閉特定檢查
+
+- 規則文件本身（`contributor-handbook.md`、`docs-writing-style.md`）會引用被禁的句型當例子，預設略過。要連它們一起掃用 `--include-rule-docs`。
+- 任何頁面要展示違規範例時，用 inline 指令局部關閉：
+
+    ```markdown
+    <!-- docs-style-lint: disable -->
+    這段示範了被禁的句型，不會被檢查。
+    <!-- docs-style-lint: enable -->
+    ```
+
+  同一行結尾放 `<!-- docs-style-lint: disable-line -->` 可只關閉該行。
+
+## 試跑結果（2026-06，全 zh-TW）
+
+| 規則 | 數量 |
+|---|---|
+| semicolon | 36 |
+| em-dash | 25 |
+| colloquial-jiang（warn） | 11 |
+| definition-phrasing（warn） | 6 |
+| quote-juxtapose | 5 |
+| frontmatter-missing（slug） | 2 |
+| bushi-ershi / buzhi-ershi / fullwidth-slash | 各 1 |
+
+共 71 error、17 warn、32 個檔案。最近校稿過的文章乾淨，違規集中在較早的翻譯文。
+
+## 上線進程
+
+1. 私有試跑穩定。✅
+2. 移入公開 `anoni-net/docs`，GitHub Action 對變更檔跑「warn 不擋」。← 現在
+3. 收斂誤報後升為 blocking gate（拿掉 `continue-on-error` + 設 branch protection 必過）。
+4. 視需要做一次全庫清理 pass，把舊文遺留違規補掉。

--- a/tools/docs_style_lint.py
+++ b/tools/docs_style_lint.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""anoni.net/docs 編輯標準掃描器（Tier 1）。
+
+把貢獻者百科「寫作風格規範」裡可機器判斷的硬規則做成檢查，輸出 file:line 與
+規則代碼。語意層的規則（去 AI 味、安全配方、操作者帳號、三段對稱）需 AI 或人工
+複審，不在此掃描，清單見 tools/README.md。
+
+用法：
+    python3 tools/docs_style_lint.py <檔案或目錄> [...]
+    python3 tools/docs_style_lint.py --no-warn <path>     # 只看 error
+    python3 tools/docs_style_lint.py --format json <path>
+
+掃描前會剝除 fenced code、inline code、HTML 註解、Markdown 連結的 URL 與裸 URL，
+避免在程式碼與網址上誤判。front matter 不套用內文標點規則，只做欄位檢查。
+
+exit code：有任一 error 回 1，否則回 0（warn 不影響 exit code）。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# 嚴重度
+ERROR = "error"
+WARN = "warn"
+
+# (代碼, 嚴重度, 已編譯 regex, 訊息)。regex 跑在「已剝除程式碼/URL」的內文上。
+PROSE_RULES = [
+    ("em-dash", ERROR, re.compile(r"—"),
+     "禁用破折號「—」，改用冒號、逗號或拆成兩句"),
+    ("semicolon", ERROR, re.compile(r"；"),
+     "避免分號「；」，改用「。」或拆句"),
+    ("fullwidth-slash", ERROR, re.compile(r"／"),
+     "不使用全形「／」，並列用「、」，需斜線用半形 /"),
+    ("bushi-ershi", ERROR, re.compile(r"不是[^。！？\n]{0,40}?而是"),
+     "禁用「不是…而是…」句型，改用正向直述"),
+    ("buzhi-ershi", ERROR, re.compile(r"不再只是[^。！？\n]{0,40}?而是"),
+     "禁用「不再只是…而是…」句型，改用正向直述"),
+    ("quote-juxtapose", ERROR, re.compile(r"」「"),
+     "並列引號之間要加「、」（「甲」、「乙」）"),
+    # 定義句型，偶有正當用法（指的是），列為 warn
+    ("definition-phrasing", WARN, re.compile(r"(談的是|指的是|涵蓋的是)"),
+     "避免「談的是/指的是/涵蓋的是」，直接把定義說完整"),
+    # 機器欄位名直接出現在內文，提醒人性化（附原文）
+    ("machine-field", WARN, re.compile(r"\bweb_connectivity\b"),
+     "機器欄位名請人性化並附原文，例：網路連線測試（Web Connectivity）"),
+]
+
+# 句首 AI 套語（套用在剝除後、每行去掉清單/引言標記後的開頭）
+AI_OPENERS = ["值得注意的是", "總的來說", "綜上所述"]
+AI_OPENER_RE = re.compile(r"^[\s>*\-+]*(" + "|".join(AI_OPENERS) + r")")
+
+# 口語「講」，扣掉常見正當詞
+JIANG_RE = re.compile(r"講")
+JIANG_ALLOW = re.compile(r"(演講|講座|講師|講者|講習|講義|講堂|宣講)")
+
+# 部落格 front matter 必填欄位（title 來自 H1，不在此列）
+BLOG_REQUIRED = ["date", "slug", "categories", "authors"]
+
+# inline 關閉指令：<!-- docs-style-lint: disable --> / enable / disable-line
+LINT_DIRECTIVE = re.compile(r"<!--\s*docs-style-lint:\s*(disable|enable|disable-line)\s*-->")
+
+# 規則文件本身會引用被禁的句型當例子，預設略過（可用 --include-rule-docs 強制掃）
+RULE_DOCS = {"contributor-handbook.md", "docs-writing-style.md"}
+
+
+def split_front_matter(text: str):
+    """回傳 (front_matter_lines, body_start_lineno, fm_dict)。沒有 front matter 回 ([],0,{})。"""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return [], 0, {}
+    for i in range(1, len(lines)):
+        if lines[i].strip() in ("---", "..."):
+            fm = {}
+            for ln in lines[1:i]:
+                m = re.match(r"^([A-Za-z0-9_\-]+)\s*:", ln)
+                if m:
+                    fm[m.group(1)] = ln.split(":", 1)[1].strip()
+            return lines[1:i], i + 1, fm
+    return [], 0, {}
+
+
+def strip_noise(line: str, state: dict) -> str:
+    """把程式碼、URL、註解換成等長空白，保留行號與其餘字元位置。"""
+    # 多行 fenced code
+    fence = re.match(r"^\s*(```|~~~)", line)
+    if state.get("in_fence"):
+        if fence:
+            state["in_fence"] = False
+        return " " * len(line)
+    if fence:
+        state["in_fence"] = True
+        return " " * len(line)
+    # 多行 HTML 註解
+    out = line
+    if state.get("in_comment"):
+        end = out.find("-->")
+        if end == -1:
+            return " " * len(out)
+        out = " " * (end + 3) + out[end + 3:]
+        state["in_comment"] = False
+
+    def blank(m):
+        return " " * len(m.group(0))
+
+    # 單行 HTML 註解 / 未閉合註解
+    out = re.sub(r"<!--.*?-->", blank, out)
+    if "<!--" in out:
+        idx = out.index("<!--")
+        state["in_comment"] = True
+        out = out[:idx] + " " * (len(out) - idx)
+    # inline code
+    out = re.sub(r"`[^`]*`", blank, out)
+    # Markdown 連結的 URL 部分：[text](url) → 保留 [text]，URL 換空白
+    out = re.sub(r"(\]\()([^)]*)(\))", lambda m: m.group(1) + " " * len(m.group(2)) + m.group(3), out)
+    # 裸 URL
+    out = re.sub(r"https?://\S+", blank, out)
+    return out
+
+
+def lint_file(path: Path):
+    findings = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        findings.append((0, ERROR, "read-error", str(e), ""))
+        return findings
+
+    fm_lines, body_start, fm = split_front_matter(text)
+
+    # front matter 欄位檢查（只對 blog posts 強制全部欄位）
+    if "/blog/posts/" in path.as_posix():
+        for key in BLOG_REQUIRED:
+            if key not in fm:
+                findings.append((1, ERROR, "frontmatter-missing",
+                                 f"blog post 缺 front matter 欄位「{key}」", ""))
+        has_h1 = re.search(r"^# \S", text, re.MULTILINE) is not None
+        if "title" not in fm and not has_h1:
+            findings.append((1, WARN, "title-missing",
+                             "blog post 沒有 title front matter，也沒有 H1 標題", ""))
+        if "summary" not in fm and "description" not in fm:
+            findings.append((1, WARN, "frontmatter-summary",
+                             "blog post 建議有 summary 或 description", ""))
+
+    state = {}
+    in_fm = bool(fm_lines)
+    fm_end_line = body_start  # 1-based 行號：front matter 結尾的 --- 行
+    disabled = False
+    for i, raw in enumerate(text.splitlines(), start=1):
+        # 略過 front matter 區塊（含起訖 ---）的內文規則
+        if in_fm and i <= fm_end_line:
+            continue
+        d = LINT_DIRECTIVE.search(raw)
+        if d:
+            kind = d.group(1)
+            if kind == "disable":
+                disabled = True
+                continue
+            if kind == "enable":
+                disabled = False
+                continue
+            if kind == "disable-line":
+                continue
+        if disabled:
+            continue
+        clean = strip_noise(raw, state)
+        if not clean.strip():
+            continue
+        for code, sev, rx, msg in PROSE_RULES:
+            for m in rx.finditer(clean):
+                snippet = raw[max(0, m.start() - 8): m.start() + 12].strip()
+                findings.append((i, sev, code, msg, snippet))
+        if AI_OPENER_RE.search(clean):
+            findings.append((i, ERROR, "ai-opener",
+                             "避免以「值得注意的是/總的來說/綜上所述」開頭", raw.strip()[:24]))
+        for m in JIANG_RE.finditer(clean):
+            around = clean[max(0, m.start() - 1): m.start() + 2]
+            if not JIANG_ALLOW.search(around):
+                findings.append((i, WARN, "colloquial-jiang",
+                                 "口語「講」建議改書面語（提到、說明）", raw[max(0, m.start() - 6): m.start() + 6].strip()))
+    return findings
+
+
+def iter_md(paths):
+    for p in paths:
+        p = Path(p)
+        if p.is_dir():
+            yield from sorted(p.rglob("*.md"))
+        elif p.suffix == ".md":
+            yield p
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="anoni.net/docs 編輯標準掃描器（Tier 1）")
+    ap.add_argument("paths", nargs="+", help="要掃描的 .md 檔或目錄")
+    ap.add_argument("--no-warn", action="store_true", help="只顯示 error")
+    ap.add_argument("--include-rule-docs", action="store_true",
+                    help="連規則文件本身（貢獻者百科等）一起掃")
+    ap.add_argument("--format", choices=["text", "json", "github"], default="text",
+                    help="github: 輸出 GitHub Actions annotation（::error/::warning）")
+    args = ap.parse_args(argv)
+
+    results = {}
+    n_err = n_warn = n_files = n_skipped = 0
+    for f in iter_md(args.paths):
+        if not args.include_rule_docs and f.name in RULE_DOCS:
+            n_skipped += 1
+            continue
+        n_files += 1
+        items = lint_file(f)
+        if args.no_warn:
+            items = [x for x in items if x[1] == ERROR]
+        if not items:
+            continue
+        results[str(f)] = items
+        for _, sev, *_ in items:
+            if sev == ERROR:
+                n_err += 1
+            else:
+                n_warn += 1
+
+    if args.format == "json":
+        out = {fp: [dict(line=l, severity=s, rule=c, message=m, snippet=sn)
+                    for (l, s, c, m, sn) in items]
+               for fp, items in results.items()}
+        print(json.dumps({"files": out, "errors": n_err, "warnings": n_warn},
+                         ensure_ascii=False, indent=2))
+    elif args.format == "github":
+        # GitHub Actions workflow command，問題會 inline 標在 PR 變更行上
+        for fp, items in results.items():
+            for (l, sev, code, msg, sn) in sorted(items):
+                cmd = "error" if sev == ERROR else "warning"
+                text = f"[{code}] {msg}" + (f"  | {sn}" if sn else "")
+                text = text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+                print(f"::{cmd} file={fp},line={l}::{text}")
+        print(f"docs-style-lint: {n_err} error, {n_warn} warn, {n_files} files",
+              file=sys.stderr)
+    else:
+        for fp, items in results.items():
+            print(f"\n{fp}")
+            for (l, sev, code, msg, sn) in sorted(items):
+                tag = "ERROR" if sev == ERROR else "warn "
+                extra = f"  | {sn}" if sn else ""
+                print(f"  {l:>4}: {tag} [{code}] {msg}{extra}")
+        skip_note = f"，略過規則文件 {n_skipped} 個" if n_skipped else ""
+        print(f"\n總計：{n_err} error、{n_warn} warn，掃描 {n_files} 個檔案{skip_note}")
+
+    return 1 if n_err else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 目的

把編輯標準掃描器接成 CI，在每個 PR 自動對「變更的 docs Markdown」檢查貢獻者百科裡可機器判斷的硬規則。Tier 2 語意規則（去 AI 味、安全配方、操作者帳號、三段對稱）仍需人或 AI 複審，不在此掃。

## 內容

- `tools/docs_style_lint.py`：純 Python 標準庫掃描器，新增 `--format github` 輸出 `::error`/`::warning` annotation。
- `tools/README.md`：用法、規則清單、Tier 2 未涵蓋清單、已知邊界。
- `.github/workflows/docs-style-lint.yml`：`pull_request` 觸發，用 `git diff` 算出變更的 `docs/**/*.md`，跑 `--format github`，問題 inline 標在 PR 變更行。

## 現在是 warn 階段（不擋 merge）

- 問題只提醒，job 維持綠燈（`continue-on-error`）。先讓大家習慣、順便收斂誤報。
- 之後改 blocking：拿掉 workflow 的 `continue-on-error`，並在 repo 設定把 `docs-style-lint` 設為 branch protection 必過。這步是 repo 設定，不在這個 PR。

## 設計重點

- **只掃變更檔**：舊文有約 71 個遺留違規（多為早期翻譯文的 `；`、破折號），全庫掃會擋住所有人。CI 只掃這個 PR 改到的 md，舊文不受影響。全庫清理留作之後選擇性的 pass。
- **規則文件自身略過**：貢獻者百科會引用被禁句型當例子，預設略過，並支援 `<!-- docs-style-lint: disable -->` inline 指令。
- **剝除 code/URL**：掃描前移除程式碼區塊、inline code、HTML 註解、URL，避免誤判。

## 驗證

- 本機對含破折號的舊文跑 `--format github`，確認輸出 `::error file=...,line=...::...` 格式正確、exit code 正確。
- 這個 PR 沒有改任何 `docs/**/*.md`，所以 workflow 會觸發但掃描步驟回報「沒有變更的 Markdown」後綠燈，驗證接線。首個改到 docs 的 PR 就會看到 annotation。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
