### PR TITLE
docs(changelog): 補上 Tor Browser 15.0.19 與 Tails 7.10（三語）

### DIFF
--- a/docs/en/changelog/tails.md
+++ b/docs/en/changelog/tails.md
@@ -8,6 +8,17 @@ icon: material/usb-flash-drive-outline
 
 [Tails](https://tails.net/){target="_blank"} operating system release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tails 7.10
+
+> 2026-07-23 · [Upstream announcement](https://tails.net/news/version_7.10/){target="_blank"}
+
+- A scheduled release introducing a new shutdown procedure and a new video player.
+- Adopts GNOME's standard shutdown procedure. The Power Off dialog now warns about unsaved documents and open applications, and shutdown completes automatically after 60 seconds. It is a bit slower in exchange for better data protection. An emergency shutdown option remains for a faster power-off.
+- The video player is now Celluloid, more modern and reliable, and it has no network access. To watch videos online, use Tor Browser or install VLC as additional software. Celluloid does not work on computers manufactured in 2011 or earlier.
+- Tor Browser updated to 15.0.19.
+- Updated some firmware to improve support for newer hardware such as graphics cards and Wi-Fi.
+- Automatic upgrades are available from Tails 7.0 or later; a manual upgrade is available if the automatic one fails. Fresh installations will erase existing Persistent Storage.
+
 ## Tails 7.9.1
 
 > 2026-07-01 · [Upstream announcement](https://tails.net/news/version_7.9.1/){target="_blank"}

--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -8,6 +8,16 @@ icon: simple/torbrowser
 
 Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tor Browser 15.0.19
+
+> 2026-07-21 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}
+
+- A small release focused on Firefox security fixes, carrying important security updates from Firefox.
+- Rebased the Firefox base onto 140.13.0esr (tor-browser#45117); desktop and Android GeckoView also moved to 140.13.0esr.
+- Backported security fixes from Firefox 153 (tor-browser#45124).
+- NoScript updated to 13.6.31.1984.
+- Reverted the earlier Funding the Commons implementation changes (tor-browser#44748).
+
 ## Tor Browser 15.0.18
 
 > 2026-07-14 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15018/){target="_blank"}

--- a/docs/zh-CN/changelog/tails.md
+++ b/docs/zh-CN/changelog/tails.md
@@ -8,6 +8,17 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 操作系统的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tails 7.10
+
+> 2026-07-23 · [上游公告](https://tails.net/news/version_7.10/){target="_blank"}
+
+- 例行排程版本，带来新的关机流程与视频播放器。
+- 改用 GNOME 标准关机流程。关机前会提醒尚未保存的文档与开启中的应用程序，并在 60 秒后自动关机。速度略慢，换来更好的数据保护。紧急关机选项仍保留，供需要快速断电时使用。
+- 视频播放器改用 Celluloid，更现代也更可靠，且不具网络访问权限。要在线看视频请改用 Tor Browser，或额外安装 VLC。此播放器不支持 2011 年（含）以前制造的电脑。
+- Tor Browser 升至 15.0.19。
+- 更新部分 firmware，改善显卡、Wi-Fi 等较新硬件的支持。
+- 可从 Tails 7.0 以后版本自动升级，若自动升级失败可改用手动升级。全新安装会清除既有的 Persistent Storage。
+
 ## Tails 7.9.1
 
 > 2026-07-01 · [上游公告](https://tails.net/news/version_7.9.1/){target="_blank"}

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -8,6 +8,16 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon 与 Onion 服务的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tor Browser 15.0.19
+
+> 2026-07-21 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}
+
+- 以 Firefox 安全修补为主的小版本，带入来自 Firefox 的重要安全更新。
+- Firefox 基底 rebase 至 140.13.0esr（tor-browser#45117），桌面版与 Android 版 GeckoView 同步升至 140.13.0esr。
+- 从 Firefox 153 backport 安全修补（tor-browser#45124）。
+- NoScript 升至 13.6.31.1984。
+- 还原先前 Funding the Commons 相关的实作变更（tor-browser#44748）。
+
 ## Tor Browser 15.0.18
 
 > 2026-07-14 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15018/){target="_blank"}

--- a/docs/zh-TW/changelog/tails.md
+++ b/docs/zh-TW/changelog/tails.md
@@ -8,6 +8,17 @@ icon: material/usb-flash-drive-outline
 
 [Tails](../tools/what-is-tails.md) 作業系統的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。
 
+## Tails 7.10
+
+> 2026-07-23 · [上游公告](https://tails.net/news/version_7.10/){target="_blank"}
+
+- 例行排程版本，帶來新的關機流程與影片播放器。
+- 改用 GNOME 標準關機流程。關機前會提醒尚未儲存的文件與開啟中的應用程式，並在 60 秒後自動關機。速度略慢，換來更好的資料保護。緊急關機選項仍保留，供需要快速斷電時使用。
+- 影片播放器改用 Celluloid，更現代也更可靠，且不具網路存取權限。要線上看影片請改用 Tor Browser，或額外安裝 VLC。此播放器不支援 2011 年（含）以前製造的電腦。
+- Tor Browser 升至 15.0.19。
+- 更新部分 firmware，改善顯示卡、Wi-Fi 等較新硬體的支援。
+- 可從 Tails 7.0 以後版本自動升級，若自動升級失敗可改用手動升級。全新安裝會清除既有的 Persistent Storage。
+
 ## Tails 7.9.1
 
 > 2026-07-01 · [上游公告](https://tails.net/news/version_7.9.1/){target="_blank"}

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -8,6 +8,16 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注。
 
+## Tor Browser 15.0.19
+
+> 2026-07-21 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}
+
+- 以 Firefox 安全修補為主的小版本，帶入來自 Firefox 的重要安全更新。
+- Firefox 基底 rebase 至 140.13.0esr（tor-browser#45117），桌面版與 Android 版 GeckoView 同步升至 140.13.0esr。
+- 從 Firefox 153 backport 安全修補（tor-browser#45124）。
+- NoScript 升至 13.6.31.1984。
+- 還原先前 Funding the Commons 相關的實作變更（tor-browser#44748）。
+
 ## Tor Browser 15.0.18
 
 > 2026-07-14 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15018/){target="_blank"}


### PR DESCRIPTION
## 摘要

對照官方上游後，changelog 補上兩筆新版本，三語（zh-TW / zh-CN / en）同步。

### Tor Browser 15.0.19（2026-07-21）
- Firefox 安全修補為主的小版本
- Firefox 基底 rebase 至 140.13.0esr、GeckoView 同步、backport Firefox 153 安全修補
- NoScript 升至 13.6.31.1984
- 還原先前 Funding the Commons 相關實作變更
- [上游公告](https://blog.torproject.org/new-release-tor-browser-15019/)

### Tails 7.10（2026-07-23）
- 改用 GNOME 標準關機流程（提醒未儲存文件、60 秒後自動關機）
- 影片播放器改用 Celluloid（無網路存取，2011 年以前電腦不支援）
- Tor Browser 升至 15.0.19、firmware 更新
- [上游公告](https://tails.net/news/version_7.10/)

### 對照結果
Arti 2.5.0、OONI Probe 6.1.1 經對照上游皆已是最新，本次無需補。

## 檔案
`tor.md` 與 `tails.md` 各三語，共 6 檔 +63 行。套用文件寫作風格（未用破折號與「；」）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)