### PR TITLE
docs(changelog): Tor Browser 15.0.17 與 OONI Probe 6.1.0 三語條目

### DIFF
--- a/docs/en/changelog/ooni.md
+++ b/docs/en/changelog/ooni.md
@@ -8,6 +8,19 @@ icon: material/access-point-network
 
 [OONI](https://ooni.org/){target="_blank"} Probe, Explorer, and Run release summaries. Newest at the top. Each entry links back to the full translation.
 
+## OONI Probe 6.1.0
+
+> 2026-06-25 · [Upstream announcement](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.0){target="_blank"}
+
+- Measurement engine remains on OONI Probe CLI v3.29.0.
+- Adds support for anonymous credentials, integrating the passport mechanism.
+- Desktop adds a "Run at startup" preference.
+- macOS desktop bundles and signs the JavaFX native libraries; JavaFX becomes optional for desktop distributions.
+- Desktop database access is pinned to a single dedicated thread for stability.
+- The descriptors screen gains a manual refresh button.
+- Updated translations and bumped dependencies (Kotlin, Compose, and others).
+- Various bug fixes and stability improvements.
+
 ## OONI Probe 6.0.2
 
 > 2026-05-25 · [Upstream announcement](https://github.com/ooni/probe-multiplatform/releases/tag/v6.0.2){target="_blank"}

--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -8,6 +8,15 @@ icon: simple/torbrowser
 
 Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tor Browser 15.0.17
+
+> 2026-06-28 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15017/){target="_blank"}
+
+- A small release focused on a tor security update, with no change to the Firefox base.
+- tor client updated to 0.4.9.11.
+- NoScript updated to 13.6.25.1984.
+- Build process updated boklm's GPG subkey and renewed morgan's signing key (tor-browser-build#41821, #41827).
+
 ## Tor Browser 15.0.16
 
 > 2026-06-17 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15016/){target="_blank"}

--- a/docs/zh-CN/changelog/ooni.md
+++ b/docs/zh-CN/changelog/ooni.md
@@ -8,6 +8,19 @@ icon: material/access-point-network
 
 [OONI](../tools/what-is-ooni.md) Probe、Explorer、Run 等网络审查观测工具的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## OONI Probe 6.1.0
+
+> 2026-06-25 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.0){target="_blank"}
+
+- 量测引擎维持使用 OONI Probe CLI v3.29.0。
+- 新增匿名凭证（anonymous credentials）支持，整合 passport 机制。
+- 桌面版新增「开机时启动」偏好设置。
+- macOS 桌面版打包并签署 JavaFX 原生库，JavaFX 改为桌面发行版的可选组件。
+- 桌面版数据库存取固定在单一专用线程，提升稳定性。
+- descriptors 界面新增手动刷新按钮。
+- 翻译更新，升级 Kotlin、Compose 等依赖项目。
+- 多项 bug 修正与稳定性提升。
+
 ## OONI Probe 6.0.2
 
 > 2026-05-25 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.0.2){target="_blank"}

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -8,6 +8,14 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon 与 Onion 服务的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tor Browser 15.0.17
+
+> 2026-06-28 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15017/){target="_blank"}
+
+- 以 tor 安全更新为主的小版本，未变动 Firefox 基底。
+- tor 客户端升至 0.4.9.11，NoScript 升至 13.6.25.1984。
+- 构建流程更新 boklm 的 GPG 子密钥与 morgan 的续期密钥（tor-browser-build#41821、#41827）。
+
 ## Tor Browser 15.0.16
 
 > 2026-06-17 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15016/){target="_blank"}

--- a/docs/zh-TW/changelog/ooni.md
+++ b/docs/zh-TW/changelog/ooni.md
@@ -8,6 +8,19 @@ icon: material/access-point-network
 
 [OONI Probe](../tools/what-is-ooni.md) 跨平台應用（Windows、macOS、Linux、Android、iOS）的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
+## OONI Probe 6.1.0
+
+> 2026-06-25 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.0){target="_blank"}
+
+- 量測引擎維持使用 OONI Probe CLI v3.29.0。
+- 新增匿名憑證（anonymous credentials）支援，整合 passport 機制。
+- 桌面版新增「開機時啟動」偏好設定。
+- macOS 桌面版打包並簽署 JavaFX 原生函式庫，JavaFX 改為桌面發行版的可選元件。
+- 桌面版資料庫存取固定在單一專用執行緒，提升穩定性。
+- descriptors 畫面新增手動重新整理按鈕。
+- 翻譯更新，並升級 Kotlin、Compose 等依賴項目。
+- 多項 bug 修正與穩定性提升。
+
 ## OONI Probe 6.0.2
 
 > 2026-05-25 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.0.2){target="_blank"}

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -8,6 +8,15 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注。
 
+## Tor Browser 15.0.17
+
+> 2026-06-28 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15017/){target="_blank"}
+
+- 以 tor 安全更新為主的小版本，未變動 Firefox 基底。
+- tor 用戶端升至 0.4.9.11。
+- NoScript 升至 13.6.25.1984。
+- 建置流程更新 boklm 的 GPG 子金鑰與 morgan 的續期金鑰（tor-browser-build#41821、#41827）。
+
 ## Tor Browser 15.0.16
 
 > 2026-06-17 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15016/){target="_blank"}


### PR DESCRIPTION
## 摘要

例行 changelog 更新巡檢（2026-06-30），補上兩個上游有新版的軟體，三語各一條，置於各檔最上方。

| 軟體 | 新版本 | 發布日 | 重點 |
|---|---|---|---|
| Tor Browser | 15.0.17 | 2026-06-28 | tor 用戶端升至 `0.4.9.11` 的安全更新、NoScript 13.6.25.1984，未動 Firefox 基底 |
| OONI Probe | 6.1.0 | 2026-06-25 | 新增匿名憑證（anonymous credentials）整合 passport、桌面版開機自啟、macOS 簽署 JavaFX 原生函式庫；引擎維持 CLI v3.29.0 |

## 變更檔案

- `zh-TW/changelog/{tor,ooni}.md`（SSOT）
- `zh-CN/changelog/{tor,ooni}.md`
- `en/changelog/{tor,ooni}.md`

## 巡檢結果（無更動者）

- Tails 7.9（2026-06-18）已是最新
- Arti 2.4.0（2026-06-01）已是最新（2.5.0 上游約 7/1 釋出，下次巡檢再補）
- Tor Browser Alpha 16.0a7 已是最新

🤖 Generated with [Claude Code](https://claude.com/claude-code)