### PR TITLE
ci(docs): 快取 privacy 外掛的外部資產，止住反覆的建置失敗

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -35,6 +35,27 @@ jobs:
         run: uv sync --group=dev
       - name: Show packages
         run: uv tree
+      # mkdocs-material 的 privacy 外掛會把外部資產下載到
+      # docs/.cache/plugin/privacy/assets/external/<host>/。**下載失敗時它仍然會把該檔
+      # 登記進 files**，之後 copy_static_files 找不到檔案就丟 FileNotFoundError，整個
+      # 建置失敗。外掛本身沒有重試，而 .cache 既不在版控也沒進 CI 快取，等於每次建置
+      # 都要重新對十幾個外部主機碰運氣。2026-07 就因為 interseclab.org 與
+      # search.anoni.net 各失敗一次，兩次都不是內容有問題。
+      #
+      # 把這個目錄快取起來，上一次成功下載的檔案就會留著，單一主機的暫時性故障不再
+      # 拖垮建置。只快取 privacy 一個子目錄（約 45 MB），social 外掛的字型與卡片
+      # （約 177 MB）不含在內，那部分是可重算的，也不是失敗來源。
+      #
+      # 注意：快取全新或被 LRU 淘汰時（首次建置、長期沒跑）仍然要重新下載，
+      # 那種情況下這層保護不存在。要根治得把外部圖片鏡像到 assets.anoni.net。
+      - name: Cache privacy plugin external assets
+        uses: actions/cache@v4
+        with:
+          path: docs/.cache/plugin/privacy
+          key: mkdocs-privacy-${{ github.sha }}
+          restore-keys: |
+            mkdocs-privacy-
+
       - name: Install mkdocs-material social dependencies
         run: sudo apt-get install libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
       - name: Build Docs (/)


### PR DESCRIPTION
## 問題

`mkdocs-material` 的 `privacy` 外掛會把外部資產下載到 `docs/.cache/plugin/privacy/assets/external/<host>/`。

**下載失敗時它仍然會把該檔登記進 `files`**，之後 `copy_static_files` 找不到檔案就丟 `FileNotFoundError`，整個建置失敗。外掛本身沒有重試。

而 `.cache` 既不在版控也沒進 CI 快取，等於**每次建置都要對十幾個外部主機重新碰運氣**。

2026-07 就掛了兩次：

| 失敗主機 | 與內容變更有關？ |
|---|---|
| `interseclab.org` | 否 |
| `search.anoni.net` | 否 |

兩次都不是內容有問題，重跑就過了。這種失敗會消耗信任，久了大家會習慣性重跑而不看原因。

## 目前依賴的外部主機

`docs/.cache/plugin/privacy/assets/external/` 底下有 16 個主機、146 個檔案：

```
assets.anoni.net      70 個  36M      ooni.org               8 個  3.4M
fonts.gstatic.com     30 個  892K     tails.net              6 個  270K
cdn.jsdelivr.net      13 個  592K     forum.torproject.org   6 個  984K
www.sambent.com        3 個  389K     interseclab.org        2 個  619K
unpkg.com              1 個  1.6M     assets.kktix.io        1 個  1.3M
vega.github.io         1 個   84K     blog.torproject.org    1 個   51K
search.anoni.net       1 個   50K     github.com             1 個   22K
images.anoni.net       1 個   26K     fonts.googleapis.com   1 個   15K
```

任何一個暫時性故障都會讓整份建置失敗。

## 做法

加一個 `actions/cache`，只快取 `docs/.cache/plugin/privacy`。

用 `restore-keys` 做前綴回退，所以永遠會取回最近一次的快取，語意是「留住上次成功下載的檔案」。單一主機暫時掛掉時，用上次的檔案繼續，建置不受影響。

### 為什麼不整包快取 `docs/.cache`

整個目錄是 **222 MB**，其中 **177 MB 是 social 外掛的字型與產生的卡片**。那部分可重算、內容一變就失效、而且不是失敗來源。只快取 privacy 的 **46 MB**，快取才不會每次都churn。

## 這不是根治

快取全新或被 LRU 淘汰時（首次建置、長期沒跑）仍然要重新下載，那種情況下這層保護不存在。

要根治得把外部圖片鏡像到 `assets.anoni.net`（已經有 70 個檔案在那裡，機制是現成的），或是在 `assets_exclude` 排除不穩定的主機。那是另一個工作，先把反覆失敗止住。

## 驗證

- YAML 可解析，步驟數 17，新步驟落在 `Show packages` 與 social 依賴安裝之間，在所有建置步驟之前
- 快取路徑 `docs/.cache/plugin/privacy` 實測 46 MB
- 沒有動到任何建置指令與上傳邏輯

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmENQmBjZvrVE9abzz971T
