### PR TITLE
docs: 更新三語首頁「最新動態」至 2026/06/13

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -147,11 +147,11 @@ Our standing varies by jurisdiction. We don't claim equal depth across the regio
 
 !!! tip "Latest"
 
-    - `Update`{style="color: var(--cat-privacy);"}: [MADLink (Mandarin translation): ADLINK's 1,708 CSA-7400 units in Kazakhstan's censorship stack](./blog/posts/report-madlink.md) — 2026-05-23
-    - `New`{style="color: var(--brand-cyan-600);"}: [Campus Tor Relay templates — proposal, SOP, and FAQ](./blog/posts/2026-campus-tor-relay-template-kit.md) — 2026-05-21
-    - `Update`{style="color: var(--cat-privacy);"}: [Transaction Denied — a Sinophone Asia-Pacific reading of EFF's book on financial censorship](./blog/posts/2026-financial-companies-as-censors.md) — 2026-05-21
-    - `New`{style="color: var(--brand-cyan-600);"}: [onionoo MCP is now public — query the Tor relay network in plain language](./blog/posts/2026-onionoo-mcp-public.md) — 2026-05-19
-    - `New`{style="color: var(--brand-cyan-600);"}: [What is Differential Privacy?](./blog/posts/2025-what-is-differential-privacy.md) — 2026-04-27
+    - `New`{style="color: var(--brand-cyan-600);"}: [Brief yourself before you travel — take the right questions to your own AI](./blog/posts/travel-ai-briefing.md) — 2026-06-10
+    - `New`{style="color: var(--brand-cyan-600);"}: [We surveyed all 336 OONI Run v2 links, and three of them drive 72% of all measurements](./blog/posts/2026-ooni-run-v2-usage-patterns.md) — 2026-06-02
+    - `Update`{style="color: var(--cat-privacy);"}: [How Unredacted Helps People in Censored Regions Reach the Open Internet](./blog/posts/keeping-the-doors-open.md) — 2026-06-01
+    - `Update`{style="color: var(--cat-privacy);"}: [After Iran's 80-day blackout, traffic surged through our community's Tor WebTunnel bridge](./blog/posts/iran-blackout-webtunnel.md) — 2026-05-28
+    - `New`{style="color: var(--brand-cyan-600);"}: [CryptPad 2026.5.0: zh_Hant Lands as a Built-in Locale After Two and a Half Years Upstream](./blog/posts/2026-cryptpad-zh-hant.md) — 2026-05-25
     - `Event`{style="color: var(--accent-action);"}: [COSCUP 2026 Call for Proposals](./activity/coscup-2026-cfp.md) — 2026-04-08
 
     More at [:material-bullhorn-outline: Updates](./blog/index.md).

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -139,11 +139,11 @@ hide:
 
 !!! tip "最新动态"
 
-    - `更新`{style="color: var(--cat-privacy);"}：[InterSecLab MADLink 报告翻译：凌华 1,708 台 CSA-7400 进入哈萨克斯坦审查系统](./blog/posts/report-madlink.md) - 2026/05/23
-    - `更新`{style="color: var(--cat-privacy);"}：[Transaction Denied 中文导读：金融公司作为审查者](./blog/posts/2026-financial-companies-as-censors.md) - 2026/05/21
-    - `新增`{style="color: var(--brand-cyan-600);"}：[onionoo MCP 上线：用一句中文问 Tor 中继节点现况](./blog/posts/2026-onionoo-mcp-public.md) - 2026/05/19
-    - `新增`{style="color: var(--brand-cyan-600);"}：[什么是差分隐私](./blog/posts/2025-what-is-differential-privacy.md) - 2026/04/27
-    - `更新`{style="color: var(--cat-privacy);"}：[Cure53 完成 Tor VPN 安全审计](./blog/posts/2026-code-audit-for-tor-vpn-completed-by-cure53.md) - 2026/04/19
+    - `新增`{style="color: var(--brand-cyan-600);"}：[出国前数字安全：把该问的问题打包成 prompt，带回去问你自己信任的 AI](./blog/posts/travel-ai-briefing.md) - 2026/06/10
+    - `新增`{style="color: var(--brand-cyan-600);"}：[普查 336 条 OONI Run v2 清单：3 条就占了全网 72% 的检测量](./blog/posts/2026-ooni-run-v2-usage-patterns.md) - 2026/06/02
+    - `更新`{style="color: var(--cat-privacy);"}：[Unredacted 如何帮受审查地区的人连上开放网络](./blog/posts/keeping-the-doors-open.md) - 2026/06/01
+    - `更新`{style="color: var(--cat-privacy);"}：[伊朗封网 80 多天后重新开放，流量涌进社群架设的 Tor WebTunnel](./blog/posts/iran-blackout-webtunnel.md) - 2026/05/28
+    - `新增`{style="color: var(--brand-cyan-600);"}：[CryptPad 2026.5.0 上线：正体中文（zh_Hant）正式收进内建语系](./blog/posts/2026-cryptpad-zh-hant.md) - 2026/05/25
     - `活动`{style="color: var(--accent-action);"}：[COSCUP 2026 公开征稿](./activity/coscup-2026-cfp.md) - 2026/04/08
 
     更多公告请见 [:material-bullhorn-outline: 近期公告](./blog/index.md)。

--- a/docs/zh-TW/index.md
+++ b/docs/zh-TW/index.md
@@ -139,11 +139,11 @@ hide:
 
 !!! tip "最新動態"
 
-    - `更新`{style="color: var(--cat-privacy);"}：[InterSecLab MADLink 報告翻譯：凌華 1,708 台 CSA-7400 進入哈薩克審查系統](./blog/posts/report-madlink.md) - 2026/05/23
-    - `新增`{style="color: var(--brand-cyan-600);"}：[校園 Tor Relay 範本工具包：提案、SOP、FAQ 三份範本上線](./blog/posts/2026-campus-tor-relay-template-kit.md) - 2026/05/21
-    - `更新`{style="color: var(--cat-privacy);"}：[Transaction Denied 中文導讀：金融公司作為審查者](./blog/posts/2026-financial-companies-as-censors.md) - 2026/05/21
-    - `新增`{style="color: var(--brand-cyan-600);"}：[onionoo MCP 上線：用一句中文問 Tor 中繼節點現況](./blog/posts/2026-onionoo-mcp-public.md) - 2026/05/19
-    - `新增`{style="color: var(--brand-cyan-600);"}：[什麼是差分隱私](./blog/posts/2025-what-is-differential-privacy.md) - 2026/04/27
+    - `新增`{style="color: var(--brand-cyan-600);"}：[出國前數位安全：把該問的問題打包成 prompt，帶回去問你自己信任的 AI](./blog/posts/travel-ai-briefing.md) - 2026/06/10
+    - `新增`{style="color: var(--brand-cyan-600);"}：[普查 336 條 OONI Run v2 清單：3 條就佔了全網 72% 的檢測量](./blog/posts/2026-ooni-run-v2-usage-patterns.md) - 2026/06/02
+    - `更新`{style="color: var(--cat-privacy);"}：[Unredacted 如何幫受審查地區的人連上開放網路](./blog/posts/keeping-the-doors-open.md) - 2026/06/01
+    - `更新`{style="color: var(--cat-privacy);"}：[伊朗封網 80 多天後重新開放，流量湧進社群架設的 Tor WebTunnel](./blog/posts/iran-blackout-webtunnel.md) - 2026/05/28
+    - `新增`{style="color: var(--brand-cyan-600);"}：[CryptPad 2026.5.0 上線：正體中文（zh_Hant）正式收進內建語系](./blog/posts/2026-cryptpad-zh-hant.md) - 2026/05/25
     - `活動`{style="color: var(--accent-action);"}：[COSCUP 2026 公開徵稿](./activity/coscup-2026-cfp.md) - 2026/04/08
 
     更多公告請見 [:material-bullhorn-outline: 近期公告](./blog/index.md)。


### PR DESCRIPTION
## 摘要

三語首頁 `index.md` 的「最新動態」原本都停在 2026/05/23,補上 05/23 之後的 5 篇新文,維持 6 條、釘住即將到來的 COSCUP 活動,三語對齊。

## 補進來的 5 篇(zh-TW / zh-CN / en 皆已有翻譯)

| tag | 文章 | 日期 |
|---|---|---|
| 新增 | 出國前數位安全(travel-ai-briefing) | 06/10 |
| 新增 | 普查 336 條 OONI Run v2 清單 | 06/02 |
| 更新 | Unredacted 如何幫受審查地區連上開放網路 | 06/01 |
| 更新 | 伊朗封網重開、流量湧進 Tor WebTunnel | 05/28 |
| 新增 | CryptPad 2026.5.0 正體中文收進內建語系 | 05/25 |

## 下架的舊項目

report-madlink、campus-tor-relay-kit、financial-companies-as-censors、onionoo-mcp、differential-privacy、Cure53 audit(各語系原本殘留的不同舊項目一併清掉,三語現在對齊)。

## 備註

- tag 沿用既有規則:翻譯/導讀類 `更新`(綠)、原創/公告類 `新增`(cyan)、活動 `活動`(橘)。
- 連結目標檔案三語皆存在,CJK 文字無半形逗號,en 沿用 em dash 格式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)