### PR TITLE
fix(docs): clear privacy plugin cache before build to self-heal external-asset mirroring

### DIFF
--- a/docs/build_docs_anoni.sh
+++ b/docs/build_docs_anoni.sh
@@ -1,4 +1,6 @@
 rm -rf ./output/*
+# 清掉 privacy plugin 快取，避免外部資源（如 vega-embed）換 URL 形狀後殘留舊鏡像 symlink 害圖表不 render
+rm -rf .cache/plugin/privacy
 sh ./run.sh
 sh ./run_en.sh
 sh ./run_zh-tw.sh

--- a/docs/build_docs_anoni_ipfs.sh
+++ b/docs/build_docs_anoni_ipfs.sh
@@ -61,6 +61,8 @@ cleanup_source() {
 trap cleanup_source EXIT
 
 rm -rf ./output/*
+# 清掉 privacy plugin 快取，避免外部資源（如 vega-embed）換 URL 形狀後殘留舊鏡像 symlink 害圖表不 render
+rm -rf .cache/plugin/privacy
 RUN replace_sitename_anoni_ipfs.sh
 RUN run.sh
 RUN run_en.sh

--- a/docs/build_docs_anoni_onion.sh
+++ b/docs/build_docs_anoni_onion.sh
@@ -1,5 +1,7 @@
 sh ./replace_sitename_anoni_onion.sh
 rm -rf ./output/*
+# 清掉 privacy plugin 快取，避免外部資源（如 vega-embed）換 URL 形狀後殘留舊鏡像 symlink 害圖表不 render
+rm -rf .cache/plugin/privacy
 sh ./run.sh
 sh ./run_en.sh
 sh ./run_zh-tw.sh


### PR DESCRIPTION
## 問題

正式站 blog 文章（如 [2026-ooni-run-v2-usage-patterns](https://anoni.net/docs/blog/2026/06/2026-ooni-run-v2-usage-patterns/)）的 vegalite 圖表在本地 `serve` 正常、正式站卻全部不 render。

頁面原始碼裡 vega 三支 script 只有 `vega-embed` 壞掉：

```
.../assets/external/cdn.jsdelivr.net/npm/vega@5.js          ✅
.../assets/external/cdn.jsdelivr.net/npm/vega-lite@5.js     ✅
../../../../https:/cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js   ❌ 404
```

## 根因

Material privacy plugin 把外部 JS 鏡像到 `assets/external/` 並存進永續快取 `docs/.cache/plugin/privacy/`。

- 舊設定的無副檔名 URL `npm/vega-embed@6` 被存成 `vega-embed@6.js` + symlink `vega-embed@6 -> vega-embed@6.js`。
- PR #82 把 URL 改成 versioned 的 `npm/vega-embed@6/build/vega-embed.min.js`，新 URL 需要 `vega-embed@6` 是**目錄**，但快取殘留的 symlink（指向檔案）擋住目錄建立 → 鏡像失敗 → script src 退化成壞掉相對路徑 → 整頁圖表不 render。

在持久化 build 主機（伺服器常駐 checkout）上這個壞快取一直殘留，改 config 也救不回，得手動清快取。GitHub Actions 因 fresh checkout 無此問題。

對照實驗（同一個 mkdocs-material 9.7.6，僅切換快取）：髒快取 → 壞、清快取 → `vega-embed@6/build/vega-embed.min.js` 以 60,630 bytes 真檔正確鏡像。

## 修正

三支 deploy 腳本（標準 / onion / ipfs）build 前加 `rm -rf .cache/plugin/privacy`，每次 deploy 重新鏡像外部資源，任何 URL 形狀變更都自動自癒。

- `.cache/` 未被 git 追蹤，故不影響 ipfs 腳本的 working-tree-clean 檢查（`git diff --quiet`）與 trap 的 `git restore .`，`set -e` 下對不存在路徑 `rm -rf` 也不中斷。
- 三支皆通過 `bash -n`。
- 代價：每次 deploy 第一個 build 會重抓外部資源（vega 三件、twemoji svg 等），約多幾秒；同次 deploy 其餘三個 build 沿用新快取。

## 部署後驗證

merge 後伺服器 `git pull` + 重新 deploy，確認 `https://anoni.net/docs/assets/external/cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js` 回 200，圖表恢復。

🤖 Generated with [Claude Code](https://claude.com/claude-code)