### PR TITLE
fix(ci): docs-style-lint 只掃中文（zh-TW/zh-CN），不掃 en

### DIFF
--- a/.github/workflows/docs-style-lint.yml
+++ b/.github/workflows/docs-style-lint.yml
@@ -1,4 +1,5 @@
-# 編輯標準掃描器（Tier 1）。只掃這個 PR 變更到的 docs Markdown。
+# 編輯標準掃描器（Tier 1）。只掃這個 PR 變更到的「中文」docs Markdown（zh-TW、zh-CN）。
+# 英文版（docs/en）的標點規則不同（破折號、分號在英文是正常的），不在此掃。
 #
 # 目前是 warn 階段：問題以 annotation 標在 PR 變更行上，但 continue-on-error 讓 job
 # 維持綠燈，不擋 merge。收斂誤報後要改 blocking，只要拿掉下面的 continue-on-error，
@@ -8,7 +9,8 @@ name: docs-style-lint
 on:
   pull_request:
     paths:
-      - "docs/**/*.md"
+      - "docs/zh-TW/**/*.md"
+      - "docs/zh-CN/**/*.md"
       - "tools/docs_style_lint.py"
       - ".github/workflows/docs-style-lint.yml"
 
@@ -33,7 +35,7 @@ jobs:
         continue-on-error: true
         run: |
           base="${{ github.event.pull_request.base.sha }}"
-          mapfile -t files < <(git diff --name-only --diff-filter=ACM "$base" HEAD -- docs \
+          mapfile -t files < <(git diff --name-only --diff-filter=ACM "$base" HEAD -- docs/zh-TW docs/zh-CN \
             | grep -E '\.md$' || true)
           if [ ${#files[@]} -eq 0 ]; then
             echo "沒有變更的 Markdown，略過。"

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,7 +2,7 @@
 
 把公開[貢獻者百科](https://anoni.net/docs/community/contributor-handbook/)「寫作風格規範」裡可機器判斷的硬規則做成檢查，輸出 `file:line` 與規則代碼。
 
-編輯標準的單一來源是貢獻者百科，這支腳本是它的執法工具。透過 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 在每個 PR 對變更的 Markdown 自動跑，目前為 warn 階段（提醒不擋）。
+編輯標準的單一來源是貢獻者百科，這支腳本是它的執法工具。規則是中文寫作規範，套用在 zh-TW 與 zh-CN，不掃英文版（docs/en 的破折號、分號等在英文是正常的）。透過 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 在每個 PR 對變更的中文 Markdown 自動跑，目前為 warn 階段（提醒不擋）。
 
 ## 用法
 
@@ -23,7 +23,7 @@ python3 tools/docs_style_lint.py --format json <path>
 
 ## CI：GitHub Action（只掃變更檔）
 
-舊文有不少遺留違規（見下方試跑結果）。CI 不全庫掃，只掃這次 PR 變更到的 Markdown，避免舊文擋住新貢獻。由 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 處理：`pull_request` 觸發、用 `git diff` 算出變更的 `docs/**/*.md`，跑 `--format github` 把問題以 annotation 標在 PR 的變更行上。
+舊文有不少遺留違規（見下方試跑結果）。CI 不全庫掃，只掃這次 PR 變更到的 Markdown，避免舊文擋住新貢獻。由 [`.github/workflows/docs-style-lint.yml`](../.github/workflows/docs-style-lint.yml) 處理：`pull_request` 觸發、用 `git diff` 算出變更的中文 Markdown（`docs/zh-TW`、`docs/zh-CN`，不含 en），跑 `--format github` 把問題以 annotation 標在 PR 的變更行上。
 
 目前是 **warn 階段**：問題只提醒，job 維持綠燈，不擋 merge。要改 blocking：拿掉 workflow 裡的 `continue-on-error`，並在 repo 設定把這個 check 設為 branch protection 必過。
 


### PR DESCRIPTION
## 問題

剛上線的 docs-style-lint CI 會掃 `docs/**/*.md`，包含英文版。英文本來就用破折號、分號等標點，掃描器的中文寫作規則不適用，對 `docs/en` 會大量誤報（單獨掃 docs/en 就有 276 個 em-dash 誤報）。

## 修正

把 workflow 的 `paths` 觸發條件與 `git diff` 範圍限定到 `docs/zh-TW`、`docs/zh-CN`，README 同步標註規則只套用中文。

英文版若日後要有自己的風格檢查，應另立一套英文規則，不混用這支。

🤖 Generated with [Claude Code](https://claude.com/claude-code)