### PR TITLE
fix(build): 改寫 IPFS/Onion 版 repo 根 snippet 來源的 URL

### DIFF
--- a/docs/build_docs_anoni_ipfs.sh
+++ b/docs/build_docs_anoni_ipfs.sh
@@ -51,11 +51,13 @@ if ! git diff --quiet; then
 fi
 
 # 任何狀況（正常結束、中途失敗、Ctrl-C）都還原 source
-# 避免 replace_sitename_anoni_ipfs.sh 的 in-place 修改殘留在 working tree
+# 避免 replace_sitename_anoni_ipfs.sh 的 in-place 修改殘留在 working tree。
+# 用 :/（整個 repo）而非 .（僅 docs/），因為 replace 也會改寫 repo 根的 snippet 正本
+# （如 ../BECOME_ANONI.md）。開頭的 git diff --quiet 已檢查整個 repo，還原範圍對齊它才安全。
 cleanup_source() {
   rc=$?
   echo "[build] 還原 source（清除 replace 留下的 in-place 修改）"
-  git restore . 2>/dev/null || true
+  git restore :/ 2>/dev/null || true
   exit $rc
 }
 trap cleanup_source EXIT

--- a/docs/replace_sitename_anoni_ipfs.sh
+++ b/docs/replace_sitename_anoni_ipfs.sh
@@ -15,6 +15,14 @@ find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \
 	-exec sed -i 's|https://anoni.net/docs|https://anoni-net.ipns.dweb.link|g' {} +
 
+# pymdownx snippets（--8<--）的正本放 repo 根目錄（base_path 含 '..'），
+# 例如 community/become-anoni.md 嵌入 ../BECOME_ANONI.md。這些檔在 docs/ 之外，
+# 上面 find ./ 掃不到，build 時會把含 https://anoni.net/docs 的原文 inline 進 output，
+# 害 build_docs_anoni_ipfs.sh 的 sanity check 失敗。先一併改寫 repo 根的 markdown snippet 來源。
+# （build_docs_anoni_ipfs.sh 的 cleanup trap 用 git restore :/ 還原整個 repo）
+find .. -maxdepth 1 -type f -name '*.md' \
+	-exec sed -i 's|https://anoni.net/docs|https://anoni-net.ipns.dweb.link|g' {} +
+
 find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename_anoni_ipfs.sh' \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \

--- a/docs/replace_sitename_anoni_onion.sh
+++ b/docs/replace_sitename_anoni_onion.sh
@@ -20,6 +20,17 @@ find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \
 	-exec sed -i 's|https://anoni.net/docs|http://docs.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion|g' {} +
 
+# pymdownx snippets（--8<--）的正本放 repo 根目錄（base_path 含 '..'），
+# 例如 community/become-anoni.md 嵌入 ../BECOME_ANONI.md。這些檔在 docs/ 之外，
+# 上面 find ./ 掃不到，build 時會把含主站 URL 的原文 inline 進 output，
+# 害 onion 鏡像殘留 clearnet 連結。一併改寫 repo 根的 markdown snippet 來源。
+find .. -maxdepth 1 -type f -name '*.md' -exec sed -i \
+	-e 's|https://anoni.net/api|http://anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion/api|g' \
+	-e 's|https://anoni.net/docs|http://docs.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion|g' \
+	-e 's|https://form.anoni.net|http://form.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion|g' \
+	-e 's|https://pad.anoni.net|http://pad.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion|g' \
+	{} +
+
 find ./ -path './onion' -prune -o \
 	-type f ! -name 'replace_sitename.sh' \
 	-type f ! -name 'replace_sitename_anoni_onion.sh' \


### PR DESCRIPTION
## 問題

IPFS 與 Onion 兩種鏡像 build 都會殘留 clearnet 主站連結，IPFS 版更會在 sanity check 失敗、產不出可上傳的鏡像。

`community/become-anoni.md` 用 pymdownx snippets `--8<-- "BECOME_ANONI.md"` 嵌入 repo 根目錄的 `../BECOME_ANONI.md`（snippets `base_path` 含 `..`）。兩支 replace 腳本都只 `find ./`（docs 內）改寫 URL，掃不到 repo 根那份 snippet 正本。build 時 snippet 把含 `https://anoni.net/docs` 的原文 inline 進 output，殘留在 become-anoni 頁與其 search_index。

## 修正

- **`replace_sitename_anoni_ipfs.sh`**：新增 `find .. -maxdepth 1 -type f -name '*.md'`，把 repo 根 markdown 的 `https://anoni.net/docs` → `https://anoni-net.ipns.dweb.link`。
- **`build_docs_anoni_ipfs.sh`**：cleanup trap 的 `git restore` 從 `.`（僅 docs/）改成 `:/`（整個 repo），讓 repo 根那份被 in-place 改寫的 snippet 來源也能還原。開頭 `git diff --quiet` 本就檢查整個 repo，範圍對齊才一致。
- **`replace_sitename_anoni_onion.sh`**：新增同一段 `find .. -maxdepth 1`，把 repo 根 markdown 的 api/docs/form/pad 四組 URL 改寫成對應 onion 位址。onion build（`build_docs_anoni_onion.sh`）是 server 端部署、無 restore trap 也無 sanity check，故只改 replace 腳本、不動 build 腳本。

## 驗證

**IPFS**：全新 worktree 跑 `./build_docs_anoni_ipfs.sh --no-upload`（symlink 主 checkout 的 `.venv`/`.cache`）。四個語系全部建完、mirror 2115 檔、`https://anoni.net/docs` 殘留 = 0、become-anoni 連結改成 dweb.link、sanity check 通過、乾淨退出。

**Onion**：本機跑 onion replace（GNU sed）+ 主站 `mkdocs build -s`。`../BECOME_ANONI.md` 的 `/docs` 改寫成 onion 位址、become-anoni 輸出殘留 `https://anoni.net/docs` = 0、onion docs 連結 19 處到位。（server 端 `/srv/ooni-docs-output` 部署＋`sudo chown` 無法在本機跑，但 snippet→output 的 inline 機制與已端到端驗證的 IPFS 路徑相同。）

本次 IPFS 版本已用同一轉換手動補在輸出端並完成上傳（新 CID `bafybeig6ffk5u3ahtnv5hqanob256jhdl56sx5kbiwnarkjnodlvgdan5m`，IPNS 已更新）；此 PR 讓兩版 pipeline 之後都能自動處理。

## 附帶觀察（未在本 PR 處理）

- `replace_sitename_anoni_ipfs.sh` 第一行 `find ./output ...` 假設 `./output` 已存在，全新 checkout（無前次 build 殘留）會因 `set -e` 早退。本機既有工作目錄通常有 `./output` 所以不會踩到。

🤖 Generated with [Claude Code](https://claude.com/claude-code)