### PR TITLE
docs(tools): Asian Diceware 改用 v0.4.0 小冊並新增「為什麼只有 ~3.8%」一節

### DIFF
--- a/docs/en/tools/asian-diceware.md
+++ b/docs/en/tools/asian-diceware.md
@@ -25,7 +25,7 @@ The technique has a name, Diceware, proposed by Arnold Reinhold in 1995[^reinhol
 
 ## What we made
 
-asian-diceware is a 7,776-word, EFF-compatible wordlist that works as a drop-in replacement for the EFF Large Wordlist, matching its security and usability. The difference is the vocabulary: we include 161 dictionary-attested Asian loanwords (verified against OED, Merriam-Webster, and Cambridge) and fill the rest with the most common, easy-to-spell English words.
+asian-diceware is a 7,776-word, EFF-compatible wordlist that works as a drop-in replacement for the EFF Large Wordlist, matching its security and usability. The difference is the vocabulary: we include 292 dictionary-attested Asian loanwords (verified against OED, Merriam-Webster, and Cambridge) and fill the rest with the most common, easy-to-spell English words.
 
 Many of these are already everyday English words anywhere, with extra resonance for anyone who grew up around Asian languages and food: `tofu`, `ramen`, `miso`, `matcha`, `karaoke`, `tsunami`, `kimchi`, `bibimbap`, `typhoon`, `oolong`, `yoga`, `karma`, `curry`, `mango`. Some carry a Sinophone flavor — `oolong`, `boba` (bubble tea, which originated in Taiwan), `ketchup` (whose root traces to Hokkien, a southern Chinese language), `pinyin`. Others you might not realize are Asian loanwords at all, like `shampoo`, `bungalow`, `jungle`, `gecko`, `bazaar`, and `guru`.
 
@@ -35,9 +35,20 @@ The wordlist is open source (code under MIT, the wordlist data under CC-BY-4.0);
 
 Looking ahead, the community also wants to build an anonymous-service platform along the lines of [AnonTicket](https://anonticket.torproject.org/){target="_blank"} (still at the planning stage), where an account is identified by a string of random words instead of an email — and this list is meant to be the word source for those codes.
 
+## Why only ~3.8%?
+
+Treat the 3.8% (292 of 7,776 words) like a beer's ABV: a deliberately chosen number, not a watered-down accident. The share is capped by how many *recognizable* Asian loanwords English has actually absorbed as single dictionary words. An exhaustive OED / Merriam-Webster / Cambridge sweep turns up roughly 330 that a Sinophone reader would recognize; 292 are pinned and about 40 are held in reserve, so the recognizable well is nearly dry.
+
+Pushing much higher (say 10%, ≈ 778 words) would force one of two things, and we want neither:
+
+- **Flooding the list with obscure words** (`puttee`, `howdah`, `nilgai`, `maund`) that most people can't spell, say, or recall. That breaks the EFF property this list exists to keep: a passphrase you can write down and read back without errors.
+- **Switching to romanized Mandarin or Zhuyin syllables.** That is a separate project — Hanyu Pinyin, Wade-Giles, and Tongyong all coexist, so spellings collide and turn ambiguous.
+
+And here is where the ABV analogy breaks down: a higher percentage does not make the passphrase stronger. Every word carries the same 12.925 bits, whether it is `tofu` or `the`. The entropy comes from the list being exactly 7,776 words with each die roll uniform, never from where the words came from. The Asian share changes flavor and recognizability, never security. So unlike beer, "higher proof" buys you nothing here, and usability wins when it conflicts with cultural coverage.
+
 ## How to use it
 
-Rolling dice against a table is the most direct way; a handful of dice plus one table is enough, no coding required. There are two ways to get the table: print the A5 booklet ([download the PDF](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.3.1.pdf){target="_blank"}; see [Print a booklet](#Print-a-booklet) below), or open the dice file [`asian_diceware_7776_dice.txt`](https://raw.githubusercontent.com/anoni-net/asian-diceware/main/output/asian_diceware_7776_dice.txt){target="_blank"} on GitHub.
+Rolling dice against a table is the most direct way; a handful of dice plus one table is enough, no coding required. There are two ways to get the table: print the A5 booklet ([download the PDF](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.4.0.pdf){target="_blank"}; see [Print a booklet](#Print-a-booklet) below), or open the dice file [`asian_diceware_7776_dice.txt`](https://raw.githubusercontent.com/anoni-net/asian-diceware/main/output/asian_diceware_7776_dice.txt){target="_blank"} on GitHub.
 
 **Method 1 — physical dice.** Roll 5 dice and read them left to right as a five-digit number (each die 1–6). The table is sorted in numeric order (from 11111 to 66666), so you can flip close to your number, or search for the line that starts with your five digits; the word after it is the one you drew. Repeat six times and join them with `-`. For example, rolling `6 3 4 4 4` reads as `63444`, which maps to `tofu`.
 
@@ -148,7 +159,7 @@ We formatted the 7,776-word list as an A5 dice-lookup booklet, complete with a c
 The wordlist is CC-BY-4.0, so anyone can print it and hand it out. When the community runs in-person events (mostly in Taiwan), we bring printed copies; if you run into us, you are welcome to say hello. See [Activity](../activity/index.md) for where we will be next, or [Stay Informed](../contact.md) for updates.
 
 !!! tip "Download the A5 booklet (PDF)"
-    [asian_diceware_7776_booklet_a5_v0.3.1.pdf](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.3.1.pdf){target="_blank"} (about 36 pages; prints on A4 or US Letter with any home or shop printer, then fold into a booklet). The wordlist data is CC-BY-4.0, so you are welcome to print, hand out, and reuse it — please keep the attribution on the colophon page.
+    [asian_diceware_7776_booklet_a5_v0.4.0.pdf](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.4.0.pdf){target="_blank"} (about 36 pages; prints on A4 or US Letter with any home or shop printer, then fold into a booklet). The wordlist data is CC-BY-4.0, so you are welcome to print, hand out, and reuse it — please keep the attribution on the colophon page.
 
 ## :material-chat-question: Related reading
 

--- a/docs/zh-CN/tools/asian-diceware.md
+++ b/docs/zh-CN/tools/asian-diceware.md
@@ -23,7 +23,7 @@ Tails 在建立加密存储时也会直接建议一组这样的密语（5.12 起
 
 ## 我们做了什么：带亚洲味的英文字典
 
-asian-diceware 是一份 7776 字、与 EFF 相容的密语词表，可以当成 EFF Large Wordlist 的直接替代品，安全性与可用性对齐。差别在用字，我们固定收录 161 个有字典背书（OED、Merriam-Webster、Cambridge 查证）的亚洲外来语，其余用最高频、好拼写的常见英文字填满。
+asian-diceware 是一份 7776 字、与 EFF 相容的密语词表，可以当成 EFF Large Wordlist 的直接替代品，安全性与可用性对齐。差别在用字，我们固定收录 292 个有字典背书（OED、Merriam-Webster、Cambridge 查证）的亚洲外来语，其余用最高频、好拼写的常见英文字填满。
 
 这些外来语对华语圈与亚洲的读者特别好认：`tofu`、`ramen`、`miso`、`matcha`、`karaoke`、`tsunami`、`kimchi`、`bibimbap`、`typhoon`、`oolong`、`yoga`、`karma`、`curry`、`mango`。其中有不少华语圈的味道：`oolong`（乌龙茶）、`boba`（珍珠奶茶，源自台湾）、`ketchup`（源头可追到闽南语）、`pinyin`（拼音）。也有一些你可能没发现是亚洲外来语的字，像 `shampoo`、`bungalow`、`jungle`、`gecko`、`bazaar`、`guru`。
 
@@ -33,9 +33,20 @@ asian-diceware 是一份 7776 字、与 EFF 相容的密语词表，可以当成
 
 社群接下来也想做一个类似 [AnonTicket](https://anonticket.torproject.org/){target="_blank"} 的匿名服务平台（还在规划阶段），账号代码就用一组随机英文字、而非 email。这份 asian-diceware 词表正是为了当未来这类服务的代码字源而准备。AnonTicket 本身如何用在与 Tor 上游协作，见 [Tor Project 生态与对接](../community/tor-project-ecosystem.md)。
 
+## 为什么亚洲外来语只占约 3.8%
+
+词表里的亚洲外来语约占 3.8%（7776 字中 292 个）。这个比例可以比照啤酒的酒精浓度（ABV）来看，是刻意挑过的数字。比例的上限取决于英语实际吸收成「单一字典词」的可辨识亚洲外来语有多少。把 OED、Merriam-Webster、Cambridge 查过一轮，华语圈读者认得出来的大约 330 个，其中 292 个纳入清单，另外约 40 个留作备援，可辨识的外来语几乎就到顶了。
+
+想再往上拉（例如 10%、约 778 个字），只会逼出两种做法，两种我们都不采用：
+
+- **拿冷僻词充数**（`puttee`、`howdah`、`nilgai`、`maund`），多数人拼不出、念不准、也记不住。这会破坏这份清单要守住的 EFF 特性，也就是抄得下来、念得回去、不容易出错。
+- **改用罗马拼音的官话或注音音节**，那属于另一个项目。华语圈用过汉语拼音、威妥玛、通用拼音几套拼法，彼此打架、容易产生歧义。
+
+酒精浓度的比喻到这里就不成立了。比例拉高，密语并不会更强。无论抽到 `tofu` 还是 `the`，每个字都带一样的 12.925 bits。强度来自清单恰好 7776 字、每次掷骰概率均匀，跟字的来源无关。亚洲外来语的比例只改变这份表的风味与好认程度，不影响安全性。所以跟啤酒不一样，这里「浓度更高」并不会多给你什么。当文化覆盖和好用性冲突时，好用性优先。
+
 ## 如何使用
 
-掷骰子查表是最直觉的方式，一把骰子加一张表就能开始，不必懂编程。要查的那张表有两种取得方式。印一本 A5 小册最方便（[直接下载 PDF](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.3.1.pdf){target="_blank"}，更多说明见下方〈[印一本小册带着走](#印一本小册带着走)〉），或直接开启 GitHub 上的 dice 档 [`asian_diceware_7776_dice.txt`](https://raw.githubusercontent.com/anoni-net/asian-diceware/main/output/asian_diceware_7776_dice.txt){target="_blank"}。
+掷骰子查表是最直觉的方式，一把骰子加一张表就能开始，不必懂编程。要查的那张表有两种取得方式。印一本 A5 小册最方便（[直接下载 PDF](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.4.0.pdf){target="_blank"}，更多说明见下方〈[印一本小册带着走](#印一本小册带着走)〉），或直接开启 GitHub 上的 dice 档 [`asian_diceware_7776_dice.txt`](https://raw.githubusercontent.com/anoni-net/asian-diceware/main/output/asian_diceware_7776_dice.txt){target="_blank"}。
 
 **方法一，用实体骰子查表：**掷 5 颗骰，由左到右读成一个五位数（每颗 1 到 6）。那张表是照代码从小到大排列的，翻到、或用搜索找到开头是你这五位数的那一行，后面接的字就是抽到的字。重复 6 次，把 6 个字用 `-` 接起来。例如掷出 `6 3 4 4 4`，读成 `63444`，查到 `tofu`。
 
@@ -146,7 +157,7 @@ asian-diceware 是一份 7776 字、与 EFF 相容的密语词表，可以当成
 社群在台湾参加工作坊、小聚、研讨会这类实体活动时，也会带几本印好的小册到现场发送。如果你在活动里拿到一本、或刚好遇到我们，非常欢迎过来聊聊，问密语、问匿名网络，或只是打声招呼都可以。想知道我们最近会出现在哪，见 [活动参与](../activity/index.md)。想直接找我们，可以到社群的 Matrix（入口见 [沟通与协作工具](../community/tools.md)），或 [持续关注](../contact.md) 我们的后续消息。
 
 !!! tip "下载 A5 小册（PDF）"
-    [asian_diceware_7776_booklet_a5_v0.3.1.pdf](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.3.1.pdf){target="_blank"}（约 36 页，用家里或便利店的打印机打印 A4、对折成册即可）。词表资料采 CC-BY-4.0，欢迎自行打印、发放与再利用，请保留版权页的出处标注。
+    [asian_diceware_7776_booklet_a5_v0.4.0.pdf](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.4.0.pdf){target="_blank"}（约 36 页，用家里或便利店的打印机打印 A4、对折成册即可）。词表资料采 CC-BY-4.0，欢迎自行打印、发放与再利用，请保留版权页的出处标注。
 
 ## :material-chat-question: 一同了解
 

--- a/docs/zh-TW/tools/asian-diceware.md
+++ b/docs/zh-TW/tools/asian-diceware.md
@@ -23,7 +23,7 @@ Tails 在建立加密儲存時也會直接建議一組這樣的密語（5.12 起
 
 ## 我們做了什麼：帶亞洲味的英文字典
 
-asian-diceware 是一份 7776 字、與 EFF 相容的密語詞表，可以當成 EFF Large Wordlist 的直接替代品，安全性與可用性對齊。差別在用字，我們固定收錄 161 個有字典背書（OED、Merriam-Webster、Cambridge 查證）的亞洲外來語，其餘用最高頻、好拼寫的常見英文字填滿。
+asian-diceware 是一份 7776 字、與 EFF 相容的密語詞表，可以當成 EFF Large Wordlist 的直接替代品，安全性與可用性對齊。差別在用字，我們固定收錄 292 個有字典背書（OED、Merriam-Webster、Cambridge 查證）的亞洲外來語，其餘用最高頻、好拼寫的常見英文字填滿。
 
 這些外來語對台灣與亞洲讀者特別好認：`tofu`、`ramen`、`miso`、`matcha`、`karaoke`、`tsunami`、`kimchi`、`bibimbap`、`typhoon`、`oolong`、`yoga`、`karma`、`curry`、`mango`。其中有不少台灣與華語圈的味道：`oolong`（烏龍茶）、`boba`（珍珠奶茶，源自台灣）、`ketchup`（源頭可追到閩南語）、`pinyin`（拼音）。也有一些你可能沒發現是亞洲外來語的字，像 `shampoo`、`bungalow`、`jungle`、`gecko`、`bazaar`、`guru`。
 
@@ -31,9 +31,20 @@ asian-diceware 是一份 7776 字、與 EFF 相容的密語詞表，可以當成
 
 這份詞表開源（程式碼採 MIT、詞表資料採 CC-BY-4.0），原始碼與完整詞表在 [GitHub anoni-net/asian-diceware](https://github.com/anoni-net/asian-diceware){target="_blank"}。詞表的功能是讓抽字這一步更好認好記，本身不涉及加密。真正的安全來自你如何產生、保管與使用密語。
 
+## 為什麼亞洲外來語只占約 3.8%
+
+詞表裡的亞洲外來語約占 3.8%（7776 字中 292 個）。這個比例可以比照啤酒的酒精濃度（ABV）來看，是刻意挑過的數字。比例的上限取決於英語實際吸收成「單一字典詞」的可辨識亞洲外來語有多少。把 OED、Merriam-Webster、Cambridge 查過一輪，台灣與華語圈讀者認得出來的大約 330 個，其中 292 個納入清單，另外約 40 個留作備援，可辨識的外來語幾乎就到頂了。
+
+想再往上拉（例如 10%、約 778 個字），只會逼出兩種做法，兩種我們都不採用：
+
+- **拿冷僻詞充數**（`puttee`、`howdah`、`nilgai`、`maund`），多數人拼不出、唸不準、也記不住。這會破壞這份清單要守住的 EFF 特性，也就是抄得下來、唸得回去、不容易出錯。
+- **改用羅馬拼音的官話或注音音節**，那屬於另一個專案。台灣同時有漢語拼音、威妥瑪、通用拼音幾套拼法，彼此打架、容易產生歧義。
+
+酒精濃度的比喻到這裡就不成立了。比例拉高，密語並不會更強。無論抽到 `tofu` 還是 `the`，每個字都帶一樣的 12.925 bits。強度來自清單恰好 7776 字、每次擲骰機率均勻，跟字的來源無關。亞洲外來語的比例只改變這份表的風味與好認程度，不影響安全性。所以跟啤酒不一樣，這裡「濃度更高」並不會多給你什麼。當文化覆蓋和好用性衝突時，好用性優先。
+
 ## 如何使用
 
-擲骰子查表是最直覺的方式，一把骰子加一張表就能開始，不必懂程式。要查的那張表有兩種取得方式。印一本 A5 小冊最方便（[直接下載 PDF](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.3.1.pdf){target="_blank"}，更多說明見下方〈[印一本小冊帶著走](#印一本小冊帶著走)〉），或直接開啟 GitHub 上的 dice 檔 [`asian_diceware_7776_dice.txt`](https://raw.githubusercontent.com/anoni-net/asian-diceware/main/output/asian_diceware_7776_dice.txt){target="_blank"}。
+擲骰子查表是最直覺的方式，一把骰子加一張表就能開始，不必懂程式。要查的那張表有兩種取得方式。印一本 A5 小冊最方便（[直接下載 PDF](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.4.0.pdf){target="_blank"}，更多說明見下方〈[印一本小冊帶著走](#印一本小冊帶著走)〉），或直接開啟 GitHub 上的 dice 檔 [`asian_diceware_7776_dice.txt`](https://raw.githubusercontent.com/anoni-net/asian-diceware/main/output/asian_diceware_7776_dice.txt){target="_blank"}。
 
 **方法一，用實體骰子查表：**擲 5 顆骰，由左到右讀成一個五位數（每顆 1 到 6）。那張表是照代碼從小到大排列的，翻到、或用搜尋找到開頭是你這五位數的那一行，後面接的字就是抽到的字。重複 6 次，把 6 個字用 `-` 接起來。例如擲出 `6 3 4 4 4`，讀成 `63444`，查到 `tofu`。
 
@@ -144,7 +155,7 @@ asian-diceware 是一份 7776 字、與 EFF 相容的密語詞表，可以當成
 社群參加工作坊、小聚、研討會這類實體活動時，也會帶幾本印好的小冊到現場發送。如果你在活動裡拿到一本、或剛好遇到我們，非常歡迎過來聊聊，問密語、問匿名網路，或只是打聲招呼都可以。想知道我們最近會出現在哪，見 [活動參與](../activity/index.md)。想直接找我們，可以到社群的 Matrix（入口見 [社群自架服務](../community/tools.md)），或 [持續關注](../contact.md) 我們的後續消息。
 
 !!! tip "下載 A5 小冊（PDF）"
-    [asian_diceware_7776_booklet_a5_v0.3.1.pdf](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.3.1.pdf){target="_blank"}（約 36 頁，用家裡或便利商店的印表機印 A4、對折成冊即可）。詞表資料採 CC-BY-4.0，歡迎自行列印、發放與再利用，請保留版權頁的出處標註。
+    [asian_diceware_7776_booklet_a5_v0.4.0.pdf](https://assets.anoni.net/file/asian_diceware_7776_booklet_a5_v0.4.0.pdf){target="_blank"}（約 36 頁，用家裡或便利商店的印表機印 A4、對折成冊即可）。詞表資料採 CC-BY-4.0，歡迎自行列印、發放與再利用，請保留版權頁的出處標註。
 
 ## 我們想做的匿名服務平台
 


### PR DESCRIPTION
## 變更

把 `tools/asian-diceware`（zh-TW / zh-CN / en）同步到 asian-diceware v0.4：

- **A5 小冊 PDF 連結改為 v0.4.0**：〈如何使用〉內嵌下載連結與〈印一本小冊帶著走〉的 tip box 都改成 `asian_diceware_7776_booklet_a5_v0.4.0.pdf`。檔案已上傳並驗證可下載（HTTP 200、application/pdf、約 228 KB）。
- **新增「為什麼只有 ~3.8%（酒精濃度比喻）」章節**：移植自 asian-diceware README 的 v0.4 內容，說明亞洲外來語占比的設計取捨，並點明比例高低不影響密語強度（熵來自 7776 字均勻抽樣，與字的來源無關）。
- **固定收錄外來語數量 161 → 292**：對齊 v0.4 詞表擴充，與新章節引用的 292 一致。

## 語系框架

- zh-TW 為 single source of truth。
- zh-CN 維持華語圈去地理化框架（華語圈讀者、華語圈用過幾套拼音）。
- en 去台灣中心（a Sinophone reader），保留英文破折號排版。

## 檢查

- `tools/docs_style_lint.py` 三檔皆 0 error、0 warn。
- v0.4.0 PDF 連結已驗證可下載。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
