### PR TITLE
docs: changelog 補上 Tails 7.9（三語同步）

### DIFF
--- a/docs/en/changelog/tails.md
+++ b/docs/en/changelog/tails.md
@@ -8,6 +8,16 @@ icon: material/usb-flash-drive-outline
 
 [Tails](https://tails.net/){target="_blank"} operating system release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tails 7.9
+
+> 2026-06-18 · [Upstream announcement](https://tails.net/news/version_7.9/){target="_blank"}
+
+- Regular scheduled release, not an emergency security update.
+- Tor Browser updated to 15.0.16.
+- Updated some firmware packages, improving support for newer hardware such as graphics and Wi-Fi.
+- Fixed a bug where the "outdated Secure Boot certificate" prompt could appear in the rare case when the certificates were already up to date.
+- The Linux kernel, Thunderbird, and the Debian base are unchanged from 7.8. Automatic upgrades are available from Tails 7.0 or later.
+
 ## Tails 7.8.1
 
 > 2026-06-04 · [Upstream announcement](https://tails.net/news/version_7.8.1/){target="_blank"}

--- a/docs/zh-CN/changelog/tails.md
+++ b/docs/zh-CN/changelog/tails.md
@@ -8,6 +8,16 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 操作系统的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tails 7.9
+
+> 2026-06-18 · [上游公告](https://tails.net/news/version_7.9/){target="_blank"}
+
+- 例行排程版本，非紧急安全发布。
+- Tor Browser 升至 15.0.16。
+- 更新部分 firmware 套件，改善较新硬件的支持，包含显卡、Wi-Fi 等。
+- 修正在 Secure Boot 证书其实已是最新的少数情境下，仍误跳「证书过期」通知的问题。
+- 未变动 Linux 内核、Thunderbird 与 Debian 底层，沿用 7.8 的软件组合。可从 Tails 7.0 以后版本自动升级。
+
 ## Tails 7.8.1
 
 > 2026-06-04 · [上游公告](https://tails.net/news/version_7.8.1/){target="_blank"}

--- a/docs/zh-TW/changelog/tails.md
+++ b/docs/zh-TW/changelog/tails.md
@@ -8,6 +8,16 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 作業系統的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
+## Tails 7.9
+
+> 2026-06-18 · [上游公告](https://tails.net/news/version_7.9/){target="_blank"}
+
+- 例行排程版本，非緊急安全釋出。
+- Tor Browser 升至 15.0.16。
+- 更新部分 firmware 套件，改善較新硬體的支援，包含顯示卡、Wi-Fi 等。
+- 修正在 Secure Boot 憑證其實已是最新的少數情境下，仍誤跳「憑證過期」通知的問題。
+- 未變動 Linux 核心、Thunderbird 與 Debian 底層，沿用 7.8 的軟體組合。可從 Tails 7.0 以後版本自動升級。
+
 ## Tails 7.8.1
 
 > 2026-06-04 · [上游公告](https://tails.net/news/version_7.8.1/){target="_blank"}


### PR DESCRIPTION
## 變更內容

`changelog/` 巡檢發現上游 **Tails 7.9**（2026-06-18）已釋出，站上只記錄到 7.8.1。本 PR 在三語 `changelog/tails.md` 補上 7.9 條目，插在 7.8.1 上方。

來源：[Tails 7.9 上游公告](https://tails.net/news/version_7.9/)

### 重點（例行排程版，非緊急安全釋出）
- Tor Browser 升至 15.0.16
- 更新部分 firmware 套件，改善較新硬體支援（顯示卡、Wi-Fi 等）
- 修正 Secure Boot 憑證已是最新時仍誤跳「憑證過期」通知的問題
- 未變動 Linux 核心、Thunderbird 與 Debian 底層，沿用 7.8 軟體組合，可從 7.0 以後自動升級

### 三語處理
- `docs/zh-TW/changelog/tails.md`：SSOT
- `docs/zh-CN/changelog/tails.md`：簡中同步
- `docs/en/changelog/tails.md`：英文同步

### 巡檢結果（其餘三項皆已是最新）
| 軟體 | 站上記錄 | 上游最新 |
|---|---|---|
| Tor Browser | 15.0.16 | 15.0.16 ✅ |
| **Tails** | 7.8.1 → **7.9** | 7.9 |
| OONI Probe | 6.0.2 | 6.0.2 ✅ |
| Arti | 2.4.0 | 2.4.0 ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)