### PR TITLE
docs(changelog): 新增 Tails 7.8.1 緊急安全更新條目（三語）

### DIFF
--- a/docs/en/changelog/tails.md
+++ b/docs/en/changelog/tails.md
@@ -8,6 +8,15 @@ icon: material/usb-flash-drive-outline
 
 [Tails](https://tails.net/){target="_blank"} operating system release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tails 7.8.1
+
+> 2026-06-04 · [Upstream announcement](https://tails.net/news/version_7.8.1/){target="_blank"}
+
+- Emergency security release fixing a serious Linux kernel vulnerability and several Tor client security vulnerabilities.
+- Patches the Linux kernel flaw CVE-2026-43503 (kernel updated to 6.12.90-2), a local privilege escalation that lets an application inside Tails gain administrator privileges; combined with other unknown vulnerabilities it could fully compromise Tails and deanonymize the user. No active exploitation has been observed.
+- Tor client updated to 0.4.9.9, fixing several security vulnerabilities.
+- This is a security-only emergency release; Tor Browser, Thunderbird, and the Debian base version are unchanged from 7.8. Automatic upgrades are available from Tails 7.0 or later.
+
 ## Tails 7.8
 
 > 2026-05-21 · [Upstream announcement](https://tails.net/news/version_7.8/){target="_blank"}

--- a/docs/zh-CN/changelog/tails.md
+++ b/docs/zh-CN/changelog/tails.md
@@ -8,6 +8,15 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 操作系统的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tails 7.8.1
+
+> 2026-06-04 · [上游公告](https://tails.net/news/version_7.8.1/){target="_blank"}
+
+- 紧急安全更新，修补 Linux 内核重大漏洞与 Tor 客户端的多个安全漏洞。
+- 修补 Linux 内核漏洞 CVE-2026-43503（内核升至 6.12.90-2），此漏洞可让 Tails 内的应用程序取得管理员权限，配合其他未知漏洞可能被用于完整接管 Tails 并进行去匿名化。目前尚未发现实际被利用案例。
+- Tor 客户端升至 0.4.9.9，修补多个安全漏洞。
+- 此版为安全专用的紧急发布，未变动 Tor Browser、Thunderbird 与 Debian 底层版本，沿用 7.8 的软件组合。可从 Tails 7.0 以后版本自动升级。
+
 ## Tails 7.8
 
 > 2026-05-21 · [上游公告](https://tails.net/news/version_7.8/){target="_blank"}

--- a/docs/zh-TW/changelog/tails.md
+++ b/docs/zh-TW/changelog/tails.md
@@ -8,6 +8,15 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 作業系統的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
+## Tails 7.8.1
+
+> 2026-06-04 · [上游公告](https://tails.net/news/version_7.8.1/){target="_blank"}
+
+- 緊急安全更新，修補 Linux 核心重大漏洞與 Tor 用戶端的多個安全漏洞。
+- 修補 Linux 核心漏洞 CVE-2026-43503（核心升至 6.12.90-2），此漏洞可讓 Tails 內的應用程式取得管理員權限，配合其他未知漏洞可能被用於完整接管 Tails 並進行去匿名化。目前尚未發現實際被利用案例。
+- Tor 用戶端升至 0.4.9.9，修補多個安全漏洞。
+- 此版為安全專用的緊急釋出，未變動 Tor Browser、Thunderbird 與 Debian 底層版本，沿用 7.8 的軟體組合。可從 Tails 7.0 以後版本自動升級。
+
 ## Tails 7.8
 
 > 2026-05-21 · [上游公告](https://tails.net/news/version_7.8/){target="_blank"}


### PR DESCRIPTION
## 摘要

例行核對 `changelog/` 追蹤的四項軟體（Tor Browser、Tails、Arti、OONI Probe）有無新版。截至 2026-06-06，只有 **Tails 出新版 7.8.1（2026-06-04）**，本 PR 在 zh-TW / zh-CN / en 三語各補一條，置於 7.8 上方，沿用既有 7.7.x 緊急更新條目格式。

其餘三項皆為最新，無需更動：

| 軟體 | 最新版 | 來源確認 |
|---|---|---|
| Tor Browser | 穩定 15.0.15、Alpha 16.0a7（2026-06-03） | dist 目錄無 15.0.16 / 16.0a8 |
| Arti | 2.4.0（2026-06-01） | CHANGELOG 頂端與 git tag 皆為此版 |
| OONI Probe | 6.0.2（2026-05-25） | GitHub API 無 6.0.3 / 6.1.0 |

## Tails 7.8.1 重點

- 安全專用緊急釋出（[上游公告](https://tails.net/news/version_7.8.1/)）。
- Linux 核心升至 6.12.90-2，修補本機提權漏洞 CVE-2026-43503。
- Tor 用戶端升至 0.4.9.9，修補多個安全漏洞。
- Tor Browser、Thunderbird、Debian 底層版本沿用 7.8。

🤖 Generated with [Claude Code](https://claude.com/claude-code)