### PR TITLE
[2026-07-23] blog 新增：FISA Section 702 到期翻譯（zh-TW / zh-CN / en）

### DIFF
--- a/docs/en/blog/posts/2026-victory-702-has-expired.md
+++ b/docs/en/blog/posts/2026-victory-702-has-expired.md
@@ -1,0 +1,104 @@
+---
+date: 2026-06-16
+authors:
+    - anoni-net
+categories:
+    - Update
+    - Privacy
+    - Translated Article
+slug: 2026-victory-702-has-expired
+image: "https://assets.anoni.net/blog/2026-victory-702-has-expired.png"
+summary: "FISA Section 702 lets US intelligence collect the communications of non-US persons abroad without a warrant, and the PRISM and Upstream programs Snowden exposed in 2013 both run on it. It lapsed at midnight on 12 June 2026. EFF calls it a victory — but everyone outside America, including readers across the Sinophone Asia-Pacific, was always a lawful target, and the lapse protects them far less than it protects Americans."
+description: "A Sinophone Asia-Pacific read of the Section 702 lapse: what warrantless US surveillance of non-US persons actually covers, its link to Snowden's PRISM/Upstream disclosures, and why the 'victory' is thinner once you are outside the Fourth Amendment."
+---
+
+# Section 702 Has Expired: A Sinophone Asia-Pacific Read on Warrantless US Surveillance
+
+<figure markdown="span">
+    <a href="https://assets.anoni.net/blog/2026-victory-702-has-expired.png" target="_blank">
+        <img src="https://assets.anoni.net/blog/2026-victory-702-has-expired.png"
+            alt="EFF's NSA eagle graphic, reworking the NSA seal into an eagle plugging its talons into telecom lines, representing warrantless mass surveillance"
+            style="border-radius: 10px;">
+    </a>
+    <figcaption>Image: EFF designer Hugh D'Andrade's "NSA eagle," which reworks the NSA seal into an eagle plugging its talons into the nation's telecom lines. From [EFF's NSA spying work](https://www.eff.org/nsa-spying){target="_blank"}, licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}[^img].</figcaption>
+</figure>
+
+!!! info ""
+
+    This post is an anoni.net reading based on the EFF Deeplinks article:
+
+    - [Victory! 702 has Expired! | June 12, 2026](https://www.eff.org/deeplinks/2026/06/victory-702-has-expired){target="_blank"} by India McKinney
+
+At midnight on **12 June 2026**, Section 702 of the Foreign Intelligence Surveillance Act lapsed[^1]. EFF, which spent years arguing the program should require a warrant before the FBI reaches Americans' communications — or else expire — calls the lapse a victory[^1].
+
+It is a real victory, and a narrow one. Section 702 was always built to collect the communications of *non-US persons* located abroad. That means everyone outside America — including readers in Taiwan, Hong Kong, mainland China, Macau, Singapore, and Malaysia — has always been a lawful target of this authority. The fight that just lapsed it was overwhelmingly a fight about protecting Americans. For the rest of us, the lapse changes much less than the headline suggests.
+
+<!-- more -->
+
+## What Section 702 is
+
+Section 702 was created by the FISA Amendments Act of 2008[^3]. It lets US intelligence agencies collect the communications — emails, messages, calls — of foreigners abroad believed to hold foreign intelligence value, without an individual warrant. US citizens are shielded by the Fourth Amendment and a warrant requirement; non-US persons are not.
+
+In practice, 702 also sweeps up large volumes of Americans' communications through what the government calls "incidental collection": whenever an American corresponds with a targeted foreigner, their side of the conversation lands in the database too. That is where the domestic controversy starts.
+
+Two collection methods sit under 702, and the names are familiar:
+
+- **Downstream (formerly PRISM):** the government compels companies such as Google, Microsoft, Apple, Facebook, and Yahoo to hand over matching user communications[^2].
+- **Upstream:** the NSA collects traffic directly from the internet backbone — the cables and switches that carry it[^2].
+
+## The Snowden connection
+
+The link to Edward Snowden is direct. PRISM and Upstream are the two concrete programs the 2013 disclosures revealed[^2], and both run on Section 702 as their legal basis. When the world first learned in June 2013 that the US could collect global internet traffic at this scale, what it was looking at was Section 702 in operation. Snowden exposed *how* the collection works; Section 702 is *what makes it lawful*.
+
+Thirteen years later, the authority behind those programs has lapsed for the first time.
+
+## Backdoor searches: the core of the fight
+
+702 nominally targets foreigners. What drew the constitutional fight inside the US is the **backdoor search** — officially a "US person query." Because incidental collection fills the 702 database with Americans' communications, the FBI, CIA, and NSA can query it using an American's name, email, or phone number, with no separate warrant — routing around the Fourth Amendment.
+
+The numbers are large, and so are the compliance failures. The FBI ran close to 5 million US person queries between 2019 and 2022; the queries were mostly procedurally permitted, but the dispute is that most lacked a documented justification[^4]. In a single reporting period the government disclosed more than 278,000 noncompliant searches of the Section 702 database[^4]. The 2024 Reforming Intelligence and Securing America Act (RISAA) added modest reforms but left warrantless querying intact, and by August 2024 the FBI was reported to be using a tool that sidestepped even those limits[^4].
+
+## What happened in June 2026
+
+The lapse turned on a personnel fight. President Trump named Bill Pulte — then director of the Federal Housing Finance Agency — as acting Director of National Intelligence, replacing the departing Tulsi Gabbard[^1][^5]. The DNI oversees the agencies that run 702, and handing that post to someone with no intelligence background who had pursued the president's political opponents on mortgage-fraud allegations was enough that Senate Democrats refused to advance their reauthorization bill, while the House rejected even a short-term extension[^1][^5]. After several temporary extensions, the authority stopped at midnight on 12 June[^1].
+
+Expiry does not mean collection stopped that day. The Foreign Intelligence Surveillance Court's existing certifications run through March 2027, giving collection a legal basis in the meantime; as one legal expert put it, "702 will not go dark — that is a myth"[^5]. The lapse is a legal and political turning point, not an off switch.
+
+## Why EFF still calls it a victory
+
+EFF's point is that the abuse risk never depended on any one person or administration. If Congress is worried that someone might reach Americans' sensitive data, the responsible fix is stronger structural transparency, accountability, and oversight — not swapping out a single nominee[^1]. Across 2026, bipartisan appetite for reform grew, with more members opposing any reauthorization that lacks a warrant requirement for backdoor searches[^1]. An authority that ran for over a decade, survived Snowden, and repeatedly beat back reform was forced into a lapse — that, by itself, shows sustained advocacy works.
+
+## Seen from outside the US
+
+If you are outside America, the most important thing to take from the lapse is your position in the structure. 702 targets non-US persons, so simply being in Taiwan, Hong Kong, mainland China, Macau, Singapore, or anywhere else outside the US already places you inside the lawful scope. The backdoor-search fight is about Americans whose Fourth Amendment protection was routed around. You were never inside that protection — querying your 702-collected communications is not even a back door for the US government; it is the front door.
+
+A common reflex is to assume this does not matter because you are not personally a target. But privacy protects against *capability*, not against present intent. An agency that is not interested in you today does not thereby give up the capability, and the targets and uses of mass collection shift with politics. Putting any actor with mass-collection capability into the same threat model is more reliable than betting that you will stay uninteresting.
+
+And the lapse does not close the other doors. The NSA's primary authority for overseas signals intelligence is **Executive Order 12333** (signed in 1981), which has no FISA Court supervision, limited congressional oversight, and is entirely unaffected by the 702 lapse[^6]. Collection of non-US persons can continue with or without 702. That is why the "victory" is thinner from outside America, and why the durable answer is encryption you control rather than any single statute.
+
+Data residency is the next misunderstanding. Sinophone Asia-Pacific users lean heavily on US cloud and communication services — Google Workspace, Microsoft 365, iCloud, AWS, and Meta's WhatsApp and Instagram (some of which require getting around blocking inside mainland China, but are everyday tools in Hong Kong, Macau, Singapore, Malaysia, and the diaspora). Keeping data in a local data center does not exempt it: if the provider is headquartered in the US, the **CLOUD Act** (2018) can compel it to hand over data it controls regardless of where the servers sit[^7]. The EU spent years litigating this same problem with the US; the Sinophone region has no equivalent arrangement at all. The defense that actually holds is end-to-end encryption (E2EE): if the keys are not in the provider's hands, data handed over or intercepted in transit stays unreadable — which is what blunts both incidental collection and backdoor searches.
+
+Encryption protects content; **Tor** also hides the connection itself. Upstream reads traffic off the backbone — where you connect, who you talk to. Places like Taiwan and Hong Kong route most international traffic over submarine cables[^8], and the trans-Pacific routes to the US west and east coasts are major trunks; whenever a connection's destination or path crosses a US backbone, the packets fall within Upstream's reach. Tor encrypts and relays traffic through multiple hops, so the backbone sees only encrypted Tor traffic and the provider cannot tie it to the real user, breaking the connection mapping that PRISM and Upstream rely on. Tor blunts this kind of bulk passive collection, though not targeted active attacks — the NSA's own "Tor Stinks" deck conceded it could only deanonymize a small fraction of users[^9].
+
+Risk is not evenly spread. Journalists and civil-society groups who work with overseas newsrooms, international bodies, and sources already carry heavy cross-border traffic, so incidental collection reaches them more often; those roles are worth raising the bar for — sensitive collaboration over Tor, source lists kept off US-company clouds. And for many Sinophone users, the more immediate threat is domestic surveillance — from mainland China's censorship and real-name systems to the varying communications-interception regimes across the region — against which the same tools, E2EE and Tor, are the same line of defense. anoni.net invests in decentralization, self-hosting, and encryption precisely because, as 12 June showed, collection continues and EO 12333 is untouched: the prudent move is capability you hold yourself, not a law you hope holds.
+
+The lapse will not make surveillance disappear, and it will not zero out the privacy risk on cross-border communication. For anyone outside the US, the thing to watch is the legal structure that authorizes collection — and the first concrete step is small: move everyday contact onto tools that are end-to-end encrypted by default, and route sensitive connections through Tor.
+
+## Related reading
+
+- [Why internet freedom matters](../../basics/internet-freedom.md): the structural framing behind authorities like 702
+- [Upstream vs. PRISM](https://www.eff.org/pages/upstream-prism){target="_blank"} — EFF, on the two 702 collection methods
+- [Section 702, Explained](https://www.brennancenter.org/our-work/research-reports/section-702-foreign-intelligence-surveillance-act){target="_blank"} — Brennan Center
+
+_English coverage of the technical defenses here is still thin on this site; the deeper concept and tool pages exist in Mandarin and are on the roadmap for English._
+
+[^1]: [Victory! 702 has Expired!](https://www.eff.org/deeplinks/2026/06/victory-702-has-expired){target="_blank"} - EFF Deeplinks (India McKinney, 2026-06-12)
+[^2]: [Upstream vs. PRISM](https://www.eff.org/pages/upstream-prism){target="_blank"} - EFF (the two collection methods under 702 and their link to the 2013 Snowden disclosures)
+[^3]: [The 702 Ultimatum: Warrant Requirement or Bust](https://www.eff.org/deeplinks/2026/06/702-ultimatum-warrant-requirement-or-bust){target="_blank"} - EFF Deeplinks
+[^4]: [Section 702 of the Foreign Intelligence Surveillance Act, Explained](https://www.brennancenter.org/our-work/research-reports/section-702-foreign-intelligence-surveillance-act){target="_blank"} - Brennan Center for Justice (backdoor-search counts, compliance violations, RISAA background)
+[^5]: [A key spy authority, Section 702, expired due to inaction in Congress. Here's what happens next.](https://www.cbsnews.com/news/fisa-section-702-expiring-congress-what-that-means/){target="_blank"} - CBS News (timeline, Pulte appointment, certifications continuing through March 2027)
+[^6]: [Foreign Intelligence Surveillance (FISA Section 702, Executive Order 12333, and Section 215 of the Patriot Act): A Resource Page](https://www.brennancenter.org/our-work/research-reports/foreign-intelligence-surveillance-fisa-section-702-executive-order-12333){target="_blank"} - Brennan Center for Justice (EO 12333 as the primary overseas authority, without FISC oversight, unaffected by the 702 lapse)
+[^7]: [Cross-Border Data Sharing Under the CLOUD Act](https://www.congress.gov/crs-product/R45173){target="_blank"} - Congressional Research Service (US providers can be compelled to disclose data they control regardless of server location)
+[^8]: [Taiwan's undersea cables](https://taiwaninsight.org/2024/10/02/the-most-critical-resilience-questions-of-them-all-taiwans-undersea-cables/){target="_blank"} - Taiwan Insight (Taiwan's dependence on international submarine cables)
+[^9]: [NSA and GCHQ target Tor network that protects anonymity of web users](https://www.schneier.com/essays/archives/2013/10/nsa_and_gchq_target.html){target="_blank"} - Bruce Schneier (originally in The Guardian, on the "Tor Stinks" and EgotisticalGiraffe documents)
+[^img]: Header image [NSA-eagle-2_0.png](https://www.eff.org/files/banner_library/NSA-eagle-2_0.png){target="_blank"}, from [EFF's NSA spying work](https://www.eff.org/nsa-spying){target="_blank"}, by EFF designer Hugh D'Andrade, licensed [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}.

--- a/docs/en/blog/posts/2026-victory-702-has-expired.md
+++ b/docs/en/blog/posts/2026-victory-702-has-expired.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-16
+date: 2026-07-23
 authors:
     - anoni-net
 categories:

--- a/docs/zh-CN/blog/posts/2026-victory-702-has-expired.md
+++ b/docs/zh-CN/blog/posts/2026-victory-702-has-expired.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-16
+date: 2026-07-23
 authors:
     - anoni-net
 categories:

--- a/docs/zh-CN/blog/posts/2026-victory-702-has-expired.md
+++ b/docs/zh-CN/blog/posts/2026-victory-702-has-expired.md
@@ -1,0 +1,132 @@
+---
+date: 2026-06-16
+authors:
+    - anoni-net
+categories:
+    - 更新
+    - 翻译文章
+    - 隐私
+slug: 2026-victory-702-has-expired
+image: "https://assets.anoni.net/blog/2026-victory-702-has-expired.png"
+summary: "FISA Section 702 让美国情报机构不需令状就能收集境外人士的通信，2013 年斯诺登揭露的 PRISM 与 Upstream 都建立在这条授权之上。2026 年 6 月 12 日午夜，它在国会僵局中暂时到期。无论你在台湾、香港、澳门还是其他华语环境，本来就是这套境外监控的合法对象，这篇说清楚这套权力的范围、跟斯诺登事件的关联，以及为什么 EFF 把暂时失效也视为一场胜利。"
+description: "FISA Section 702 让美国情报机构不需令状就能收集境外人士通信，2013 年斯诺登揭露的 PRISM 与 Upstream 都建立在它之上。2026 年 6 月 12 日它暂时到期。华语地区使用者本来就是境外监控的合法对象，这篇交代权力范围、斯诺登关联，以及 EFF 视为胜利的理由。"
+---
+
+# :material-eye-off-outline: FISA 702 条款到期：美国无令状收集境外通信的授权，2026 年 6 月暂时失效
+
+<figure markdown="span">
+    <a href="https://assets.anoni.net/blog/2026-victory-702-has-expired.png" target="_blank">
+        <img src="https://assets.anoni.net/blog/2026-victory-702-has-expired.png"
+            alt="EFF 的 NSA eagle 图，把 NSA 标志改画成一只老鹰用爪子接上电信线路，象征无令状的大规模监控"
+            style="border-radius: 10px;">
+    </a>
+    <figcaption>图片为 EFF 设计师 Hugh D'Andrade 绘制的「NSA eagle」，把 NSA 标志改画成老鹰用爪子接上电信线路，象征无令状的大规模监控。出自 [EFF 的 NSA 监控专题](https://www.eff.org/nsa-spying){target="_blank"}，授权为 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}[^img]。</figcaption>
+</figure>
+
+你寄一封信到 Gmail、用 iMessage 跟在美国的朋友聊天、用 WhatsApp 联络海外的家人，这些通信只要有一端落在美国的服务或网络上，本来就可能被美国情报机构在不需令状的情况下收集。授权这件事的法律叫 FISA Section 702（《外国情报监控法》第 702 条）。2026 年 6 月 12 日午夜，这条授权在美国国会的僵局中到期[^1]。
+
+EFF（电子前线基金会）把这件事称为一场胜利。要理解为什么，得先知道 702 是什么、它跟 2013 年斯诺登（Edward Snowden）揭露的监控计划是什么关系，以及为什么华语地区使用者长期就是这套监控的合法对象，这次「暂时失效」对这个处境又意味着什么。
+
+<!-- more -->
+
+## Section 702 是什么
+
+Section 702 由美国 2008 年的《FISA Amendments Act》（外国情报监控法修正案）设立[^3]。它允许美国情报机构在认定某位境外人士握有外国情报价值时，不经个别令状就收集这个人的通信，包含电子邮件、消息与通话。
+
+关键在「境外人士」这四个字。702 的设计对象是美国境外的所有人，所以美国境外的每一个人，包含华语地区的使用者，在法律上本来就是这套收集的合法目标。美国公民受美国宪法第四修正案保护，需要令状，境外人士没有这层保护。
+
+实务上，702 还会大量「附带收集」（incidental collection）到美国人的通信。只要美国人跟被锁定的境外目标有来往，他的邮件、消息、通话就会一并被收进数据库。这是后面争议的起点。
+
+702 授权之下有两种具体的收集方式，名字许多人其实听过：
+
+- **下游收集（Downstream，旧称 PRISM）**：政府要求 Google、Microsoft、Apple、Facebook、Yahoo 等科技公司，交出符合条件的使用者通信[^2]。
+- **上游收集（Upstream）**：NSA（国家安全局）直接从互联网骨干的缆线与交换器上截取流量[^2]。
+
+PRISM 与 Upstream 不是传说中的代号。它们是 702 这条法律授权底下，实际在跑的两个程序。
+
+## 跟斯诺登事件的关联
+
+斯诺登在 2013 年揭露的监控计划，法律基础正是 Section 702。当年 6 月，这位前 NSA 合同人员把一批内部简报交给记者，PRISM 与 Upstream 这两个名字就是从那批文件流入公众视野的[^2]。全世界第一次看到「原来美国可以这样收集全球的网络通信」，看到的就是 702 在运作的样子。
+
+斯诺登揭露的是「如何收集」，Section 702 则是「凭什么能收集」的法律授权。
+
+从立法到暂时失效，这套授权的几个主要时间点：
+
+- `2008` 年：《FISA Amendments Act》通过，设立 Section 702，让原本游走在灰色地带的无令状收集有了明文授权。
+- `2013` 年：斯诺登揭露 PRISM 与 Upstream，702 第一次成为全球公共议题，各国才意识到自己是这套收集的对象。
+- 之后十多年：702 经 `2012`、`2017`、`2024` 多次重新授权，每一次都伴随改革派与情报机构的拉锯，EFF 等团体持续要求加上令状门槛。`2024` 年的 RISAA 把授权延到 `2026` 年 4 月，之后再靠临时延长撑到 6 月。
+- `2026` 年 6 月 12 日：在一场国会僵局中暂时到期。
+
+斯诺登当年揭露的计划，过了十三年，它的法律授权第一次出现空窗。
+
+## 后门搜索（backdoor searches）为什么是争议核心
+
+702 名义上锁定境外人士，真正在美国国内引发宪法争议的是后门搜索（backdoor searches），官方称为「美国人查询」（US person queries）。
+
+702 收集进来的庞大通信数据库里，因为附带收集而塞满了美国人的通信。FBI（美国联邦调查局）、CIA（中央情报局）、NSA 之后可以用美国人的姓名、电子邮件、电话这类识别码去查询这个数据库，不需要另外申请令状。等于绕过了第四修正案对美国人的保护，从后门拿到数据。
+
+规模不小，违规也不少：
+
+- FBI 在 `2019` 到 `2022` 年间，对美国人做了将近 `500` 万次查询，这些查询程序上多属合法，争议在于大多缺乏个案的合理说明[^4]。
+- 政府在 `2022` 年 3 月通报，光是对 Section 702 数据库的搜索，就有超过 `278,000` 次不符规定[^4]。
+- 2024 年国会通过《Reforming Intelligence and Securing America Act》（RISAA，情报改革与保障美国法），加了一些改革，但没有解决无令状查询这个根本问题。到 `2024` 年 8 月，已经有报道指出 FBI 用了一个查询工具绕过 RISAA 的限制[^4]。
+
+EFF 长期主张，FBI 要查询美国人在 702 之下被收集的通信，应该先取得令状。如果做不到这个门槛，那就让整个方案到期，不要再续[^1]。
+
+## 2026 年 6 月发生什么
+
+702 这次到期，导火线跟一桩人事任命有关。特朗普提名 Bill Pulte（时任联邦住房金融局局长）暂代国家情报总监（DNI），接替宣布请辞的 Tulsi Gabbard[^1][^5]。DNI 监督的正是执行 702 的情报机构，把这个位子交给一位没有情报资历、又曾以房贷诈欺名义追查特朗普政敌的人选，让参议院民主党不愿在这个时间点放行。他们以 Pulte 缺乏情报、军事与国会经历为由，拒绝推进自家版本的重新授权法案，众议院则否决了短期续延[^1][^5]。国会几次靠临时延长把期限往后推，最后在 6 月 12 日午夜停在到期[^1]。
+
+到期不等于监控当天就停。依现有报道，外国情报监控法院（FISC）对既有方案的重新认证效力延续到 2027 年 3 月，为这段期间的收集留下法律依据。有法律专家直言「702 不会就此停摆（go dark），那是迷思」[^5]。这次到期更接近一个法律与政治上的转折点，而非开关被立刻关掉。
+
+## 为什么 EFF 把暂时失效也当成胜利
+
+EFF 点出，这套权力的滥用风险从来不系于某一个人或某一届政府。如果国会担心的是「某个人可能拿到美国人的敏感信息」，负责任的做法是去强化制度层面的透明、究责与监督机制，而不是把希望寄托在换掉某个人选[^1]。
+
+2026 年一整年，国会两党对改革的胃口都在变大，愈来愈多人反对在没有令状门槛的前提下重新授权 702[^1]。一条运作了十多年、斯诺登揭露过、改革多次卡关的监控授权，能走到暂时失效这一步，本身就说明持续倡议是有用的。
+
+## 回到华语地区：你本来就是境外监控的合法对象
+
+702 的失效对美国的倡议者是一场胜利，对华语地区的使用者能保护到的范围却很有限。702 这几年的争议重点是保护美国人，后门搜索争的是美国人受第四修正案保护、却被绕过去查。无论你在台湾、香港、澳门、新马还是其他华语环境，本来就不在第四修正案的保护范围内，要查询你在 702 之下被收集的通信，对美国政府而言连后门都算不上，是正门。
+
+### 你仍然是合法收集对象
+
+有些人觉得反正自己不是美国政府针对的目标，因此对 702 无感。隐私防护设防的对象是能力，不是当下的善意或意图。一个机构今天没盯上你，不代表它握有的收集能力会跟着缩手，收集的对象与用途也会随政治情势改变。把任何握有大规模收集能力的行为者放进同一套[威胁模型](../../basics/threat-model.md)，比依赖「现在应该查不到我」可靠。
+
+就算 702 真的消失，收集境外人士的手段也不只这一条。NSA 海外信号情报的主要法源是第 12333 号行政命令（Executive Order 12333，EO 12333，1981 年签署），它没有 FISC 的司法监督，国会监督也有限，而且完全不受这次 702 到期影响[^6]。对华语地区使用者这种境外人士的收集，702 在不在都能继续。这也是为什么这场胜利对华语读者该庆祝的成分有限，隐私还是得靠自己用加密守住，不能寄望某一条法律。
+
+### 真正的防线是端对端加密
+
+华语地区大量依赖美国的云端与通信服务，Google Workspace、Microsoft 365、iCloud、AWS、Meta 旗下的 WhatsApp 与 Instagram 都在其中（其中部分在中国大陆需要绕过封锁才能使用，但在港澳、新马与海外华人社群是日常工具）。很多人以为数据放在本地机房就安全，但只要服务商总部在美国，美国的 CLOUD Act（2018 年通过）就能要求它交出所掌控的数据，服务器放哪里不影响[^7]。欧盟为了同样的问题跟美国周旋多年、打过好几轮官司，华语地区连对等的数据保护协定都没有，处境更被动。真正有效的防线是端对端加密（E2EE），密钥不在服务商手上，就算数据被交出、或在传输途中被截取，没有密钥也读不到内容，对附带收集与后门搜索都挡得住。
+
+端对端加密保护的是通信内容，Tor 进一步遮住连接本身。Upstream 从网络骨干截取流量，拿到的是你连去哪、跟谁往来这类连接信息。台湾、香港这类地方对外连接高度依赖国际海缆[^8]，通往美西、美东的跨太平洋缆线是重要干道之一，连接只要目的地或路由经过美国骨干，封包就落在 Upstream 的截取范围内。Tor 把流量加密后经多个中继转送，骨干上只看得到一段加密的 Tor 流量，服务商那边也对不出真正的使用者，等于打断 PRISM 与 Upstream 所仰赖的连接对应关系。Tor 挡得住这种大规模被动收集，但挡不了针对个人的主动入侵，例如利用浏览器漏洞去匿名化，斯诺登文件里 NSA 的 Tor Stinks 简报就坦承，只能去匿名化一小部分使用者[^9]。运作原理见 [什么是 Tor](../../tools/what-is-tor.md)。
+
+### 谁的风险更高，社群能一起做什么
+
+需要跟海外编辑室、国际组织、消息来源往来的记者与公民团体，跨境通信本来就多，附带收集碰到他们的机率比一般人高，这些角色值得把防护等级拉高，敏感协作走 Tor、不要把消息来源名单放在美国企业的云端，延伸的角色指南见 [记者如何保护消息来源](../../scenarios/journalist.md) 与 [社运行动者的数位准备](../../scenarios/activist.md)。匿名网络社群 anoni.net 把力气放在去中心、自架与加密这些靠自己的能力上，而不是等哪条法律来保障，正是因为 702 到期当天收集照旧、EO 12333 不受影响这个现实。对许多华语地区使用者来说，本地的监控往往是更切身的威胁，从中国大陆的网络审查与实名制，到各地不同的通信监察制度，加密与 Tor 对这些同样是防线。台湾的个资法、揭弊者保护法是其中一组本地脉络的例子，相关讨论见 [台湾个资法 2025 修法](../../taiwan/pdpa-2025.md) 与 [揭弊者保护法的技术观察](../../taiwan/whistleblower-law.md)。
+
+702 暂时失效不会让监控立刻消失，跨境通信的隐私风险也不会因此归零。对每一个身在美国境外的人，真正要盯紧的是授权监控的法律结构，先确认自己在这套结构里的位置。今天就能做的第一步，是把日常联络换成默认端对端加密的工具，敏感的对外连接走 Tor。
+
+## 相关阅读
+
+- [端对端加密如何运作](../../advanced/e2ee.md)：为什么加密过的内容就算被截取也读不到
+- [什么是 Tor](../../tools/what-is-tor.md)：多重中继转送如何打断大规模被动收集靠的连接对应
+- [匿名通信工具比较](../../tools/messaging-comparison.md)：哪些通信工具默认端对端加密、各自的取舍
+- [为什么 Metadata 比你想的更暴露](../../basics/metadata.md)：就算读不到内容，「谁跟谁、何时何地」本身就足以下决定
+- [威胁模型：先想清楚你在防谁](../../basics/threat-model.md)：把国家级监控放进自己的威胁模型
+- [台湾个资法 2025 修法](../../taiwan/pdpa-2025.md)：一个华语地区的数据保护制度案例
+
+---
+
+> 本文编译自 EFF Deeplinks 文章 [Victory! 702 has Expired!](https://www.eff.org/deeplinks/2026/06/victory-702-has-expired){target="_blank"}（作者 India McKinney，2026-06-12），并补上 Section 702 的背景、跟斯诺登事件的关联，以及华语地区观点。
+
+[^1]: [Victory! 702 has Expired!](https://www.eff.org/deeplinks/2026/06/victory-702-has-expired){target="_blank"} - EFF Deeplinks（作者 India McKinney，2026-06-12）
+[^2]: [Upstream vs. PRISM](https://www.eff.org/pages/upstream-prism){target="_blank"} - EFF（说明 702 之下 Upstream 与 PRISM 两种收集方式，及其与 2013 年斯诺登揭露的关系）
+[^3]: [The 702 Ultimatum: Warrant Requirement or Bust](https://www.eff.org/deeplinks/2026/06/702-ultimatum-warrant-requirement-or-bust){target="_blank"} - EFF Deeplinks（EFF 对本次到期前的主张：加上令状门槛，否则就让它到期）
+[^4]: [Section 702 of the Foreign Intelligence Surveillance Act, Explained](https://www.brennancenter.org/our-work/research-reports/section-702-foreign-intelligence-surveillance-act){target="_blank"} - Brennan Center for Justice（backdoor searches 次数、违规通报、RISAA 2024 背景）
+[^5]: [A key spy authority, Section 702, expired due to inaction in Congress. Here's what happens next.](https://www.cbsnews.com/news/fisa-section-702-expiring-congress-what-that-means/){target="_blank"} - CBS News（到期时间线、Pulte 任命、既有认证延续至 2027 年 3 月）
+[^6]: [Foreign Intelligence Surveillance (FISA Section 702, Executive Order 12333, and Section 215 of the Patriot Act)：A Resource Page](https://www.brennancenter.org/our-work/research-reports/foreign-intelligence-surveillance-fisa-section-702-executive-order-12333){target="_blank"} - Brennan Center for Justice（EO 12333 为 NSA 海外监控的主要法源，无 FISC 司法监督，不受 702 到期影响）
+[^7]: [Cross-Border Data Sharing Under the CLOUD Act](https://www.congress.gov/crs-product/R45173){target="_blank"} - Congressional Research Service（CLOUD Act 可要求美国服务商交出其掌控的数据，与服务器所在地无关）
+[^8]: [海底电缆：藏在台湾深海的网络护国神山](https://www.bnext.com.tw/article/60585/taiwan-submarine-cable){target="_blank"} - 数位时代（台湾国际海缆主干道走向）
+[^9]: [NSA and GCHQ target Tor network that protects anonymity of web users](https://www.schneier.com/essays/archives/2013/10/nsa_and_gchq_target.html){target="_blank"} - Bruce Schneier（原载 The Guardian，说明 Tor Stinks 与 EgotisticalGiraffe 文件内容）
+[^img]: 题图 [NSA-eagle-2_0.png](https://www.eff.org/files/banner_library/NSA-eagle-2_0.png){target="_blank"}，出自 [EFF 的 NSA 监控专题](https://www.eff.org/nsa-spying){target="_blank"}，作者为 EFF 设计师 Hugh D'Andrade，授权 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}。

--- a/docs/zh-TW/blog/posts/2026-victory-702-has-expired.md
+++ b/docs/zh-TW/blog/posts/2026-victory-702-has-expired.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-16
+date: 2026-07-23
 authors:
     - anoni-net
 categories:

--- a/docs/zh-TW/blog/posts/2026-victory-702-has-expired.md
+++ b/docs/zh-TW/blog/posts/2026-victory-702-has-expired.md
@@ -1,0 +1,132 @@
+---
+date: 2026-06-16
+authors:
+    - anoni-net
+categories:
+    - 更新
+    - 翻譯文章
+    - 隱私
+slug: 2026-victory-702-has-expired
+image: "https://assets.anoni.net/blog/2026-victory-702-has-expired.png"
+summary: "FISA Section 702 讓美國情報機構不需令狀就能蒐集境外人士的通訊，2013 年史諾登揭露的 PRISM 與 Upstream 都建立在這條授權之上。2026 年 6 月 12 日午夜，它在國會僵局中暫時到期。對長期身為境外監控合法對象的台灣使用者，這篇說清楚這套權力的範圍、跟史諾登事件的關聯，以及為什麼 EFF 把暫時失效也視為一場勝利。"
+description: "FISA Section 702 讓美國情報機構不需令狀就能蒐集境外人士通訊，2013 年史諾登揭露的 PRISM 與 Upstream 都建立在它之上。2026 年 6 月 12 日它暫時到期。台灣使用者本來就是境外監控的合法對象，這篇交代權力範圍、史諾登關聯，以及 EFF 視為勝利的理由。"
+---
+
+# :material-eye-off-outline: FISA 702 條款到期：美國無令狀蒐集境外通訊的授權，2026 年 6 月暫時失效
+
+<figure markdown="span">
+    <a href="https://assets.anoni.net/blog/2026-victory-702-has-expired.png" target="_blank">
+        <img src="https://assets.anoni.net/blog/2026-victory-702-has-expired.png"
+            alt="EFF 的 NSA eagle 圖，把 NSA 標誌改畫成一隻老鷹用爪子接上電信線路，象徵無令狀的大規模監控"
+            style="border-radius: 10px;">
+    </a>
+    <figcaption>圖片為 EFF 設計師 Hugh D'Andrade 繪製的「NSA eagle」，把 NSA 標誌改畫成老鷹用爪子接上電信線路，象徵無令狀的大規模監控。出自 [EFF 的 NSA 監控專題](https://www.eff.org/nsa-spying){target="_blank"}，授權為 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}[^img]。</figcaption>
+</figure>
+
+你寄一封信到 Gmail、用 iMessage 跟在美國的朋友聊天、用 WhatsApp 聯絡海外的家人，這些通訊只要有一端落在美國的服務或網路上，原本就可能被美國情報機構在不需令狀的情況下蒐集。授權這件事的法律叫 FISA Section 702（《外國情報監控法》第 702 條）。2026 年 6 月 12 日午夜，這條授權在美國國會的僵局中到期[^1]。
+
+EFF（電子前線基金會）把這件事稱為一場勝利。要理解為什麼，得先知道 702 是什麼、它跟 2013 年史諾登（Edward Snowden）揭露的監控計畫是什麼關係，以及為什麼台灣使用者長期就是這套監控的合法對象，這次「暫時失效」對這個處境又意味著什麼。
+
+<!-- more -->
+
+## Section 702 是什麼
+
+Section 702 由美國 2008 年的《FISA Amendments Act》（外國情報監控法修正案）設立[^3]。它允許美國情報機構在認定某位境外人士握有外國情報價值時，不經個別令狀就蒐集這個人的通訊，包含電子郵件、訊息與通話。
+
+關鍵在「境外人士」這四個字。702 的設計對象是美國境外的所有人，所以美國境外的每一個人，包含台灣使用者，在法律上原本就是這套蒐集的合法目標。美國公民受美國憲法第四修正案保護，需要令狀，境外人士沒有這層保護。
+
+實務上，702 還會大量「附帶蒐集」（incidental collection）到美國人的通訊。只要美國人跟被鎖定的境外目標有來往，他的郵件、訊息、通話就會一併被收進資料庫。這是後面爭議的起點。
+
+702 授權之下有兩種具體的蒐集方式，名字許多人其實聽過：
+
+- **下游蒐集（Downstream，舊稱 PRISM）**：政府要求 Google、Microsoft、Apple、Facebook、Yahoo 等科技公司，交出符合條件的使用者通訊[^2]。
+- **上游蒐集（Upstream）**：NSA（國家安全局）直接從網際網路骨幹的纜線與交換器上擷取流量[^2]。
+
+PRISM 與 Upstream 不是傳說中的代號。它們是 702 這條法律授權底下，實際在跑的兩個程式。
+
+## 跟史諾登事件的關聯
+
+史諾登在 2013 年揭露的監控計畫，法律基礎正是 Section 702。當年 6 月，這位前 NSA 約聘人員把一批內部簡報交給記者，PRISM 與 Upstream 這兩個名字就是從那批文件流入公眾視野的[^2]。全世界第一次看到「原來美國可以這樣蒐集全球的網路通訊」，看到的就是 702 在運作的樣子。
+
+史諾登揭露的是「如何蒐集」，Section 702 則是「憑什麼能蒐集」的法律授權。
+
+從立法到暫時失效，這套授權的幾個主要時間點：
+
+- `2008` 年：《FISA Amendments Act》通過，設立 Section 702，讓原本游走在灰色地帶的無令狀蒐集有了明文授權。
+- `2013` 年：史諾登揭露 PRISM 與 Upstream，702 第一次成為全球公共議題，各國才意識到自己是這套蒐集的對象。
+- 之後十多年：702 經 `2012`、`2017`、`2024` 多次重新授權，每一次都伴隨改革派與情報機構的拉鋸，EFF 等團體持續要求加上令狀門檻。`2024` 年的 RISAA 把授權延到 `2026` 年 4 月，之後再靠臨時延長撐到 6 月。
+- `2026` 年 6 月 12 日：在一場國會僵局中暫時到期。
+
+史諾登當年揭露的計畫，過了十三年，它的法律授權第一次出現空窗。
+
+## 後門搜尋（backdoor searches）為什麼是爭議核心
+
+702 名義上鎖定境外人士，真正在美國國內引發憲法爭議的是後門搜尋（backdoor searches），官方稱為「美國人查詢」（US person queries）。
+
+702 蒐集進來的龐大通訊資料庫裡，因為附帶蒐集而塞滿了美國人的通訊。FBI（美國聯邦調查局）、CIA（中央情報局）、NSA 之後可以用美國人的姓名、電子郵件、電話這類識別碼去查詢這個資料庫，不需要另外申請令狀。等於繞過了第四修正案對美國人的保護，從後門拿到資料。
+
+規模不小，違規也不少：
+
+- FBI 在 `2019` 到 `2022` 年間，對美國人做了將近 `500` 萬次查詢，這些查詢程序上多屬合法，爭議在於大多缺乏個案的合理說明[^4]。
+- 政府在 `2022` 年 3 月通報，光是對 Section 702 資料庫的搜尋，就有超過 `278,000` 次不符規定[^4]。
+- 2024 年國會通過《Reforming Intelligence and Securing America Act》（RISAA，情報改革與保障美國法），加了一些改革，但沒有解決無令狀查詢這個根本問題。到 `2024` 年 8 月，已經有報導指出 FBI 用了一個查詢工具繞過 RISAA 的限制[^4]。
+
+EFF 長期主張，FBI 要查詢美國人在 702 之下被蒐集的通訊，應該先取得令狀。如果做不到這個門檻，那就讓整個方案到期，不要再續[^1]。
+
+## 2026 年 6 月發生什麼
+
+702 這次到期，導火線跟一樁人事任命有關。川普提名 Bill Pulte（時任聯邦住房金融局局長）暫代國家情報總監（DNI），接替宣布請辭的 Tulsi Gabbard[^1][^5]。DNI 監督的正是執行 702 的情報機構，把這個位子交給一位沒有情報資歷、又曾以房貸詐欺名義追查川普政敵的人選，讓參議院民主黨不願在這個時間點放行。他們以 Pulte 缺乏情報、軍事與國會經歷為由，拒絕推進自家版本的重新授權法案，眾議院則否決了短期續延[^1][^5]。國會幾次靠臨時延長把期限往後推，最後在 6 月 12 日午夜停在到期[^1]。
+
+到期不等於監控當天就停。依現有報導，外國情報監控法院（FISC）對既有方案的重新認證效力延續到 2027 年 3 月，為這段期間的蒐集留下法律依據。有法律專家直言「702 不會就此停擺（go dark），那是迷思」[^5]。這次到期更接近一個法律與政治上的轉折點，而非開關被立刻關掉。
+
+## 為什麼 EFF 把暫時失效也當成勝利
+
+EFF 點出，這套權力的濫用風險從來不繫於某一個人或某一屆政府。如果國會擔心的是「某個人可能拿到美國人的敏感資訊」，負責任的做法是去強化制度層面的透明、究責與監督機制，而不是把希望寄託在換掉某個人選[^1]。
+
+2026 年一整年，國會兩黨對改革的胃口都在變大，愈來愈多人反對在沒有令狀門檻的前提下重新授權 702[^1]。一條運作了十多年、史諾登揭露過、改革多次卡關的監控授權，能走到暫時失效這一步，本身就說明持續倡議是有用的。
+
+## 回到台灣：你本來就是境外監控的合法對象
+
+702 的失效對美國的倡議者是一場勝利，對台灣讀者能保護到的範圍卻很有限。702 這幾年的爭議重點是保護美國人，後門搜尋爭的是美國人受第四修正案保護、卻被繞過去查。台灣人本來就不在第四修正案的保護範圍內，要查詢台灣人在 702 之下被蒐集的通訊，對美國政府而言連後門都算不上，是正門。
+
+### 你仍然是合法蒐集對象
+
+很多人因為台美關係友好，覺得被美國蒐集總比被別人蒐集好，因此對 702 無感。隱私防護設防的對象是能力，不是當下的善意。一個機構今天友好，不代表它握有的蒐集能力會跟著縮手，蒐集的對象與用途也會隨政治情勢改變。把任何握有大規模蒐集能力的行為者放進同一套[威脅模型](../../basics/threat-model.md)，比依賴「現在是盟友」可靠。
+
+就算 702 真的消失，蒐集境外人士的手段也不只這一條。NSA 海外訊號情報的主要法源是第 12333 號行政命令（Executive Order 12333，EO 12333，1981 年簽署），它沒有 FISC 的司法監督，國會監督也有限，而且完全不受這次 702 到期影響[^6]。對台灣人這種境外人士的蒐集，702 在不在都能繼續。這也是為什麼這場勝利對台灣讀者該慶祝的成分有限，隱私還是得靠自己用加密守住，不能寄望某一條法律。
+
+### 真正的防線是端對端加密
+
+台灣社會大量依賴美國的雲端與通訊服務，Google Workspace、Microsoft 365、iCloud、AWS、Meta 旗下的 WhatsApp 與 Instagram 都在其中。很多人以為資料放在台灣機房就安全，但只要服務商總部在美國，美國的 CLOUD Act（2018 年通過）就能要求它交出所掌控的資料，伺服器放哪裡不影響[^7]。歐盟為了同樣的問題跟美國周旋多年、打過好幾輪官司，台灣連對等的資料保護協定都沒有，處境更被動。真正有效的防線是端對端加密（E2EE），金鑰不在服務商手上，就算資料被交出、或在傳輸途中被擷取，沒有金鑰也讀不到內容，對附帶蒐集與後門搜尋都擋得住。
+
+端對端加密保護的是通訊內容，Tor 進一步遮住連線本身。Upstream 從網路骨幹擷取流量，拿到的是你連去哪、跟誰往來這類連線資訊。台灣是海島，對外連線高度依賴國際海纜[^8]，通往美西、美東的跨太平洋纜線是重要幹道之一，連線只要目的地或路由經過美國骨幹，封包就落在 Upstream 的擷取範圍內。Tor 把流量加密後經多個中繼轉送，骨幹上只看得到一段加密的 Tor 流量，業者那邊也對不出真正的使用者，等於打斷 PRISM 與 Upstream 所仰賴的連線對應關係。Tor 擋得住這種大規模被動蒐集，但擋不了針對個人的主動入侵，例如利用瀏覽器漏洞去匿名化，史諾登文件裡 NSA 的 Tor Stinks 簡報就坦承，只能去匿名化一小部分使用者[^9]。運作原理見 [什麼是 Tor](../../tools/what-is-tor.md)。
+
+### 誰的風險更高，社群能一起做什麼
+
+需要跟海外編輯室、國際組織、消息來源往來的記者與公民團體，跨境通訊本來就多，附帶蒐集碰到他們的機率比一般人高，這些角色值得把防護等級拉高，敏感協作走 Tor、不要把消息來源名單放在美國企業的雲端，延伸的角色指南見 [記者如何保護消息來源](../../scenarios/journalist.md) 與 [社運行動者的數位準備](../../scenarios/activist.md)。匿名網路社群 anoni.net 把力氣放在去中心、自架與加密這些靠自己的能力上，而不是等哪條法律來保障，正是因為 702 到期當天蒐集照舊、EO 12333 不受影響這個現實。同樣的令狀門檻問題在台灣也有自己的版本，通訊保障及監察法、科技偵查相關立法的爭議都是本地戰場，相關討論見 [台灣個資法 2025 修法](../../taiwan/pdpa-2025.md) 與 [揭弊者保護法的技術觀察](../../taiwan/whistleblower-law.md)。
+
+702 暫時失效不會讓監控立刻消失，跨境通訊的隱私風險也不會因此歸零。對每一個身在美國境外的人，真正要盯緊的是授權監控的法律結構，先確認自己在這套結構裡的位置。今天就能做的第一步，是把日常聯絡換成預設端對端加密的工具，敏感的對外連線走 Tor。
+
+## 相關閱讀
+
+- [端對端加密如何運作](../../advanced/e2ee.md)：為什麼加密過的內容就算被擷取也讀不到
+- [什麼是 Tor](../../tools/what-is-tor.md)：多重中繼轉送如何打斷大規模被動蒐集靠的連線對應
+- [匿名通訊工具比較](../../tools/messaging-comparison.md)：哪些通訊工具預設端對端加密、各自的取捨
+- [為什麼 Metadata 比你想的更暴露](../../basics/metadata.md)：就算讀不到內容，「誰跟誰、何時何地」本身就足以下決定
+- [威脅模型：先想清楚你在防誰](../../basics/threat-model.md)：把國家級監控放進自己的威脅模型
+- [台灣個資法 2025 修法](../../taiwan/pdpa-2025.md)：在地的資料保護制度脈絡
+
+---
+
+> 本文編譯自 EFF Deeplinks 文章 [Victory! 702 has Expired!](https://www.eff.org/deeplinks/2026/06/victory-702-has-expired){target="_blank"}（作者 India McKinney，2026-06-12），並補上 Section 702 的背景、跟史諾登事件的關聯，以及台灣觀點。
+
+[^1]: [Victory! 702 has Expired!](https://www.eff.org/deeplinks/2026/06/victory-702-has-expired){target="_blank"} - EFF Deeplinks（作者 India McKinney，2026-06-12）
+[^2]: [Upstream vs. PRISM](https://www.eff.org/pages/upstream-prism){target="_blank"} - EFF（說明 702 之下 Upstream 與 PRISM 兩種蒐集方式，及其與 2013 年史諾登揭露的關係）
+[^3]: [The 702 Ultimatum: Warrant Requirement or Bust](https://www.eff.org/deeplinks/2026/06/702-ultimatum-warrant-requirement-or-bust){target="_blank"} - EFF Deeplinks（EFF 對本次到期前的主張：加上令狀門檻，否則就讓它到期）
+[^4]: [Section 702 of the Foreign Intelligence Surveillance Act, Explained](https://www.brennancenter.org/our-work/research-reports/section-702-foreign-intelligence-surveillance-act){target="_blank"} - Brennan Center for Justice（backdoor searches 次數、違規通報、RISAA 2024 背景）
+[^5]: [A key spy authority, Section 702, expired due to inaction in Congress. Here's what happens next.](https://www.cbsnews.com/news/fisa-section-702-expiring-congress-what-that-means/){target="_blank"} - CBS News（到期時間線、Pulte 任命、既有認證延續至 2027 年 3 月）
+[^6]: [Foreign Intelligence Surveillance (FISA Section 702, Executive Order 12333, and Section 215 of the Patriot Act)：A Resource Page](https://www.brennancenter.org/our-work/research-reports/foreign-intelligence-surveillance-fisa-section-702-executive-order-12333){target="_blank"} - Brennan Center for Justice（EO 12333 為 NSA 海外監控的主要法源，無 FISC 司法監督，不受 702 到期影響）
+[^7]: [Cross-Border Data Sharing Under the CLOUD Act](https://www.congress.gov/crs-product/R45173){target="_blank"} - Congressional Research Service（CLOUD Act 可要求美國服務商交出其掌控的資料，與伺服器所在地無關）
+[^8]: [海底電纜：藏在台灣深海的網路護國神山](https://www.bnext.com.tw/article/60585/taiwan-submarine-cable){target="_blank"} - 數位時代（台灣國際海纜主幹道走向）
+[^9]: [NSA and GCHQ target Tor network that protects anonymity of web users](https://www.schneier.com/essays/archives/2013/10/nsa_and_gchq_target.html){target="_blank"} - Bruce Schneier（原載 The Guardian，說明 Tor Stinks 與 EgotisticalGiraffe 文件內容）
+[^img]: 題圖 [NSA-eagle-2_0.png](https://www.eff.org/files/banner_library/NSA-eagle-2_0.png){target="_blank"}，出自 [EFF 的 NSA 監控專題](https://www.eff.org/nsa-spying){target="_blank"}，作者為 EFF 設計師 Hugh D'Andrade，授權 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/){target="_blank"}。


### PR DESCRIPTION
編譯 EFF Deeplinks 文章 [Victory! 702 has Expired!](https://www.eff.org/deeplinks/2026/06/victory-702-has-expired)（India McKinney, 2026-06-12），三語上線。對應來源 issue：[toomore/anoni-net-ws#338](https://github.com/toomore/anoni-net-ws/issues/338)。

## 新增檔案
- `docs/zh-TW/blog/posts/2026-victory-702-has-expired.md`
- `docs/zh-CN/blog/posts/2026-victory-702-has-expired.md`
- `docs/en/blog/posts/2026-victory-702-has-expired.md`

## 內容重點
- **zh-TW（single source of truth）**：除翻譯外補上脈絡 — Section 702 背景、與史諾登 2013（PRISM／Upstream）的關聯、後門搜尋爭議、2026-06-12 到期始末（Pulte／Gabbard、FISC 認證延續至 2027/3）、為什麼 EFF 視為勝利，以及台灣觀點（境外監控對象、EO 12333／CLOUD Act、Tor 防護、海纜、高風險族群、在地監控法制）。經寫作風格、結構、目標讀者、事實查核四輪審查。
- **zh-CN**：依 zh-TW 派生、去台灣中心，「回到台灣」改為「回到華語地區」，納入中國大陸、港澳、新馬脈絡，並點出本地監控（網路審查、實名制）同樣適用加密／Tor 防線。
- **en**：anoni.net 英文原創 take（非逐字翻譯），文首 `!!! info` 標註 based-on EFF 原文，採 Sinophone Asia-Pacific 視角。en 概念頁尚缺，內部連結僅指現存的 `internet-freedom`，其餘走外部權威來源。

## 其他
- 三語題圖共用 CDN 的 EFF NSA eagle（Hugh D'Andrade，CC BY 4.0），`image:` 指向 `https://assets.anoni.net/blog/2026-victory-702-has-expired.png`（已上傳、200）。
- 三語 `mkdocs build` 皆通過，本篇無壞連結；事實宣稱已對齊出處（EFF／Brennan Center／CBS／CRS／Schneier）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)