### PR TITLE
docs(changelog): 補上 Tor Browser 15.0.18 與 OONI Probe 6.1.1（三語）

### DIFF
--- a/docs/en/changelog/ooni.md
+++ b/docs/en/changelog/ooni.md
@@ -8,6 +8,17 @@ icon: material/access-point-network
 
 [OONI](https://ooni.org/){target="_blank"} Probe, Explorer, and Run release summaries. Newest at the top. Each entry links back to the full translation.
 
+## OONI Probe 6.1.1
+
+> 2026-07-07 · [Upstream announcement](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.1){target="_blank"}
+
+- Measurement engine remains on OONI Probe CLI v3.29.0.
+- Desktop adds in-app language selection, so the interface no longer has to follow the system locale.
+- Android migrates to AGP 9 and adds the ProGuard rules needed for the JNA and UniFFI bindings.
+- Database writes are now filtered before being applied, and an index was added on `Measurement.is_done`.
+- Fixed incorrect scaling of usage figures at gigabyte size.
+- Updated translations: German, Brazilian Portuguese, European Portuguese, and Turkish.
+
 ## OONI Probe 6.1.0
 
 > 2026-06-25 · [Upstream announcement](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.0){target="_blank"}

--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -8,6 +8,15 @@ icon: simple/torbrowser
 
 Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tor Browser 15.0.18
+
+> 2026-07-14 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15018/){target="_blank"}
+
+- A small release focused on Firefox security fixes.
+- The Firefox base stays at 140.12.0esr; rather than rebasing, later fixes were cherry-picked from the firefox/esr140 branch (tor-browser#45111).
+- NoScript updated to 13.6.30.1984, and Go to 1.25.12 in the build toolchain (Windows, Linux, Android).
+- Build process updated boklm's GPG subkey (tor-browser-build#41821).
+
 ## Tor Browser 16.0a8 (alpha)
 
 > 2026-07-02 · [Upstream announcement](https://blog.torproject.org/new-alpha-release-tor-browser-160a8/){target="_blank"}

--- a/docs/zh-CN/changelog/ooni.md
+++ b/docs/zh-CN/changelog/ooni.md
@@ -8,6 +8,17 @@ icon: material/access-point-network
 
 [OONI](../tools/what-is-ooni.md) Probe、Explorer、Run 等网络审查观测工具的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## OONI Probe 6.1.1
+
+> 2026-07-07 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.1){target="_blank"}
+
+- 量测引擎维持使用 OONI Probe CLI v3.29.0。
+- 桌面版新增 app 内语言切换，不必再跟着系统语系走。
+- Android 版迁移至 AGP 9，并补上 JNA 与 UniFFI 绑定所需的 ProGuard 规则。
+- 数据库改为过滤后才写入，并为 `Measurement.is_done` 加上索引。
+- 修正用量数值在 GB 级距显示错误的问题。
+- 翻译更新：德文、巴西葡萄牙文、欧洲葡萄牙文、土耳其文。
+
 ## OONI Probe 6.1.0
 
 > 2026-06-25 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.0){target="_blank"}

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -8,6 +8,15 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon 与 Onion 服务的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tor Browser 15.0.18
+
+> 2026-07-14 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15018/){target="_blank"}
+
+- 以 Firefox 安全修补为主的小版本。
+- Firefox 基底维持 140.12.0esr，改以 cherry-pick 带入 firefox/esr140 分支的后续修补（tor-browser#45111），未做 rebase。
+- NoScript 升至 13.6.30.1984，构建工具链的 Go 升至 1.25.12（Windows、Linux、Android）。
+- 构建流程更新 boklm 的 GPG 子密钥（tor-browser-build#41821）。
+
 ## Tor Browser 16.0a8（Alpha 测试通道）
 
 > 2026-07-02 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a8/){target="_blank"}

--- a/docs/zh-TW/changelog/ooni.md
+++ b/docs/zh-TW/changelog/ooni.md
@@ -8,6 +8,17 @@ icon: material/access-point-network
 
 [OONI Probe](../tools/what-is-ooni.md) 跨平台應用（Windows、macOS、Linux、Android、iOS）的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
