### PR TITLE
docs(tools): 工具層索引篇數修正為 16 篇並補上 CryptPad 條目

### DIFF
--- a/docs/zh-CN/tools/index.md
+++ b/docs/zh-CN/tools/index.md
@@ -6,7 +6,7 @@ icon: material/toolbox-outline
 
 # :material-toolbox-outline: 工具层
 
-读完[概念层](../basics/index.md)后，这个分类介绍几个在匿名网络讨论中最常被提到的工具。13 篇文章按连线、环境、观测、日常基本功四个层次排列，每个层次解决一类问题，挑跟你情境相关的那一群开始读就好，不必整本看完。动工具之前可以先看 [威胁模型如何建立](../basics/threat-model.md)，确认自己在抗谁，避免「工具当答案」的误区。
+读完[概念层](../basics/index.md)后，这个分类介绍几个在匿名网络讨论中最常被提到的工具。16 篇文章按连线、环境、观测、日常基本功四个层次排列，每个层次解决一类问题，挑跟你情境相关的那一群开始读就好，不必整本看完。动工具之前可以先看 [威胁模型如何建立](../basics/threat-model.md)，确认自己在抗谁，避免「工具当答案」的误区。
 
 ## 先看这篇
 
@@ -40,9 +40,10 @@ icon: material/toolbox-outline
 
 ## 日常隐私基本功
 
-想从通讯、账号、金流先补齐基础的人，从这群开始。四篇主题各自独立，不必照顺序。
+想从通讯、协作、账号、金流先补齐基础的人，从这群开始。五篇主题各自独立，不必照顺序。
 
 - [匿名通讯工具比较](./messaging-comparison.md)：Signal、SimpleX、Session、Briar、Matrix 的端对端加密、Metadata 与身分模型差异。
+- [什么是 CryptPad](./what-is-cryptpad.md)：服务器读不到内容的在线协作办公套件，文档在浏览器端就完成加密，社区自建站点内建简体与正体中文界面。
 - [密码管理器入门](./password-manager.md)：Bitwarden、KeePassXC、1Password、Apple Passwords 的取舍，加上 TOTP、Passkey、硬件金钥。
 - [Asian Diceware 密语字典](./asian-diceware.md)：社群参考 EFF 做的 7776 字密语词表，混入亚洲外来语，教你怎么用骰子或安全随机数产生好记又够强的密语。
 - [加密货币的隐私光谱](./crypto-privacy-spectrum.md)：BTC、Monero、Zcash、稳定币的隐私差异与自管钱包、multisig。

--- a/docs/zh-TW/tools/index.md
+++ b/docs/zh-TW/tools/index.md
@@ -6,7 +6,7 @@ icon: material/toolbox-outline
 
 # :material-toolbox-outline: 工具層
 
-這個分類介紹幾個在匿名網路討論中最常被提到的工具（還沒看過[概念層](../basics/index.md)的話，可以先翻一下打底）。13 篇文章按連線、環境、觀測、日常基本功四個層次排列，每個層次解決一類問題，挑跟你情境相關的那一群開始讀就好，不必整本看完。動工具之前可以先看 [威脅模型如何建立](../basics/threat-model.md)，確認自己在抗誰，避免把工具直接當答案的誤區。
+這個分類介紹幾個在匿名網路討論中最常被提到的工具（還沒看過[概念層](../basics/index.md)的話，可以先翻一下打底）。16 篇文章按連線、環境、觀測、日常基本功四個層次排列，每個層次解決一類問題，挑跟你情境相關的那一群開始讀就好，不必整本看完。動工具之前可以先看 [威脅模型如何建立](../basics/threat-model.md)，確認自己在抗誰，避免把工具直接當答案的誤區。
 
 ## 先看這篇
 
@@ -40,9 +40,10 @@ icon: material/toolbox-outline
 
 ## 日常隱私基本功
 
-想從通訊、帳號、金流先補齊基礎的人，從這群開始。四篇主題彼此獨立，不必照順序。
+想從通訊、協作、帳號、金流先補齊基礎的人，從這群開始。五篇主題彼此獨立，不必照順序。
 
 - [匿名通訊工具比較](./messaging-comparison.md)：Signal、SimpleX、Session、Briar、Matrix 的端對端加密、Metadata 與身分模型差異。
+- [什麼是 CryptPad](./what-is-cryptpad.md)：伺服器讀不到內容的線上協作辦公套件，文件在瀏覽器端就完成加密，社群自架站台有完整正體中文介面。
 - [密碼管理器入門](./password-manager.md)：Bitwarden、KeePassXC、1Password、Apple Passwords 的取捨，加上 TOTP、Passkey、硬體金鑰。
 - [Asian Diceware 密語字典](./asian-diceware.md)：社群參考 EFF 做的 7776 字密語詞表，混入亞洲外來語，教你怎麼用骰子或安全亂數產生好記又夠強的密語。
 - [加密貨幣的隱私光譜](./crypto-privacy-spectrum.md)：BTC、Monero、Zcash、穩定幣的隱私差異與自管錢包、multisig。


### PR DESCRIPTION
## 背景

`#124`（GrapheneOS）合併後，工具層實際有 16 篇文章，但 zh-TW / zh-CN 的 `tools/index.md` 開頭仍寫「13 篇文章」。這個數字在 #124 之前就已經過期，不是該 PR 造成的。

## 變更

- zh-TW / zh-CN `tools/index.md`：「13 篇文章」改為「16 篇文章」。
- 補上遺漏的 [什麼是 CryptPad](../docs/zh-TW/tools/what-is-cryptpad.md) 條目。這篇已經在 `mkdocs.yml` / `mkdocs_cn.yml` 的 nav 內，但索引清單漏列，讀者從索引頁走不到。
- 補進「日常隱私基本功」群組，該群組導言的「四篇主題」隨之改為「五篇」，並在適用範圍加上「協作」。

## 計數說明

「16 篇」採計 `docs/<lang>/tools/` 底下的實際文章數（不含 `index.md`）。觀測層那條 onionoo MCP 連到 `community/onionoo-mcp.md`，屬跨區交叉連結，未列入工具層篇數。

## 驗證

- `tools/` 實際檔案數、索引列出條目數、內文宣稱數三者一致（16 / 16 / 16），zh-TW 與 zh-CN 皆是。
- `tools/docs_style_lint.py` 掃兩個檔案：0 error、0 warn。
- `mkdocs build`（`mkdocs.yml` 與 `mkdocs_cn.yml`）皆 exit 0，無連結類警告，產出頁確認新條目與「16 篇文章」都正確渲染。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzFgTGBpSpj7rNL1iQUsob