### PR TITLE
docs(onionoo-mcp): 補反向 cross-link 回連 travel-ai-briefing(三語)

### DIFF
--- a/docs/en/community/onionoo-mcp.md
+++ b/docs/en/community/onionoo-mcp.md
@@ -269,6 +269,7 @@ The agent breaks the question into a handful of MCP tool calls and assembles a s
 
 - **Report bugs or suggest tools**: <https://github.com/anoni-net/onionoo-fastapi/issues>
 - **Want to run your own Tor relay?** See the [Tor Relays Observatory](../regional/tor-relay-watcher.md) for the data we publish on relays in the region.
+- **Pre-travel checks**: [Pre-departure digital safety — brief yourself with AI prompts](../scenarios/travel-ai-briefing.md). When a journalist or NGO needs to assess a destination's Tor reachability before a trip, connecting onionoo MCP lets the AI pull real, citable Onionoo numbers.
 - **Background reading**: the [About page](../about/index.md) covers governance and how the wider site fits together; the [Regional Observatory](../regional/index.md) is where this service's outputs feed back into public analysis.
 
 Released as v1.0.0 under MIT. Issues, PRs, and Matrix discussion on which task-oriented tools to add next are all welcome.

--- a/docs/zh-CN/community/onionoo-mcp.md
+++ b/docs/zh-CN/community/onionoo-mcp.md
@@ -269,6 +269,7 @@ docker compose up -d --build
 
 - **回报问题 / 提建议**：<https://github.com/anoni-net/onionoo-fastapi/issues>
 - **想自己跑 Tor relay**：见 [如何搭建 Tor Relay](./setup-tor-relay.md)，相关观测指标在 [Tor Relays 观测点](../taiwan/tor-relay-watcher.md)。
+- **出国前评估**：[出国前数字安全：用 AI 自助生成目的地概况](../scenarios/travel-ai-briefing.md)。记者、NGO 出国前要查目的地的 Tor 可达性时，接上 onionoo MCP 就能让 AI 查到真实、可引用的 Onionoo 数字。
 - **延伸阅读**：[什么是 Tor？](../tools/what-is-tor.md)、[ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md)。
 
 服务目前以 v1.0.0 发布，授权为 MIT。欢迎 issue、PR，或在 Matrix 上一起讨论之后该补哪些任务导向工具。

--- a/docs/zh-TW/community/onionoo-mcp.md
+++ b/docs/zh-TW/community/onionoo-mcp.md
@@ -269,6 +269,7 @@ docker compose up -d --build
 
 - **回報問題 / 提建議**：<https://github.com/anoni-net/onionoo-fastapi/issues>
 - **想自己跑 Tor relay**：見 [如何搭建 Tor Relay](./setup-tor-relay.md)，相關觀測指標在 [Tor Relays 觀測點](../taiwan/tor-relay-watcher.md)。
+- **出國前評估**：[出國前數位安全：用 AI 自助產生目的地概況](../scenarios/travel-ai-briefing.md)。記者、NGO 出國前要查目的地的 Tor 可達性時，接上 onionoo MCP 就能讓 AI 查到真實、可引用的 Onionoo 數字。
 - **延伸閱讀**：[什麼是 Tor？](../tools/what-is-tor.md)、[ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)。
 
 服務目前以 v1.0.0 釋出，授權為 MIT。歡迎 issue、PR，或在 Matrix 上一起討論之後該補哪些任務導向工具。


### PR DESCRIPTION
## 摘要

#104、#105 合併後的 follow-up,補完 onionoo-mcp 與 travel-ai-briefing 之間的**雙向** cross-link。正向(旅遊頁 → onionoo MCP)已隨 #104 上線,這個 PR 補上反向(onionoo MCP → 旅遊頁)。

## 變更內容

三語 `community/onionoo-mcp.md` 的「參與與貢獻 / Get involved」清單各加一條,連到 `scenarios/travel-ai-briefing`,框成「記者、NGO 出國前評估目的地 Tor 可達性」的應用場景,呼應該頁原本就寫到的事實查核與新聞用途。

## 為什麼是合併後才補

`travel-ai-briefing` 是 #104 的新檔。先前若把反向連結塞進 #105,而 #104 尚未合併,#105 的 strict build 會對尚未存在的目標檔斷鏈。等 #104、#105 都進 main 後再補,兩邊 build 都乾淨。

## 驗證

- zh-TW、zh-CN、en 三語 `mkdocs build` 皆把連結解析為 `scenarios/travel-ai-briefing/`
- 過濾 cairo/social 雜訊後無斷鏈、無 anchor 警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)