+## OONI Probe 6.1.1
+
+> 2026-07-07 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.1){target="_blank"}
+
+- 量測引擎維持使用 OONI Probe CLI v3.29.0。
+- 桌面版新增 app 內語言切換，不必再跟著系統語系走。
+- Android 版遷移至 AGP 9，並補上 JNA 與 UniFFI 綁定所需的 ProGuard 規則。
+- 資料庫改為過濾後才寫入，並為 `Measurement.is_done` 加上索引。
+- 修正用量數值在 GB 級距顯示錯誤的問題。
+- 翻譯更新：德文、巴西葡萄牙文、歐洲葡萄牙文、土耳其文。
+
 ## OONI Probe 6.1.0
 
 > 2026-06-25 · [上游公告](https://github.com/ooni/probe-multiplatform/releases/tag/v6.1.0){target="_blank"}

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -8,6 +8,16 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注。
 
+## Tor Browser 15.0.18
+
+> 2026-07-14 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15018/){target="_blank"}
+
+- 以 Firefox 安全修補為主的小版本。
+- Firefox 基底維持 140.12.0esr，改以 cherry-pick 帶入 firefox/esr140 分支的後續修補（tor-browser#45111），未做 rebase。
+- NoScript 升至 13.6.30.1984。
+- 建置工具鏈的 Go 升至 1.25.12（Windows、Linux、Android）。
+- 建置流程更新 boklm 的 GPG 子金鑰（tor-browser-build#41821）。
+
 ## Tor Browser 16.0a8（Alpha 測試通道）
 
 > 2026-07-02 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a8/){target="_blank"}


### PR DESCRIPTION
## 摘要

例行檢查 `docs/changelog/` 追蹤的四個上游專案，補上自上次更新後的兩則新版本，zh-TW、zh-CN、en 三語系同步。

## 上游檢查結果（查核日 2026-07-15）

| 專案 | 站上原本記錄 | 上游最新 | 動作 |
|---|---|---|---|
| Tor Browser（穩定版） | 15.0.17（06-28） | **15.0.18（07-14）** | 補上 |
| Tor Browser（Alpha） | 16.0a8（07-02） | 16.0a8 | 已最新 |
| OONI Probe | 6.1.0（06-25） | **6.1.1（07-07）** | 補上 |
| Tails | 7.9.1（07-01） | 7.9.1 | 已最新 |
| Arti | 2.5.0（06-30） | 2.5.0 | 已最新 |

## 新增條目

**Tor Browser 15.0.18**（2026-07-14）：以 Firefox 安全修補為主的小版本。Firefox 基底維持 140.12.0esr，改以 cherry-pick 帶入 firefox/esr140 分支的後續修補（tor-browser#45111），未做 rebase。NoScript 升至 13.6.30.1984，Go 升至 1.25.12。tor 用戶端維持 0.4.9.11。上游未列出個別 CVE 編號。

**OONI Probe 6.1.1**（2026-07-07）：維護性釋出。桌面版新增 app 內語言切換，Android 遷移至 AGP 9 並補上 JNA/UniFFI 的 ProGuard 規則，量測引擎維持 OONI Probe CLI v3.29.0。

## 待確認

- 上游 OONI Probe 6.1.0 與 6.1.1 的 release notes 都寫「引擎 v3.29.0」，但 probe-cli 早在 2026-05-12 就釋出 v3.29.1。條目照上游宣稱寫 v3.29.0，未自行推斷。
- Arti 2.6.0 依約一個月的節奏推估落在 7 月底至 8 月初，屆時可再查。

## 驗證

- `mkdocs build` exit 0，兩頁條目確認渲染正常（僅餘既有的 libcairo 與 blog/archive git-revision 警告，與本次改動無關）。
- 已過寫作規範檢查：無「——」、「不是...而是」、「；」、全形「／」，中文段落無半形逗號。

🤖 Generated with [Claude Code](https://claude.com/claude-code)