### PR TITLE
fix(docs): en 首頁 hero 按鈕 wrap 後補垂直間距

### DIFF
--- a/docs/en/stylesheets/extra.css
+++ b/docs/en/stylesheets/extra.css
@@ -225,6 +225,16 @@ html.js-focus-visible.js body header.md-header.md-header--shadow nav.md-header__
 }
 
 /* ==========================================================================
+   .md-button — keep vertical breathing room after wrap
+   The right margin is enough on a single desktop row; add bottom margin so
+   buttons that wrap onto a second row on mobile don't stick together.
+   ========================================================================== */
+
+.md-typeset .md-button {
+  margin-bottom: 0.4rem;
+}
+
+/* ==========================================================================
    暗色模式（slate）：內文與一般文字改純白
    預設是半透明灰白（約 rgba(226, 228, 233, 0.82)），閱讀時不夠凸顯
    ========================================================================== */


### PR DESCRIPTION
## 問題

docs 首頁第一段的四個 hero 按鈕（About / Newsletter / Matrix / RSS），在小螢幕 wrap 成兩行時：

- zh-TW / zh-CN：兩行之間有垂直間距（正確）
- en：兩行黏在一起（漏修）

## 原因

`docs/en/stylesheets/extra.css` 缺少 zh-TW / zh-CN 都有的規則：

```css
.md-typeset .md-button {
  margin-bottom: 0.4rem;
}
```

當初這條「wrap 後保留垂直呼吸」的修正只加進了 zh-TW / zh-CN 的 `extra.css`，en 版沒同步到。

## 修正

在 en 的 `extra.css` 補上同一條規則（值、選擇器與另兩語系完全一致），三語系行為對齊。註解在地化為英文，貼齊 en 檔案相鄰 `.hero-icon` 區塊的風格。

僅動 CSS，未改任何 markdown 內容。

🤖 Generated with [Claude Code](https://claude.com/claude-code)