### PR TITLE
feat(games): 三件作品與總覽頁補上 OG

### DIFF
--- a/docs/en/games/index.md
+++ b/docs/en/games/index.md
@@ -2,6 +2,13 @@
 title: Interactive
 description: Privacy and anonymity technology presented as 3D visuals and playable pieces. All three current works centre on Tor - a puzzle that walks you through three-hop onion routing, a live view of traffic meeting at rendezvous points, and a relay globe built from six public datasets.
 icon: material/cube-outline
+social:
+  cards: false
+og:
+  enabled: true
+  image: https://assets.anoni.net/games/tor-network.png
+  image_width: 2993
+  image_height: 1713
 ---
 
 # :material-cube-outline: Interactive

--- a/docs/zh-CN/games/index.md
+++ b/docs/zh-CN/games/index.md
@@ -2,6 +2,13 @@
 title: 互动与呈现
 description: 以 3D 影像与可操作的游戏呈现隐私与匿名技术。目前三件作品都以 Tor 为题：走一遍三跳洋葱路由的解谜、连线流量在会合点相遇的动态呈现、整合六份公开数据的全球中继地球仪。
 icon: material/cube-outline
+social:
+  cards: false
+og:
+  enabled: true
+  image: https://assets.anoni.net/games/tor-network.png
+  image_width: 2993
+  image_height: 1713
 ---
 
 # :material-cube-outline: 互动与呈现

--- a/docs/zh-TW/games/index.md
+++ b/docs/zh-TW/games/index.md
@@ -2,6 +2,13 @@
 title: 互動與呈現
 description: 以 3D 影像與可操作的遊戲呈現隱私與匿名技術。目前三件作品都以 Tor 為題：走一遍三跳洋蔥路由的解謎、連線流量在會合點相遇的動態呈現、整合六份公開資料的全球中繼地球儀。
 icon: material/cube-outline
+social:
+  cards: false
+og:
+  enabled: true
+  image: https://assets.anoni.net/games/tor-network.png
+  image_width: 2993
+  image_height: 1713
 ---
 
 # :material-cube-outline: 互動與呈現

--- a/docs/zh-TW/games/onion-rendezvous/index.html
+++ b/docs/zh-TW/games/onion-rendezvous/index.html
@@ -5,6 +5,21 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="robots" content="noindex" />
   <title>Tor 連線流量 · anoni.net</title>
