### PR TITLE
feat(pwa): precache 納入 travel-ai-briefing(#104)與 onionoo-mcp(#105)

### DIFF
--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -65,11 +65,12 @@ const CORE_PAGES_ZH = [
   "tools/messaging-comparison/",
   "tools/password-manager/",
   "tools/crypto-privacy-spectrum/",
-  // scenarios（場景，核心 + asia-travel）
+  // scenarios（場景，核心 + asia-travel + travel-ai-briefing）
   "scenarios/",
   "scenarios/journalist/",
   "scenarios/activist/",
   "scenarios/asia-travel/",
+  "scenarios/travel-ai-briefing/",
   // advanced（進階，全部）
   "advanced/",
   "advanced/e2ee/",
@@ -84,6 +85,8 @@ const CORE_PAGES_ZH = [
   "taiwan/whistleblower-law/",
   "taiwan/ooni-asn-coverage/",
   "taiwan/tor-relay-watcher/",
+  // community（社群，選錄離線可讀的工具頁）
+  "community/onionoo-mcp/",
 ];
 
 // en 是策展型原創軌道，頁面集合與 zh 版不同（沒有 tools/、taiwan/、advanced/、help/）。
@@ -96,6 +99,8 @@ const CORE_PAGES_EN = [
   "basics/internet-freedom/",
   "scenarios/",
   "scenarios/lgbtq/",
+  "scenarios/travel-ai-briefing/",
+  "community/onionoo-mcp/",
   "regional/",
   "regional/tor-relay-watcher/",
 ];


### PR DESCRIPTION
## 摘要

把 #104 的 `scenarios/travel-ai-briefing` 與 #105 的 `community/onionoo-mcp` 加進 PWA service worker(`docs/zh-TW/sw.js`)的核心預快取清單,讓兩頁離線可讀。

## 變更內容

- `scenarios/travel-ai-briefing/`:加入 `CORE_PAGES_ZH`(zh-TW/zh-CN)與 `CORE_PAGES_EN`
- `community/onionoo-mcp/`:加入 `CORE_PAGES_ZH` 與 `CORE_PAGES_EN`,並在 `CORE_PAGES_ZH` 新增一個 community 區塊(precache 首次納入 `community/` 頁)

## 為什麼是獨立 PR,而不是塞進 #104 / #105

`sw.js`(PWA)是在 #104、#105 兩個 feature branch 從 main 分出**之後**才進 main 的,那兩個分支裡沒有 `sw.js`。precache 改動只能從目前 main 開分支做,否則會在合併時與 main 的真實 `sw.js` 大量衝突。

## 與合併順序無關

precache 在 `install` 時以 `Promise.allSettled` + `response.ok` 容忍個別 404:

- `community/onionoo-mcp/` 已在 main,合併後立即可快取。
- `scenarios/travel-ai-briefing/` 目前在 #104,此刻列入無害;#104 合併並重新部署(換 `__BUILD_VERSION__`、重跑 install)後自動納入快取。

可在 #104、#105 之前或之後合併,皆安全。

## 驗證

- `node --check docs/zh-TW/sw.js` 通過
- 以目前 main build:`community/onionoo-mcp/` 在 zh-TW 與 en 皆解析存在;`scenarios/travel-ai-briefing/` 如預期此刻不在 main(待 #104),路徑形狀與既有 `scenarios/asia-travel/` 一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)