### PR TITLE
perf(docs-ipfs): 加速 IPFS 發布散布（Accelerated DHT + ttl 1m + provide + pre-warm）

### DIFF
--- a/docs/upload_to_ipfs.sh
+++ b/docs/upload_to_ipfs.sh
@@ -89,8 +89,13 @@ done
 
 if [ -n "$OLD_CID" ]; then
     OLD_HASH="${OLD_CID#/ipfs/}"
-    echo "[upload] Unpin 舊版本: $OLD_HASH"
-    ipfs $IPFS_API pin rm "$OLD_HASH" 2>/dev/null || echo "[upload] Unpin 失敗（可能已移除），繼續"
+    if [ "$OLD_HASH" = "$NEW_CID" ]; then
+        # 內容未變時 add 出的 CID 會與舊版相同，這時 unpin + 後續 repo gc 會把剛發布的內容刪掉。
+        echo "[upload] 內容未變（CID 與舊版相同 $NEW_CID），跳過 unpin 以免移除剛發布的內容"
+    else
+        echo "[upload] Unpin 舊版本: $OLD_HASH"
+        ipfs $IPFS_API pin rm "$OLD_HASH" 2>/dev/null || echo "[upload] Unpin 失敗（可能已移除），繼續"
+    fi
 fi
 
 echo "[upload] 執行 repo GC..."

--- a/docs/upload_to_ipfs.sh
+++ b/docs/upload_to_ipfs.sh
@@ -60,12 +60,32 @@ echo "[upload] 新 CID: $NEW_CID"
 
 echo "[upload] 發布 IPNS ([anoni-net] key)..."
 # --lifetime=720h：DHT 上的 IPNS record 30 天內有效，避免 gateway 解析時找不到（預設 24h 對非每日 deploy 太短）
-# --ttl=5m：客戶端 cache IPNS 解析結果 5 分鐘，平衡解析效能與更新延遲
+# --ttl=1m：客戶端/閘道 cache IPNS 解析結果 1 分鐘，縮短發布後換新版的空窗。
+#          配合節點已開的 Routing.AcceleratedDHTClient（ipfs_host），重新解析很便宜，壓低 ttl 划算。
 ipfs $IPFS_API name publish \
     --key=anoni-net \
     --lifetime=720h \
-    --ttl=5m \
+    --ttl=1m \
     "/ipfs/$NEW_CID"
+
+# 主動把新 CID 宣告到 DHT（root 即可，閘道連上本節點後會用 bitswap 抓其餘區塊）。
+# 配合 Accelerated DHT Client，provide 很快；非致命，失敗不中斷發布。
+echo "[upload] provide 新 CID 到 DHT..."
+ipfs $IPFS_API routing provide "$NEW_CID" || echo "[upload] provide 非致命失敗，繼續"
+
+# Pre-warm 公開閘道：先抓一次，逼閘道解析並把內容收進邊緣快取，縮短第一個訪客的等待。
+# 三個目標：dweb.link/ipfs.io 用新 CID 直接暖內容；DNSLink 網址觸發重新解析。全部非致命。
+echo "[upload] Pre-warm 公開閘道..."
+for gw in \
+    "https://dweb.link/ipfs/$NEW_CID/" \
+    "https://ipfs.io/ipfs/$NEW_CID/" \
+    "https://anoni-net.ipns.dweb.link/"; do
+    if curl -fsS -o /dev/null --max-time 60 "$gw"; then
+        echo "[upload]   warmed: $gw"
+    else
+        echo "[upload]   warm 失敗（略過）: $gw"
+    fi
+done
 
 if [ -n "$OLD_CID" ]; then
     OLD_HASH="${OLD_CID#/ipfs/}"


### PR DESCRIPTION
## 問題

上傳 IPFS 版本後，`https://anoni-net.ipns.dweb.link/` 要過很久才換到新版。

## 根因

解析鏈是 `DNSLink(_dnslink.anoni.net) → /ipns/k51… → DHT 解析 → CID`。延遲來自兩段：預設 DHT client 發布 IPNS record 慢且不完整、gateway 把舊 CID 快取到 record ttl 過期。使用者刻意維持 DNS 設一次就好，所以這個 PR 只動 IPNS/節點層，**不碰 Cloudflare DNS**。

## 改動（`docs/upload_to_ipfs.sh`）

- `--ttl` 5m → 1m：dweb.link 會把 record ttl 原封當自己的 CDN `cache-control: max-age`，縮短發布後換新版的空窗。
- publish 後 `ipfs routing provide $NEW_CID`：主動把新 CID 宣告到 DHT（root 即可，閘道連上本節點後用 bitswap 抓其餘區塊）。
- pre-warm `dweb.link` / `ipfs.io` / DNSLink 三個網址：先暖內容快取、觸發重新解析。全部非致命，失敗不中斷發布。
- 防呆：內容未變時 `ipfs add` 出的 CID 會與舊版相同，這時跳過 unpin，避免後續 `repo gc` 把剛發布的內容刪掉。

## 搭配的節點端設定（已直接套在 `ipfs_host`，非本 PR diff）

- kubo 0.40.1 開 `Routing.AcceleratedDHTClient=true`，讓 publish/provide 變快、覆蓋更廣。

## 實測

- 重跑 `build_docs_anoni_ipfs.sh`：新 CID `bafybeif4rph4…` 發布成功，provide 與三個 pre-warm 都正常執行，舊版正常 unpin。
- dweb.link 邊緣 `cache-control: max-age` 從 **300s 降到 60s**（直接反映 `--ttl=1m`）。
- 節點 `ipfs name resolve --nocache` 確認 record 已指向新 CID。

注意：每次 deploy 的轉換空窗受「上一版 record 的 ttl」綁住，ttl 改動讓**下一次**轉換變快（往後上限約 60s）。dweb.link 自家 CDN 邊緣快取那層不在我們控制內，要即時可直接打 `/ipfs/<CID>/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)