+  <meta name="description" content="用發光粒子與殘影看 Tor 流量的兩種路徑：連 .onion 服務在隨機會合點相遇，連明網網站則經 3 跳出口後原路往返。relay 數、電路數、流量都能即時調整。" />
+  <!-- OG 寫死在這裡，因為這頁不經過 mkdocs 的模板。三個語系共用同一份程式，
+       抓取預覽的爬蟲不會執行 JS，所以這裡固定用預設語系 zh-TW 的文案與正規網址。 -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Tor 連線流量 · anoni.net" />
+  <meta property="og:description" content="用發光粒子與殘影看 Tor 流量的兩種路徑：連 .onion 服務在隨機會合點相遇，連明網網站則經 3 跳出口後原路往返。relay 數、電路數、流量都能即時調整。" />
+  <meta property="og:image" content="https://assets.anoni.net/games/onion-rendezvous.png" />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image:width" content="2989" />
+  <meta property="og:image:height" content="1704" />
+  <meta property="og:url" content="https://anoni.net/docs/games/onion-rendezvous/" />
+  <meta property="twitter:card" content="summary_large_image" />
+  <meta property="twitter:title" content="Tor 連線流量 · anoni.net" />
+  <meta property="twitter:description" content="用發光粒子與殘影看 Tor 流量的兩種路徑：連 .onion 服務在隨機會合點相遇，連明網網站則經 3 跳出口後原路往返。relay 數、電路數、流量都能即時調整。" />
+  <meta property="twitter:image" content="https://assets.anoni.net/games/onion-rendezvous.png" />
   <style>
     :root {
       --cyan: #00aeff; --client: #38d6ff; --service: #b98cff; --bad: #ff5a5a;

--- a/docs/zh-TW/games/onion-routing/index.html
+++ b/docs/zh-TW/games/onion-routing/index.html
@@ -5,6 +5,21 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="robots" content="noindex" />
   <title>Tor 路由解謎 · anoni.net</title>
+  <meta name="description" content="自己挑 3 個中繼組成 Tor 的 guard、middle、exit 路徑，避開被監聽的節點、把 3 跳分散到不同 ASN，遇到封鎖改走橋接。四個關卡各對應一項真實的選路考量。" />
+  <!-- OG 寫死在這裡，因為這頁不經過 mkdocs 的模板。三個語系共用同一份程式，
+       抓取預覽的爬蟲不會執行 JS，所以這裡固定用預設語系 zh-TW 的文案與正規網址。 -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Tor 路由解謎 · anoni.net" />
+  <meta property="og:description" content="自己挑 3 個中繼組成 Tor 的 guard、middle、exit 路徑，避開被監聽的節點、把 3 跳分散到不同 ASN，遇到封鎖改走橋接。四個關卡各對應一項真實的選路考量。" />
+  <meta property="og:image" content="https://assets.anoni.net/games/onion-routing.png" />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image:width" content="2990" />
+  <meta property="og:image:height" content="1706" />
+  <meta property="og:url" content="https://anoni.net/docs/games/onion-routing/" />
+  <meta property="twitter:card" content="summary_large_image" />
+  <meta property="twitter:title" content="Tor 路由解謎 · anoni.net" />
+  <meta property="twitter:description" content="自己挑 3 個中繼組成 Tor 的 guard、middle、exit 路徑，避開被監聽的節點、把 3 跳分散到不同 ASN，遇到封鎖改走橋接。四個關卡各對應一項真實的選路考量。" />
+  <meta property="twitter:image" content="https://assets.anoni.net/games/onion-routing.png" />
   <style>
     :root {
       --cyan: #00aeff; --cyan-600: #009ee6; --cyan-800: #006d99;

--- a/docs/zh-TW/games/tor-network/index.html
+++ b/docs/zh-TW/games/tor-network/index.html
@@ -5,6 +5,21 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="robots" content="noindex" />
   <title>Tor 中繼地球儀 · anoni.net</title>
+  <meta name="description" content="把全球近萬台運作中的 Tor 中繼灑進各自的國界，另外疊上連線受阻觀測、使用者估計、斷網事件與海底電纜。three.js 在瀏覽器裡跑，免安裝。" />
+  <!-- OG 寫死在這裡，因為這頁不經過 mkdocs 的模板。三個語系共用同一份程式，
+       抓取預覽的爬蟲不會執行 JS，所以這裡固定用預設語系 zh-TW 的文案與正規網址。 -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Tor 中繼地球儀 · anoni.net" />
+  <meta property="og:description" content="把全球近萬台運作中的 Tor 中繼灑進各自的國界，另外疊上連線受阻觀測、使用者估計、斷網事件與海底電纜。three.js 在瀏覽器裡跑，免安裝。" />
+  <meta property="og:image" content="https://assets.anoni.net/games/tor-network.png" />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image:width" content="2993" />
+  <meta property="og:image:height" content="1713" />
+  <meta property="og:url" content="https://anoni.net/docs/games/tor-network/" />
+  <meta property="twitter:card" content="summary_large_image" />
+  <meta property="twitter:title" content="Tor 中繼地球儀 · anoni.net" />
+  <meta property="twitter:description" content="把全球近萬台運作中的 Tor 中繼灑進各自的國界，另外疊上連線受阻觀測、使用者估計、斷網事件與海底電纜。three.js 在瀏覽器裡跑，免安裝。" />
+  <meta property="twitter:image" content="https://assets.anoni.net/games/tor-network.png" />
   <style>
     :root {
       --cyan: #00aeff; --ink: #eaf6ff; --muted: #9fb6c8;


### PR DESCRIPTION
## 這是什麼

`games/` 底下的三件作品原本完全沒有 OG，分享到社群時只有一條裸連結。總覽頁本來就有 OG，但用的是 social plugin 自動生成的卡片，這次三語都改成指定的圖。

> 這批改動原本混在 PR #156 裡，但 #156 先合併了，OG 的 commit 沒趕上，所以另外開這一支。

## 兩種做法

| 頁面 | 做法 |
|------|------|
| 三件作品的 `index.html` | 標籤寫死在 `<head>`。這三頁是獨立 HTML，不經過 mkdocs 的模板 |
| 三語總覽頁 `index.md` | front matter 的 `og:` 區塊，`overrides/main.html` 本來就支援覆蓋 |

作品那三頁是三個語系共用同一份程式，而抓取預覽的爬蟲不會執行 JS，所以固定用預設語系 zh-TW 的文案，`og:url` 指向沒有語系區段的正規網址。

## 一個踩到的坑

用 front matter 覆蓋之後，social plugin **仍然會再輸出一組自己的 `og:image`**，一頁出現兩個標籤。爬蟲遇到重複的行為不一致，Facebook 取第一個、有些取最後一個。加上 `social: cards: false` 關掉這頁的自動卡片，讓 front matter 的覆蓋成為唯一來源。

## 圖片尺寸

`og:image:width/height` 填的是各圖的**實際尺寸**，不是理想的 `1200x630`。填錯的話爬蟲會照宣告的比例裁切。

| 作品 | 尺寸 | 比例 |
|------|------|------|
| tor-network | `2993x1713` | 1.75:1 |
| onion-routing | `2990x1706` | 1.75:1 |
| onion-rendezvous | `2989x1704` | 1.75:1 |

三張都是 1.75:1，而 Facebook 與 X 以 1.91:1 呈現，上下會被裁掉一些。如果圖的重點靠近上下邊緣，之後可以考慮重新輸出成 `1200x630`。

## 驗證

- 六個頁面（三件作品加三語總覽頁）的 `og:image` **各只有一個**
- 三張圖實測 HTTP 200
- 三件作品加了 meta 之後實跑 **0 JS 錯誤**
- 三語建置無新增警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmENQmBjZvrVE9abzz971T