### PR TITLE
docs: changelog 補上 Tor Browser 15.0.16（三語同步）

### DIFF
--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -8,6 +8,15 @@ icon: simple/torbrowser
 
 Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tor Browser 15.0.16
+
+> 2026-06-17 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15016/){target="_blank"}
+
+- Important security update to Firefox.
+- Rebased onto Firefox 140.12.0esr (tor-browser#45046), with security fixes backported from Firefox 152 (tor-browser#45054); Android GeckoView also moved to 140.12.0esr.
+- NoScript updated to 13.6.24.1984, fixing a DocStartInjection regression introduced in 13.6.19.902 (tor-browser#45044); OpenSSL updated to 3.5.7.
+- Removed the tor daemon requirement for signing (tor-browser-build#41802), and updated Go to 1.25.11 in the build toolchain.
+
 ## Tor Browser 15.0.15
 
 > 2026-06-03 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15015/){target="_blank"}

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -8,6 +8,15 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon 与 Onion 服务的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tor Browser 15.0.16
+
+> 2026-06-17 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15016/){target="_blank"}
+
+- 重要的 Firefox 安全更新。
+- rebase 至 Firefox 140.12.0esr（tor-browser#45046），backport 自 Firefox 152 的安全修补（tor-browser#45054），Android 版 GeckoView 同步升至 140.12.0esr。
+- NoScript 升至 13.6.24.1984，修正前一版 13.6.19.902 在 DocStartInjection 上的 regression（tor-browser#45044），OpenSSL 升至 3.5.7。
+- 签章流程移除对 tor daemon 的依赖（tor-browser-build#41802），构建工具链的 Go 升至 1.25.11。
+
 ## Tor Browser 15.0.15
 
 > 2026-06-03 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15015/){target="_blank"}

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -8,6 +8,18 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注。
 
+## Tor Browser 15.0.16
+
+> 2026-06-17 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15016/){target="_blank"}
+
+- 重要的 Firefox 安全更新。
+- rebase 至 Firefox 140.12.0esr（tor-browser#45046），並 backport 自 Firefox 152 的安全修補（tor-browser#45054）。
+- Android 版 GeckoView 同步升至 140.12.0esr。
+- NoScript 升至 13.6.24.1984，修正前一版 13.6.19.902 在 DocStartInjection 上的 regression（tor-browser#45044）。
+- OpenSSL 升至 3.5.7。
+- 簽章流程移除對 tor daemon 的依賴（tor-browser-build#41802）。
+- 建置工具鏈的 Go 升至 1.25.11。
+
 ## Tor Browser 15.0.15
 
 > 2026-06-03 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15015/){target="_blank"}


### PR DESCRIPTION
## 變更內容

`changelog/` 巡檢發現上游 Tor Browser 已釋出 **15.0.16**（2026-06-17），目前站上只記錄到 15.0.15。本 PR 在三語的 `changelog/tor.md` 補上 15.0.16 條目，插在 15.0.15 上方。

來源：[Tor Browser 15.0.16 上游公告](https://blog.torproject.org/new-release-tor-browser-15016/)

### 重點（這版是 Firefox 安全更新版）
- rebase 至 Firefox 140.12.0esr（tor-browser#45046），backport 自 Firefox 152 的安全修補（tor-browser#45054）
- Android 版 GeckoView 同步升至 140.12.0esr
- NoScript 升至 13.6.24.1984（修正 13.6.19.902 在 DocStartInjection 上的 regression，tor-browser#45044）
- OpenSSL 升至 3.5.7
- 簽章流程移除對 tor daemon 的依賴（tor-browser-build#41802）
- 建置工具鏈 Go 升至 1.25.11
- 無 tor client 版本變動（沿用前版 0.4.9.9）

### 三語處理
- `docs/zh-TW/changelog/tor.md`：完整 7 條（SSOT）
- `docs/zh-CN/changelog/tor.md`：依既有 zh-CN 精簡合併風格、去地理化
- `docs/en/changelog/tor.md`：英文摘要

### 巡檢結果（其餘三項皆已是最新，本次不動）
| 軟體 | 站上記錄 | 上游最新 |
|---|---|---|
| Tor Browser | 15.0.15 → **15.0.16** | 15.0.16 |
| Tails | 7.8.1 | 7.8.1 ✅ |
| OONI Probe | 6.0.2 | 6.0.2 ✅ |
| Arti | 2.4.0 | 2.4.0 ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)