### PR TITLE
docs(changelog): 新增 Arti 2.4.0、Tor Browser 15.0.15 與 16.0a7（三語）

### DIFF
--- a/docs/en/changelog/arti.md
+++ b/docs/en/changelog/arti.md
@@ -8,6 +8,12 @@ icon: material/code-tags
 
 Arti is the Tor Project's next-generation Tor implementation written in Rust. Newest at the top. Each entry links back to the full translation.
 
+## Arti 2.4.0
+
+> 2026-06-01 · [Upstream announcement](https://blog.torproject.org/arti_2_4_0_released/){target="_blank"}
+
+- Continued development toward running Arti as a relay and as a directory authority, fixes for several onion service client connectivity bugs, flow control and congestion control (flowctl-cc) now stable, and multiple breaking changes to the `arti-client` `TorClient` APIs.
+
 ## Arti 2.2.0
 
 > 2026-03-31 · [Upstream announcement](https://blog.torproject.org/arti_2_2_0_released/){target="_blank"} · [Full translation](../blog/posts/2026-arti-2-2-0-released-http-connect-rpc-and-relay-development.md)
@@ -16,4 +22,4 @@ Arti is the Tor Project's next-generation Tor implementation written in Rust. Ne
 
 !!! info "Earlier versions"
 
-    Translations of Arti 2.1.0 and 1.4.1 are currently available only in [traditional Chinese](https://anoni.net/docs/changelog/arti/){target="_blank"}. English versions will be added as the community translates them.
+    Translations of Arti 2.3.0, 2.1.0, and 1.4.1 are currently available only in [traditional Chinese](https://anoni.net/docs/changelog/arti/){target="_blank"}. English versions will be added as the community translates them.

--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -8,17 +8,23 @@ icon: simple/torbrowser
 
 Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top. Each entry links back to the full translation.
 
-## Tor Browser 15.0.14
+## Tor Browser 15.0.15
 
-> 2026-05-19 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15014/){target="_blank"}
+> 2026-06-03 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15015/){target="_blank"}
 
-- Important Firefox security update, backporting fixes from Firefox 151 (tor-browser#44958).
-- Rebased onto Firefox 140.11.0esr.
-- GeckoView on Android updated to 140.11.0esr.
-- Build toolchain: Go updated to 1.25.10.
+- Important security update to the tor daemon, plus fixes for some censorship circumvention problems.
+- tor client updated to 0.4.9.9, NoScript updated to 13.6.20.1984.
+- Moat module now supports multiple configured (front, reflector) domain fronting pairs (tor-browser#42436).
+- Fixed a captcha failure on desktop (tor-browser#44997) and notified Linux i686 users that updates have ended (tor-browser#44886).
+
+## Tor Browser 16.0a7 (alpha)
+
+> 2026-06-03 · [dist directory](https://dist.torproject.org/torbrowser/16.0a7/){target="_blank"}
+
+- The alpha channel is for testing only; regular users should stay on the stable channel (15.x). Binaries are published on dist, but the upstream blog has not posted an announcement yet. Now based on Firefox 151.0a1 (the previous alpha 16.0a6 was on 150.0a1).
 
 !!! info "Earlier Tor Browser versions"
 
-    Tor Browser 15.0.13, 16.0a6 (alpha), 15.0.12, 15.0.11, and earlier entries are currently available only in [traditional Chinese](https://anoni.net/docs/changelog/tor/){target="_blank"}. English versions will be added as the community translates them.
+    Tor Browser 15.0.14, 15.0.13, 16.0a6 (alpha), 15.0.12, 15.0.11, and earlier entries are currently available only in [traditional Chinese](https://anoni.net/docs/changelog/tor/){target="_blank"}. English versions will be added as the community translates them.
 
     Past Tor-related translations also live in [Updates](../blog/index.md), including [Cure53 completes Tor VPN code audit](../blog/posts/2026-code-audit-for-tor-vpn-completed-by-cure53.md).

--- a/docs/zh-CN/changelog/arti.md
+++ b/docs/zh-CN/changelog/arti.md
@@ -8,6 +8,12 @@ icon: material/code-tags
 
 Arti 是 [Tor Project](../tools/what-is-tor.md) 以 Rust 开发的新一代 Tor 实现。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Arti 2.4.0
+
+> 2026-06-01 · [上游公告](https://blog.torproject.org/arti_2_4_0_released/){target="_blank"}
+
+- 持续推进「Arti 作为 Tor 中继」与「Arti 作为 directory authority」开发、修补多个影响 onion 服务客户端连接的错误、流量控制与拥塞控制（flowctl-cc）正式列为稳定、`arti-client` 的 `TorClient` API 出现多项破坏性变更。
+
 ## Arti 2.2.0
 
 > 2026-03-31 · [上游公告](https://blog.torproject.org/arti_2_2_0_released/){target="_blank"} · [完整翻译文章](../blog/posts/2026-arti-2-2-0-released-http-connect-rpc-and-relay-development.md)
@@ -25,3 +31,7 @@ Arti 是 [Tor Project](../tools/what-is-tor.md) 以 Rust 开发的新一代 Tor 
 > 2025-03-16 · [上游公告](https://blog.torproject.org/arti_1_4_1_released/){target="_blank"} · [完整翻译文章](../blog/posts/arti-141.md)
 
 - Arti 客户端例行更新，包含错误修正与稳定性改善，为后续中继支持与 RPC 工作铺路。
+
+!!! info "更早的 Arti 版本"
+
+    Arti 2.3.0 的完整摘要目前仅在 [正体中文版](https://anoni.net/docs/changelog/arti/){target="_blank"} 提供，简体中文版会随社群翻译滚动补上。

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -8,18 +8,24 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon 与 Onion 服务的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
-## Tor Browser 15.0.14
+## Tor Browser 15.0.15
 
-> 2026-05-19 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15014/){target="_blank"}
+> 2026-06-03 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15015/){target="_blank"}
 
-- 重要 Firefox 安全更新，backport 自 Firefox 151 的修补（tor-browser#44958）。
-- rebase 至 Firefox 140.11.0esr。
-- Android 版 GeckoView 同步升至 140.11.0esr。
-- 构建工具链的 Go 升至 1.25.10。
+- tor daemon 重要安全更新，修正部分审查规避问题。
+- tor 客户端升至 0.4.9.9，NoScript 升至 13.6.20.1984。
+- Moat 模块支持设置多组 (front, reflector) domain fronting 配对（tor-browser#42436）。
+- 修正桌面版 Captcha 无法运行的问题（tor-browser#44997），并通知 Linux i686 用户不再提供更新（tor-browser#44886）。
+
+## Tor Browser 16.0a7（Alpha 测试通道）
+
+> 2026-06-03 · [dist 目录](https://dist.torproject.org/torbrowser/16.0a7/){target="_blank"}
+
+- Alpha 通道仅供测试，一般用户请继续用稳定版（15.x）。已在 dist 提供二进制文件，官方博客尚未发布对应公告。改以 Firefox 151.0a1 为基础（前一个 Alpha 16.0a6 为 150.0a1）。
 
 !!! info "更早的 Tor Browser 版本"
 
-    Tor Browser 15.0.13、16.0a6（Alpha 测试通道）、15.0.12、15.0.11 等条目目前仅在 [正体中文版](https://anoni.net/docs/changelog/tor/){target="_blank"} 提供，简体中文版会随社群翻译滚动补上。
+    Tor Browser 15.0.14、15.0.13、16.0a6（Alpha 测试通道）、15.0.12、15.0.11 等条目目前仅在 [正体中文版](https://anoni.net/docs/changelog/tor/){target="_blank"} 提供，简体中文版会随社群翻译滚动补上。
 
     更多 Tor 相关翻译保留在 [近期公告](../blog/index.md)，包括：
 

--- a/docs/zh-TW/changelog/arti.md
+++ b/docs/zh-TW/changelog/arti.md
@@ -8,6 +8,15 @@ icon: material/code-tags
 
 Arti 是 [Tor Project](../tools/what-is-tor.md) 以 Rust 開發的新一代 Tor 實作。本頁從上游 release notes 條列摘譯，新版本永遠在最上面。
 
+## Arti 2.4.0
+
+> 2026-06-01 · [上游公告](https://blog.torproject.org/arti_2_4_0_released/){target="_blank"}
+
+- 持續往「Arti 作為 Tor 中繼」與「Arti 作為 directory authority」開發。
+- 修補多個影響 onion 服務用戶端連線的錯誤。
+- 流量控制與壅塞控制（flow control / congestion control）正式列為穩定，編譯時啟用 `flowctl-cc` feature 即可使用。
+- `arti-client` crate 出現多項 `TorClient` API 破壞性變更，並移除 `use_obsolete_software` 選項（#1960），對應 2.3.0 預告的介面調整。
+
 ## Arti 2.3.0
 
 > 2026-05-07 · [上游公告](https://blog.torproject.org/arti_2_3_0_released/){target="_blank"}

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -8,6 +8,25 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注。
 
+## Tor Browser 15.0.15
+
+> 2026-06-03 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15015/){target="_blank"}
+
+- tor daemon 重要安全更新，並修正部分審查規避問題。
+- tor 用戶端升至 0.4.9.9。
+- NoScript 升至 13.6.20.1984。
+- Moat 模組支援設定多組 (front, reflector) domain fronting 配對（tor-browser#42436）。
+- 修正桌面版（Windows、macOS、Linux）Captcha 無法運作的問題（tor-browser#44997）。
+- 通知 Linux i686 使用者不再提供更新（tor-browser#44886，backport #44361）。
+
+## Tor Browser 16.0a7（Alpha 測試通道）
+
+> 2026-06-03 · [dist 目錄](https://dist.torproject.org/torbrowser/16.0a7/){target="_blank"}
+
+- Alpha 通道僅供測試，可能含影響可用性、安全與隱私的錯誤，一般使用者請繼續用穩定版（15.x）。
+- 已在 dist 釋出二進位檔，官方部落格尚未發布對應公告。
+- 改以 Firefox 151.0a1 為基底（前一個 Alpha 16.0a6 為 150.0a1）。
+
 ## Tor Browser 15.0.14
 
 > 2026-05-19 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15014/){target="_blank"}


### PR DESCRIPTION
## 摘要

對照上游確認 `changelog/` 追蹤的四套軟體版本，補上自上次更新後的新發布。三語（zh-TW / zh-CN / en）同步更新。

| 軟體 | 站內原本 | 上游最新 | 動作 |
|---|---|---|---|
| Arti | 2.3.0 | **2.4.0**（2026-06-01） | 新增 |
| Tor Browser 穩定版 | 15.0.14 | **15.0.15**（2026-06-03） | 新增 |
| Tor Browser Alpha | 16.0a6 | **16.0a7**（dist 2026-06-03） | 新增最小條目 |
| Tails | 7.8 | 7.8 | 無變更 |
| OONI Probe | 6.0.2 | 6.0.2 | 無變更 |

## 重點

- **Arti 2.4.0**：relay / directory authority 開發、流量控制與壅塞控制（`flowctl-cc`）轉穩定、`arti-client` 的 `TorClient` API 多項破壞性變更（對應 2.3.0 預告）、修補 onion 服務用戶端連線錯誤。
- **Tor Browser 15.0.15**：tor daemon 安全更新與審查規避修正、tor 0.4.9.9、NoScript 13.6.20.1984、Moat 支援多組 (front, reflector) domain fronting、桌面版 Captcha 修正、Linux i686 停止更新通知。
- **Tor Browser 16.0a7（Alpha）**：dist 已釋出二進位檔，基底改為 Firefox 151.0a1（前一版 16.0a6 為 150.0a1）。官方部落格尚無公告，因此先加最小條目並連結 dist 目錄，待公告上線後再補完整 changelog 並換成上游公告連結。

## 多語系處理

- zh-TW 為 single source of truth，採完整條目。
- zh-CN / en 依現有精簡格式（最新版詳列 + `!!! info` 框指回 zh-TW），並補上兩者先前缺漏的 Arti 2.3.0 指引；TB 15.0.14 折入 info 框維持精簡。
- zh-CN 新增內容已在地化為大陸用詞（支持 / 设置 / 用户 / 博客 / 二进制文件 / 连接 / 拥塞）。

## 來源

- [Arti 2.4.0 公告](https://blog.torproject.org/arti_2_4_0_released/)
- [Tor Browser 15.0.15 公告](https://blog.torproject.org/new-release-tor-browser-15015/)
- [dist 16.0a7 目錄](https://dist.torproject.org/torbrowser/16.0a7/)

## 後續

- 16.0a7 官方部落格公告上線後，連結改為上游公告並補完整條目。
- zh-CN / en 仍落後的舊版本依社群人力滾動補譯。

🤖 Generated with [Claude Code](https://claude.com/claude-code)