### PR TITLE
fix(games): 英文的橋接連結接回 Snowflake

### DIFF
--- a/docs/en/games/index.md
+++ b/docs/en/games/index.md
@@ -99,7 +99,7 @@ These pages cover concepts that show up in the current works.
 
 - Anonymity and what it does not cover: [Anonymity vs privacy](../basics/anonymity-vs-privacy.md)
 - Running a relay and watching the network: [Tor relay watcher](../regional/tor-relay-watcher.md)
-- Getting through when Tor is blocked: [Set up a Tor WebTunnel bridge](../community/setup-tor-webtunnel.md)
+- Getting through when Tor is blocked: [Tor Snowflake bridges](../tools/tor-snowflake.md)
 
 ## What comes next
 

--- a/docs/zh-TW/games/onion-routing/i18n.js
+++ b/docs/zh-TW/games/onion-routing/i18n.js
@@ -85,7 +85,8 @@ const ZH_TW = {
   regionSE: '瑞典',
   sepBar: '｜',
   // 遊戲只有一份，永遠跑在 /docs/games/onion-routing/，所以 ../../ 是 /docs/。
-  // en 站沒有 what-is-tor 這三篇，改指向英文站真的有、主題也對得上的頁。
+  // en 站沒有 what-is-tor 與 ooni-asn-coverage，改指向英文站真的有、主題也對得上的頁。
+  // tor-snowflake 原本也沒有，PR #153 合併時 main 上已經補上英文版，所以接回真正對題的那篇。
   // 總覽頁是靜態 mkdocs 頁，掛 ?lang= 沒有作用，要直接連到各語系自己那份。
   docOverview: '../index.html',
   docTor: '../../tools/what-is-tor/',
@@ -163,7 +164,7 @@ const EN = {
   teachL4: 'The censor blocked every known Tor relay address at once, so you could not even reach the first hop. A bridge is an entry point that is not on any public list. Snowflake, obfs4 and WebTunnel disguise the traffic as an ordinary connection to get you into the Tor network, after which the middle and exit relays work as usual.',
   learnMoreTor: 'Further reading: anonymity vs privacy',
   learnMoreAsn: 'Further reading: watching the relay network',
-  learnMoreSnowflake: 'Further reading: setting up a WebTunnel bridge',
+  learnMoreSnowflake: 'Further reading: Tor Snowflake bridges',
 
   allClearTitle: 'All levels cleared',
   allClearLink: 'Back to Interactive for the other works',
@@ -178,7 +179,7 @@ const EN = {
   docOverview: '../../en/games/',
   docTor: '../../en/basics/anonymity-vs-privacy/',
   docAsn: '../../en/regional/tor-relay-watcher/',
-  docSnowflake: '../../en/community/setup-tor-webtunnel/',
+  docSnowflake: '../../en/tools/tor-snowflake/',
 };
 
 const ZH_CN = {


### PR DESCRIPTION
## 這是什麼

PR #153 開發期間，英文站沒有 `tools/tor-snowflake.md`，所以路由解謎第四關（橋接）的延伸閱讀只好改指 `community/setup-tor-webtunnel` 這個主題相近的替代品。#153 合併時發現 main 上已經補了英文版的 Snowflake 頁，接回真正對題的那篇。

## 改了什麼

| 位置 | 原本 | 改成 |
|------|------|------|
| `onion-routing/i18n.js` 的 `docSnowflake`（en） | `../../en/community/setup-tor-webtunnel/` | `../../en/tools/tor-snowflake/` |
| `learnMoreSnowflake`（en） | Further reading: setting up a WebTunnel bridge | Further reading: Tor Snowflake bridges |
| `docs/en/games/index.md` 延伸閱讀 | Set up a Tor WebTunnel bridge | Tor Snowflake bridges |

另外更新了 `i18n.js` 裡那句「en 站沒有 what-is-tor 這三篇」的註解。現在只剩 `what-is-tor` 與 `ooni-asn-coverage` 兩篇沒有英文版，註解不改的話會誤導後人再去找替代品。

## 驗證

- 三語共 12 條連結（延伸閱讀 3 條加回總覽 1 條，各 3 語系）在建置產物上實測全部 200
- 英文的 `docSnowflake` 現在解到 `/en/tools/tor-snowflake/`，zh-TW 與 zh-CN 不受影響
- `tools/docs_style_lint.py` 0 error、0 warn
- 建置四棵樹無非網路類警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmENQmBjZvrVE9abzz971T