### PR TITLE
docs(seo): sitemap lastmod 改用 git 修改時間

### DIFF
--- a/docs/overrides/sitemap.xml
+++ b/docs/overrides/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for file in pages -%}
+    {% if not file.page.is_link and (file.page.abs_url or file.page.canonical_url) %}
+    <url>
+         <loc>{% if file.page.canonical_url %}{{ file.page.canonical_url|e }}{% else %}{{ file.page.abs_url|e }}{% endif %}</loc>
+         {%- if file.page.meta and file.page.meta.git_revision_date_localized_raw_iso_date %}
+         <lastmod>{{ file.page.meta.git_revision_date_localized_raw_iso_date }}</lastmod>
+         {%- elif file.page.update_date %}
+         <lastmod>{{ file.page.update_date }}</lastmod>
+         {%- endif %}
+    </url>
+    {%- endif -%}
+{% endfor %}
+</urlset>

--- a/docs/overrides_cn/sitemap.xml
+++ b/docs/overrides_cn/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for file in pages -%}
+    {% if not file.page.is_link and (file.page.abs_url or file.page.canonical_url) %}
+    <url>
+         <loc>{% if file.page.canonical_url %}{{ file.page.canonical_url|e }}{% else %}{{ file.page.abs_url|e }}{% endif %}</loc>
+         {%- if file.page.meta and file.page.meta.git_revision_date_localized_raw_iso_date %}
+         <lastmod>{{ file.page.meta.git_revision_date_localized_raw_iso_date }}</lastmod>
+         {%- elif file.page.update_date %}
+         <lastmod>{{ file.page.update_date }}</lastmod>
+         {%- endif %}
+    </url>
+    {%- endif -%}
+{% endfor %}
+</urlset>

--- a/docs/overrides_en/sitemap.xml
+++ b/docs/overrides_en/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for file in pages -%}
+    {% if not file.page.is_link and (file.page.abs_url or file.page.canonical_url) %}
+    <url>
+         <loc>{% if file.page.canonical_url %}{{ file.page.canonical_url|e }}{% else %}{{ file.page.abs_url|e }}{% endif %}</loc>
+         {%- if file.page.meta and file.page.meta.git_revision_date_localized_raw_iso_date %}
+         <lastmod>{{ file.page.meta.git_revision_date_localized_raw_iso_date }}</lastmod>
+         {%- elif file.page.update_date %}
+         <lastmod>{{ file.page.update_date }}</lastmod>
+         {%- endif %}
+    </url>
+    {%- endif -%}
+{% endfor %}
+</urlset>


### PR DESCRIPTION
## 為什麼

mkdocs 內建 `sitemap.xml` 模板用 `page.update_date`，那是 **build 時間**。結果每次建置全站 281 筆的 `<lastmod>` 都是同一天（今天），等於每次部署都對 Google 宣稱「所有頁都改過」。這種明顯不可靠的 lastmod 會被搜尋引擎忽略，也失去「哪幾頁真的更新了、優先重爬」的訊號。

## 改了什麼

在三語系 `custom_dir` 各放一份 `sitemap.xml` 覆寫（`overrides/`、`overrides_en/`、`overrides_cn/`），改成：

1. 優先取 `git-revision-date-localized` 外掛已提供的 `git_revision_date_localized_raw_iso_date`（每頁最後一次 commit 的日期，格式 `YYYY-MM-DD`）
2. 自動生成、無 git 紀錄的頁面（blog 彙整/分類/分頁）fallback 回原本的 `page.update_date`

外掛本來就已啟用（每個 config 的 plugins 都有），本 PR 只是把它的日期接進 sitemap。

## 驗證

三語系分別 `mkdocs build`（帶對 `DOCS_DIR` / `OVERRIDES`）皆 exit 0，`<lastmod>` 依 git 日期分佈：

| 語系 | URL 數 | 不同 lastmod 日期數 |
|---|---|---|
| zh-TW | 196 | 27 |
| en | 116 | 21 |
| zh-CN | 174 | 25 |

格式為合法 W3C date，每個 `<url>` 都有 `<lastmod>`。

## 備註

與 SEO 舊網址 redirect（另一支 PR）互相獨立，可各自審查合併。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBVmdAMyUmykeMtEHNZPLr