### PR TITLE
fix(docs): figure 說明文字統一用 figcaption，清掉 54 處無效的 capture 標籤

### DIFF
--- a/docs/en/basics/internet-freedom.md
+++ b/docs/en/basics/internet-freedom.md
@@ -41,7 +41,7 @@ Conditions across the region vary widely. Even in jurisdictions counted as relat
             title="Freedom House — Freedom on the Net interactive map"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <capture>Freedom House — Freedom on the Net interactive map (illustrative snapshot; live data and country chapters on freedomhouse.org)</capture>
+    <figcaption>Freedom House — Freedom on the Net interactive map (illustrative snapshot; live data and country chapters on freedomhouse.org)</figcaption>
 </figure>
 
 ## Southeast Asia
@@ -63,7 +63,7 @@ Open, verifiable measurement makes regional framing concrete. [OONI](https://oon
             title="OONI Explorer — circumvention tools (CN, HK, TW illustrative)"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <capture>OONI Explorer — circumvention-tool reachability across CN, HK, TW (illustrative; live data on the OONI site)</capture>
+    <figcaption>OONI Explorer — circumvention-tool reachability across CN, HK, TW (illustrative; live data on the OONI site)</figcaption>
 </figure>
 
 [Tor](https://www.torproject.org/){target="_blank"} provides anonymous, multi-hop routing and a relay-and-bridge network that helps users maintain connection in high-pressure environments. The relay network is a decentralized volunteer infrastructure, and Tor Metrics exposes per-country relay and guard counts.
@@ -75,7 +75,7 @@ Open, verifiable measurement makes regional framing concrete. [OONI](https://oon
             title="Tor Metrics — Taiwan-region relays and guard nodes"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <capture>Tor Metrics — Taiwan-region relays and guard nodes (the Sinophone-region anchor where this community works; illustrative snapshot)</capture>
+    <figcaption>Tor Metrics — Taiwan-region relays and guard nodes (the Sinophone-region anchor where this community works; illustrative snapshot)</figcaption>
 </figure>
 
 Beyond consuming this data, anoni.net runs the [Pulse](https://github.com/anoni-net/docs/tree/main/pulse){target="_blank"} system to track Tor relay distribution across Taiwan, Hong Kong, Japan, and South Korea, and the [ASN coverage](https://github.com/anoni-net/docs/tree/main/asn_coverage){target="_blank"} tooling to map OONI observation completeness across regional autonomous systems. Both are intended to feed the cross-region comparisons being assembled on the [Regional Observatory](../regional/index.md), which is in active drafting.

--- a/docs/en/blog/posts/2026-onionoo-mcp-public.md
+++ b/docs/en/blog/posts/2026-onionoo-mcp-public.md
@@ -49,7 +49,7 @@ Once connected, you can ask the agent the following sorts of questions in plain 
             title="Claude Desktop's Taiwan Tor relay summary"
             class="brand-frame">
     </a>
-    <capture>Claude Desktop connected to onionoo MCP, replying to "Summarize Taiwan's Tor relays" with a structured report. The numbers come from upstream Onionoo and represent a point-in-time snapshot.</capture>
+    <figcaption>Claude Desktop connected to onionoo MCP, replying to "Summarize Taiwan's Tor relays" with a structured report. The numbers come from upstream Onionoo and represent a point-in-time snapshot.</figcaption>
 </figure>
 
 The pre-MCP version of this workflow meant skimming the Onionoo docs, writing a script, merging JSON, and formatting a table. A single sentence now gets you to a first-cut answer, and the cost of starting a piece of research drops sharply.

--- a/docs/en/blog/posts/updates-202508.md
+++ b/docs/en/blog/posts/updates-202508.md
@@ -60,7 +60,7 @@ Given the limited number of servers available in Asia on the current [public ser
             title="Tor Relay Types"
         >
     </a>
-    <caption>Tor Relay Types</caption>
+    <figcaption>Tor Relay Types</figcaption>
 </figure>
 
 WebTunnel is one type of Tor bridge that assists users in connecting to the Onion routing network when they can't directly access it. WebTunnel acts as a proxy server to relay connections. Since [Tails 6.18 version](https://tails.net/news/version_6.18/){target="_blank"}, it also added support for connecting via WebTunnel bridges. Due to the critical role of bridge points, connection parameters are not readily available on the Tor official website and need to be [requested](https://bridges.torproject.org/){target="_blank"} directly.

--- a/docs/en/community/onionoo-mcp.md
+++ b/docs/en/community/onionoo-mcp.md
@@ -17,7 +17,7 @@ The first half of this page is for people who want to look up data but don't wri
             title="Claude Desktop's summary of Taiwan's current Tor footprint"
             class="brand-frame">
     </a>
-    <capture>What you get back: ask in plain language, and the assistant returns a tidy report (running relay count, total bandwidth, top networks). The underlying numbers come from the Tor Project's public data; this is a point-in-time snapshot that shifts as the network evolves.</capture>
+    <figcaption>What you get back: ask in plain language, and the assistant returns a tidy report (running relay count, total bandwidth, top networks). The underlying numbers come from the Tor Project's public data; this is a point-in-time snapshot that shifts as the network evolves.</figcaption>
 </figure>
 
 ## What it can answer for you
@@ -58,7 +58,7 @@ If you are on a company or team (Team or Enterprise) account, usually only an ac
             title="The Connectors panel after pasting the URL"
             class="brand-frame">
     </a>
-    <capture>Once added, the Connectors panel shows the <code>onionoo</code> custom connector and the query tools it provides. The assistant picks the tools itself — you just ask in plain language.</capture>
+    <figcaption>Once added, the Connectors panel shows the <code>onionoo</code> custom connector and the query tools it provides. The assistant picks the tools itself — you just ask in plain language.</figcaption>
 </figure>
 
 ## Questions you can copy and paste
@@ -124,7 +124,7 @@ The service does **not** store any Onionoo data. It only forwards requests and r
             title="Swagger UI for onionoo.anoni.net"
             class="brand-frame">
     </a>
-    <capture>The Swagger UI at <code>onionoo.anoni.net/docs</code>. Every <code>/v1/*</code> endpoint has a full schema and a Try-it-out button for ad-hoc testing.</capture>
+    <figcaption>The Swagger UI at <code>onionoo.anoni.net/docs</code>. Every <code>/v1/*</code> endpoint has a full schema and a Try-it-out button for ad-hoc testing.</figcaption>
 </figure>
 
 ### Why this service
@@ -255,7 +255,7 @@ The agent breaks the question into a handful of MCP tool calls and assembles a s
             title="Claude Opus 4.7's expanded tool-use trace"
             class="brand-frame">
     </a>
-    <capture>The agent narrates its plan — what to query, which tool to pick, what to do with the response — with the actual <code>aggregate_countries</code> and <code>get_details</code> tool calls inlined. The full MCP interaction is visible, which makes debugging and prompt tuning much easier.</capture>
+    <figcaption>The agent narrates its plan — what to query, which tool to pick, what to do with the response — with the actual <code>aggregate_countries</code> and <code>get_details</code> tool calls inlined. The full MCP interaction is visible, which makes debugging and prompt tuning much easier.</figcaption>
 </figure>
 
 ### Observability and operations

--- a/docs/zh-CN/basics/internet-freedom.md
+++ b/docs/zh-CN/basics/internet-freedom.md
@@ -35,7 +35,7 @@ icon: material/chat-question
             title="Freedom House Freedom on the Net 互动地图"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <capture>Freedom House「Freedom on the Net」互动地图（各国分数随年度报告更新，画面为站内示意截图）</capture>
+    <figcaption>Freedom House「Freedom on the Net」互动地图（各国分数随年度报告更新，画面为站内示意截图）</figcaption>
 </figure>
 
 ## 东南亚
@@ -57,7 +57,7 @@ icon: material/chat-question
             title="OONI Explorer：规避工具观测（CN, HK, TW 范例）"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <capture>OONI Explorer：规避工具观测（画面为站内保留之示意截图，区间与数据以网站为准）</capture>
+    <figcaption>OONI Explorer：规避工具观测（画面为站内保留之示意截图，区间与数据以网站为准）</figcaption>
 </figure>
 
 [Tor](https://www.torproject.org/){target="_blank"} 则透过多层路由与中继网络，协助使用者在高风险环境下维持匿名与连线。Tor 中继是去中心化的志愿基础建设，可从 Tor Metrics 逐国查询分布状况。下图是台湾节点分布范例（anoni.net 社群所在地），其他国家或地区可在同一介面切换查看。
@@ -69,7 +69,7 @@ icon: material/chat-question
             title="Tor Metrics：台湾地区 Tor 中继与守护节点"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 0%);">
     </a>
-    <capture>Tor Metrics：台湾地区中继与守护节点（画面随网络状态变动）</capture>
+    <figcaption>Tor Metrics：台湾地区中继与守护节点（画面随网络状态变动）</figcaption>
 </figure>
 
 无论是执行 OONI 测试、架设 Tor 中继，或协助翻译与教学，都是在具体支撑网络自由。在香港这类国安监控升高的地区，公开架设或宣传 Tor 中继的政治风险与台湾不同，参与前应按在地处境分开评估。你可以从下方项目列表挑一项开始。

--- a/docs/zh-CN/blog/posts/2025-probe-security-without-identification.md
+++ b/docs/zh-CN/blog/posts/2025-probe-security-without-identification.md
@@ -27,7 +27,7 @@ description: "OONI 预计实施匿名凭证以减缓虚假观测数据对观测�
             title="Security without identification: transaction systems to make big brother obsolete"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <capture>在他那篇具有开创性的论文《[没有身份识别的安全性：使老大哥过时的交易系统](https://dl.acm.org/doi/10.1145/4372.4373){target="_blank"}》中，Chaum 构想了一个用户可以使用单一数字钱包匿名与多个组织互动的未来，即使这些组织互相勾结。</capture>
+    <figcaption>在他那篇具有开创性的论文《[没有身份识别的安全性：使老大哥过时的交易系统](https://dl.acm.org/doi/10.1145/4372.4373){target="_blank"}》中，Chaum 构想了一个用户可以使用单一数字钱包匿名与多个组织互动的未来，即使这些组织互相勾结。</figcaption>
 </figure>
 
 为了提升 OONI 观测数据的可信度，并防止故意或无意上传的错误测量结果对 OONI 数据库的影响，我们正在考虑在 OONI Probe 中设计和实施匿名凭证。在这篇文章中，我们提供了匿名凭证的现有文献回顾。这是为了让对密码学领域不太熟悉但又好奇的读者能够深入了解其所依据的协议。
@@ -126,7 +126,7 @@ OONI 的基础设施相当特殊：用户上传的隐私在网络层级和应用
             title="匿名凭证在理论密码学中的全貌，以及 OONI 的定位。"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <capture>匿名凭证在理论密码学中的全貌，以及 OONI 的定位。</capture>
+    <figcaption>匿名凭证在理论密码学中的全貌，以及 OONI 的定位。</figcaption>
 </figure>
 
 在文献之外，观察**当前部署凭证的生态系统**，从成熟的老牌公司到新兴的早期区块链项目，可以看到以下三种类型：

--- a/docs/zh-CN/blog/posts/2026-onionoo-mcp-public.md
+++ b/docs/zh-CN/blog/posts/2026-onionoo-mcp-public.md
@@ -49,7 +49,7 @@ Onionoo 的规范本身完整，但对 AI 代理来说有三个门槛。
             title="Claude Desktop 整理出的台湾 Tor 中继节点现况报告"
             class="brand-frame">
     </a>
-    <capture>Claude Desktop 接上 onionoo MCP 后，请模型「整理台湾 Tor 中继节点现况」回出的汇整报告。底层数值来自上游 Onionoo，这是某一时点的 snapshot。</capture>
+    <figcaption>Claude Desktop 接上 onionoo MCP 后，请模型「整理台湾 Tor 中继节点现况」回出的汇整报告。底层数值来自上游 Onionoo，这是某一时点的 snapshot。</figcaption>
 </figure>
 
 这类查询以往要先翻 Onionoo 文件、写脚本、合并 JSON、再整理表格，现在一句话就能取得初步结果。盘点完再决定下一步要往哪钻，研究启动的成本差很多。

--- a/docs/zh-CN/community/onionoo-mcp.md
+++ b/docs/zh-CN/community/onionoo-mcp.md
@@ -17,7 +17,7 @@ icon: material/api
             title="AI 助手整理出的台湾 Tor 中继节点现况报告"
             class="brand-frame">
     </a>
-    <capture>你会取得的东西：问一句中文，AI 助手回一份整理好的报告（运行中节点数、总带宽、前五大电信网络）。底层数值来自 Tor Project 官方数据，这是查询当下的快照，会随时间变动。</capture>
+    <figcaption>你会取得的东西：问一句中文，AI 助手回一份整理好的报告（运行中节点数、总带宽、前五大电信网络）。底层数值来自 Tor Project 官方数据，这是查询当下的快照，会随时间变动。</figcaption>
 </figure>
 
 ## 它能帮你回答什么
@@ -58,7 +58,7 @@ icon: material/api
             title="在 Connectors 设置页贴上网址后的样子"
             class="brand-frame">
     </a>
-    <capture>加好之后，Connectors 页会出现 <code>onionoo</code> 这个自定义连接器，底下是它提供的查询工具。AI 助手会自己挑工具，你只要用中文问就好。</capture>
+    <figcaption>加好之后，Connectors 页会出现 <code>onionoo</code> 这个自定义连接器，底下是它提供的查询工具。AI 助手会自己挑工具，你只要用中文问就好。</figcaption>
 </figure>
 
 ## 可以直接复制的问句
@@ -124,7 +124,7 @@ icon: material/api
             title="onionoo.anoni.net 的 Swagger UI"
             class="brand-frame">
     </a>
-    <capture><code>onionoo.anoni.net/docs</code> 的 Swagger UI 入口，所有 <code>/v1/*</code> 端点都有完整 schema 与「Try it out」可即时测试。</capture>
+    <figcaption><code>onionoo.anoni.net/docs</code> 的 Swagger UI 入口，所有 <code>/v1/*</code> 端点都有完整 schema 与「Try it out」可即时测试。</figcaption>
 </figure>
 
 ### 为什么做这个服务
@@ -255,7 +255,7 @@ docker compose up -d --build
             title="Claude Opus 4.7 的工具调用展开过程"
             class="brand-frame">
     </a>
-    <capture>展开模型侧的推理，可以看到代理一步一步说出要查什么、选哪个工具、结果回来后下一步要做什么。文字之间夹着实际的 <code>aggregate_countries</code>、<code>get_details</code> 工具调用，方便调试或微调 prompt。</capture>
+    <figcaption>展开模型侧的推理，可以看到代理一步一步说出要查什么、选哪个工具、结果回来后下一步要做什么。文字之间夹着实际的 <code>aggregate_countries</code>、<code>get_details</code> 工具调用，方便调试或微调 prompt。</figcaption>
 </figure>
 
 ### 观测指标与运维

--- a/docs/zh-CN/tools/onionshare.md
+++ b/docs/zh-CN/tools/onionshare.md
@@ -34,7 +34,7 @@ icon: material/share-circle
             title="OnionShare 主视窗的四个模式分页"
             class="brand-frame">
     </a>
-    <capture>OnionShare 主视窗的四个模式分页，从左到右分别是 Share Files、Receive Files、Host a Website、Chat Anonymously。</capture>
+    <figcaption>OnionShare 主视窗的四个模式分页，从左到右分别是 Share Files、Receive Files、Host a Website、Chat Anonymously。</figcaption>
 </figure>
 
 ### Send（送档）
@@ -51,7 +51,7 @@ icon: material/share-circle
             title="OnionShare Send 模式产生 .onion URL 与 private key"
             class="brand-frame">
     </a>
-    <capture>Send 模式启动分享后，OnionShare 会产生 .onion 网址与 private key。把网址跟 private key 透过不同安全管道交给对方，可避免中间人替换。</capture>
+    <figcaption>Send 模式启动分享后，OnionShare 会产生 .onion 网址与 private key。把网址跟 private key 透过不同安全管道交给对方，可避免中间人替换。</figcaption>
 </figure>
 
 <figure markdown="span">
@@ -61,7 +61,7 @@ icon: material/share-circle
             title="接收方在 Tor Browser 看到的 OnionShare 下载页"
             class="brand-frame">
     </a>
-    <capture>接收方取得 .onion 网址后，在 Tor Browser 开启看到的是默认的下载页面，外观像一般静态网站，不必额外学习。</capture>
+    <figcaption>接收方取得 .onion 网址后，在 Tor Browser 开启看到的是默认的下载页面，外观像一般静态网站，不必额外学习。</figcaption>
 </figure>
 
 ### Receive（收档）

--- a/docs/zh-CN/tools/password-manager.md
+++ b/docs/zh-CN/tools/password-manager.md
@@ -49,7 +49,7 @@ icon: material/key-variant
             title="KeePassXC 主画面显示密钥库项目列表"
             class="brand-frame">
     </a>
-    <capture>KeePassXC 主画面显示密钥库项目列表（图片来源：<a href="https://keepassxc.org/docs/" target="_blank">KeePassXC 官方文件</a>）</capture>
+    <figcaption>KeePassXC 主画面显示密钥库项目列表（图片来源：<a href="https://keepassxc.org/docs/" target="_blank">KeePassXC 官方文件</a>）</figcaption>
 </figure>
 
 ### 云端同步：Bitwarden
@@ -98,7 +98,7 @@ iOS 18 与 macOS Sequoia 起，Apple 把密码功能独立成 [Passwords](https:
             title="Bitwarden 为账号设定 TOTP authenticator 的画面"
             class="brand-frame">
     </a>
-    <capture>Bitwarden 为账号设定 TOTP authenticator 的画面（图片来源：<a href="https://bitwarden.com/help/integrated-authenticator/" target="_blank">Bitwarden 官方说明</a>）</capture>
+    <figcaption>Bitwarden 为账号设定 TOTP authenticator 的画面（图片来源：<a href="https://bitwarden.com/help/integrated-authenticator/" target="_blank">Bitwarden 官方说明</a>）</figcaption>
 </figure>
 
 ## Passkeys：取代密码的新方案

--- a/docs/zh-CN/tools/tor-browser-advanced.md
+++ b/docs/zh-CN/tools/tor-browser-advanced.md
@@ -30,7 +30,7 @@ Tor Browser 11.5 起，**Connection Assist**[^1] 达到稳定版本：侦测你�
             title="Tor Browser 的 Connection Assist 与桥接设定"
             class="brand-frame">
     </a>
-    <capture>Tor Browser 的 Connection Assist 与桥接设定（详见 <a href="https://support.torproject.org/zh-CN/bridges/" target="_blank">Tor 官方说明：桥接</a>）</capture>
+    <figcaption>Tor Browser 的 Connection Assist 与桥接设定（详见 <a href="https://support.torproject.org/zh-CN/bridges/" target="_blank">Tor 官方说明：桥接</a>）</figcaption>
 </figure>
 
 ## 安全等级（Security Level）
@@ -50,7 +50,7 @@ Tor Browser 提供三段安全等级，从网址列旁的盾牌图示点开「Ch
             title="Tor Browser Security Level slider 的三段选项"
             class="brand-frame">
     </a>
-    <capture>Tor Browser Security Level slider 的三段选项（详见 <a href="https://support.torproject.org/zh-CN/security-settings/" target="_blank">Tor 官方说明：安全性等级</a>）</capture>
+    <figcaption>Tor Browser Security Level slider 的三段选项（详见 <a href="https://support.torproject.org/zh-CN/security-settings/" target="_blank">Tor 官方说明：安全性等级</a>）</figcaption>
 </figure>
 
 ## 身份隔离：New Identity 与 New Tor Circuit
@@ -74,7 +74,7 @@ Tor Browser 默认启用 First Party Isolation，每个分页的 cookies、cache
             title="Tor Browser 汉堡选单显示 New Identity 与 New Tor Circuit for this Site"
             class="brand-frame">
     </a>
-    <capture>Tor Browser 汉堡选单显示 New Identity 与 New Tor Circuit for this Site（详见 <a href="https://support.torproject.org/zh-CN/managing-identities/" target="_blank">Tor 官方说明：管理身份</a>）</capture>
+    <figcaption>Tor Browser 汉堡选单显示 New Identity 与 New Tor Circuit for this Site（详见 <a href="https://support.torproject.org/zh-CN/managing-identities/" target="_blank">Tor 官方说明：管理身份</a>）</figcaption>
 </figure>
 
 ## Tor Circuit 检视
@@ -94,7 +94,7 @@ Tor Browser 默认启用 First Party Isolation，每个分页的 cookies、cache
             title="Tor Browser 显示当前 Tor Circuit 的三层中继节点与所在国家"
             class="brand-frame">
     </a>
-    <capture>Tor Browser 显示当前 Tor Circuit 的三层中继节点与所在国家（详见 <a href="https://support.torproject.org/zh-CN/managing-identities/" target="_blank">Tor 官方说明：管理身份</a>）</capture>
+    <figcaption>Tor Browser 显示当前 Tor Circuit 的三层中继节点与所在国家（详见 <a href="https://support.torproject.org/zh-CN/managing-identities/" target="_blank">Tor 官方说明：管理身份</a>）</figcaption>
 </figure>
 
 ## Onion 站点偏好
@@ -116,7 +116,7 @@ Tor Browser 默认启用 First Party Isolation，每个分页的 cookies、cache
             title="Tor Browser 对 .onion-Location 的提示与 onion 站点偏好设定"
             class="brand-frame">
     </a>
-    <capture>Tor Browser 对 .onion-Location 的提示与 onion 站点偏好设定（详见 <a href="https://support.torproject.org/zh-CN/onion-services/" target="_blank">Tor 官方说明：洋葱服务</a>）</capture>
+    <figcaption>Tor Browser 对 .onion-Location 的提示与 onion 站点偏好设定（详见 <a href="https://support.torproject.org/zh-CN/onion-services/" target="_blank">Tor 官方说明：洋葱服务</a>）</figcaption>
 </figure>
 
 ## 指纹抗性与视窗大小

--- a/docs/zh-CN/tools/what-is-tails.md
+++ b/docs/zh-CN/tools/what-is-tails.md
@@ -30,7 +30,7 @@ Tails 真正的价值在三个刻意的设计选择所组合出来的工作环�
             style="width: 80%;"
         >
     </a>
-    <capture>Tails 关闭后会自动遗忘，重启后如同全新的环境不留下踪迹[^1]</capture>
+    <figcaption>Tails 关闭后会自动遗忘，重启后如同全新的环境不留下踪迹[^1]</figcaption>
 </figure>
 
 Tails 完全运作于内存里，不写硬盘。关机时内存清空，这台电脑没有任何使用纪录、没有浏览历史、没有开过的档案、没有暂存。下次开机是全新环境。
@@ -49,7 +49,7 @@ Tails 完全运作于内存里，不写硬盘。关机时内存清空，这台�
             style="height: 350px;"
         >
     </a>
-    <capture>Tails 在网际网路上不留下踪迹[^1]</capture>
+    <figcaption>Tails 在网际网路上不留下踪迹[^1]</figcaption>
 </figure>
 
 Tails 的所有网路流量都经过 [Tor](./what-is-tor.md)。任何应用程序试图绕过 Tor 直接连网，会被防火墙拦下并显示警告。这跟「自己装 Tor Browser 但其他应用走一般网路」的差别很大：你在 Tails 里看到的网站不知道你的真实 IP、你下载的 Email 不洩漏连线位置、你连的云端硬盘看不到你在哪。
@@ -66,7 +66,7 @@ Tails 的所有网路流量都经过 [Tor](./what-is-tor.md)。任何应用程�
             style="width: 80%;"
         >
     </a>
-    <capture>Tails 可运行在 USB 随身碟或外接硬盘中[^1]</capture>
+    <figcaption>Tails 可运行在 USB 随身碟或外接硬盘中[^1]</figcaption>
 </figure>
 
 Tails 运作于 USB 上，开机选择从 USB 启动，主机原本的硬盘不会被读写。这意味着：

--- a/docs/zh-TW/basics/internet-freedom.md
+++ b/docs/zh-TW/basics/internet-freedom.md
@@ -59,7 +59,7 @@ icon: material/chat-question
             title="Freedom House Freedom on the Net 互動地圖"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <capture>Freedom House「Freedom on the Net」互動地圖（各國分數隨年度報告更新，畫面為站內示意截圖）</capture>
+    <figcaption>Freedom House「Freedom on the Net」互動地圖（各國分數隨年度報告更新，畫面為站內示意截圖）</figcaption>
 </figure>
 
 「狀態正在改變」的訊號近期愈來愈具體。2025 年 InterSecLab 公布了一份關於中國防火長城技術輸出的研究報告，社群完成中譯後在 [網路自由小聚](../blog/posts/internetfreedom-oct2025.md) 分享：當監控技術以容器化、產品化的方式對外輸出時，過去給個人的資安建議需要重新檢視。完整的中譯版本見 [網路政變：InterSecLab 報告](../reports/interseclab-network-coup/index.md)。2025 年 9 月再有大量防火長城內部資料外流（外洩規模約 500GB 到 600GB，來自承包商 Geedge Networks 與中國科學院信息工程研究所旗下的 MESA Lab），文件顯示這套技術已輸出到哈薩克、衣索比亞、緬甸、巴基斯坦等國，並提及另一個未具名國家，讓外界長期推測的「把審查系統當產品輸出」首次有了內部文件層級的佐證[^11]。
@@ -73,7 +73,7 @@ icon: material/chat-question
             title="OONI Explorer：規避工具觀測（CN, HK, TW 範例）"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <capture>OONI Explorer：規避工具觀測（畫面為站內保留之示意截圖，區間與資料以網站為準）</capture>
+    <figcaption>OONI Explorer：規避工具觀測（畫面為站內保留之示意截圖，區間與資料以網站為準）</figcaption>
 </figure>
 
 Tor 網路在台灣也已經有公開可見的中繼與守護節點，社群的 Tor Relay 校園建立工作正是把這份基礎建設推得更深入的具體行動。
@@ -85,7 +85,7 @@ Tor 網路在台灣也已經有公開可見的中繼與守護節點，社群的 
             title="Tor Metrics：臺灣地區 Tor 中繼與守護節點"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 0%);">
     </a>
-    <capture>Tor Metrics：臺灣地區中繼與守護節點（畫面隨網路狀態變動）</capture>
+    <figcaption>Tor Metrics：臺灣地區中繼與守護節點（畫面隨網路狀態變動）</figcaption>
 </figure>
 
 ## 你可以從哪裡開始

--- a/docs/zh-TW/blog/posts/2025-probe-security-without-identification.md
+++ b/docs/zh-TW/blog/posts/2025-probe-security-without-identification.md
@@ -27,7 +27,7 @@ description: "OONI 預計實作匿名憑證減緩假觀測資料影響觀測資�
             title="Security without identification: transaction systems to make big brother obsolete"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <capture>在他那篇具有開創性的論文《[沒有身份識別的安全性：使老大哥過時的交易系統](https://dl.acm.org/doi/10.1145/4372.4373){target="_blank"}》中，Chaum 構想了一個使用者可以使用單一數位錢包匿名與多個組織互動的未來，即使這些組織互相勾結。 </capture>
+    <figcaption>在他那篇具有開創性的論文《[沒有身份識別的安全性：使老大哥過時的交易系統](https://dl.acm.org/doi/10.1145/4372.4373){target="_blank"}》中，Chaum 構想了一個使用者可以使用單一數位錢包匿名與多個組織互動的未來，即使這些組織互相勾結。 </figcaption>
 </figure>
 
 為了提升 OONI 觀測資料的可信度，並防止故意或無意上傳的錯誤測量結果對 OONI 資料庫的影響，我們正在考慮在 OONI Probe 中設計和實作匿名憑證。在這篇文章中，我們提供了匿名憑證的現有文獻回顧。這是為了讓對密碼學領域不太熟悉但又好奇的讀者，能深入了解其所依據的協議。
@@ -133,7 +133,7 @@ OONI 的基礎設施相當特殊：使用者上傳的隱私在網路層級和應
             title="匿名憑證在理論密碼學中的全貌，以及 OONI 的定位。"
             style="border-radius: 10px;border:1px solid hsl(0, 0%, 100%);">
     </a>
-    <capture>匿名憑證在理論密碼學中的全貌，以及 OONI 的定位。</capture>
+    <figcaption>匿名憑證在理論密碼學中的全貌，以及 OONI 的定位。</figcaption>
 </figure>
 
 在文獻之外，觀察**當前佈署憑證的生態系統**，從成熟的老牌公司到新興的早期區塊鏈專案，可以看到以下三種類型：

--- a/docs/zh-TW/blog/posts/2026-onionoo-mcp-public.md
+++ b/docs/zh-TW/blog/posts/2026-onionoo-mcp-public.md
@@ -49,7 +49,7 @@ Onionoo 的規格本身完整，但對 AI 代理來說有三個門檻。
             title="Claude Desktop 整理出的臺灣 Tor 中繼節點現況報告"
             class="brand-frame">
     </a>
-    <capture>Claude Desktop 接上 onionoo MCP 後，請模型「整理臺灣 Tor 中繼節點現況」回出的彙整報告。底層數值來自上游 Onionoo，這是某一時點的 snapshot。</capture>
+    <figcaption>Claude Desktop 接上 onionoo MCP 後，請模型「整理臺灣 Tor 中繼節點現況」回出的彙整報告。底層數值來自上游 Onionoo，這是某一時點的 snapshot。</figcaption>
 </figure>
 
 這類查詢以往要先翻 Onionoo 文件、寫腳本、合併 JSON、再整理表格，現在一句話就能取得初步結果。盤點完再決定下一步要往哪鑽，研究啟動的成本差很多。

--- a/docs/zh-TW/community/onionoo-mcp.md
+++ b/docs/zh-TW/community/onionoo-mcp.md
@@ -17,7 +17,7 @@ icon: material/api
             title="AI 助理整理出的臺灣 Tor 中繼節點現況報告"
             class="brand-frame">
     </a>
-    <capture>你會取得的東西：問一句中文，AI 助理回一份整理好的報告（運作中節點數、總頻寬、前五大電信網路）。底層數值來自 Tor Project 官方資料，這是查詢當下的快照，會隨時間變動。</capture>
+    <figcaption>你會取得的東西：問一句中文，AI 助理回一份整理好的報告（運作中節點數、總頻寬、前五大電信網路）。底層數值來自 Tor Project 官方資料，這是查詢當下的快照，會隨時間變動。</figcaption>
 </figure>
 
 ## 它能幫你回答什麼
@@ -58,7 +58,7 @@ icon: material/api
             title="在 Connectors 設定頁貼上網址後的樣子"
             class="brand-frame">
     </a>
-    <capture>加好之後，Connectors 頁會出現 <code>onionoo</code> 這個自訂連接器，底下是它提供的查詢工具。AI 助理會自己挑工具，你只要用中文問就好。</capture>
+    <figcaption>加好之後，Connectors 頁會出現 <code>onionoo</code> 這個自訂連接器，底下是它提供的查詢工具。AI 助理會自己挑工具，你只要用中文問就好。</figcaption>
 </figure>
 
 ## 可以直接複製的問句
@@ -124,7 +124,7 @@ icon: material/api
             title="onionoo.anoni.net 的 Swagger UI"
             class="brand-frame">
     </a>
-    <capture><code>onionoo.anoni.net/docs</code> 的 Swagger UI 入口，所有 <code>/v1/*</code> 端點都有完整 schema 與「Try it out」可即時測試。</capture>
+    <figcaption><code>onionoo.anoni.net/docs</code> 的 Swagger UI 入口，所有 <code>/v1/*</code> 端點都有完整 schema 與「Try it out」可即時測試。</figcaption>
 </figure>
 
 ### 為什麼做這個服務
@@ -255,7 +255,7 @@ docker compose up -d --build
             title="Claude Opus 4.7 的工具呼叫展開過程"
             class="brand-frame">
     </a>
-    <capture>展開模型側的推理，可以看到代理一步一步說出要查什麼、選哪個工具、結果回來後下一步要做什麼。文字之間夾著實際的 <code>aggregate_countries</code>、<code>get_details</code> 工具呼叫，方便除錯或微調 prompt。</capture>
+    <figcaption>展開模型側的推理，可以看到代理一步一步說出要查什麼、選哪個工具、結果回來後下一步要做什麼。文字之間夾著實際的 <code>aggregate_countries</code>、<code>get_details</code> 工具呼叫，方便除錯或微調 prompt。</figcaption>
 </figure>
 
 ### 觀測指標與運維

--- a/docs/zh-TW/tools/onionshare.md
+++ b/docs/zh-TW/tools/onionshare.md
@@ -34,7 +34,7 @@ icon: material/share-circle
             title="OnionShare 主視窗的四個模式分頁"
             class="brand-frame">
     </a>
-    <capture>OnionShare 主視窗的四個模式分頁，從左到右分別是 Share Files、Receive Files、Host a Website、Chat Anonymously。</capture>
+    <figcaption>OnionShare 主視窗的四個模式分頁，從左到右分別是 Share Files、Receive Files、Host a Website、Chat Anonymously。</figcaption>
 </figure>
 
 ### Send（送檔）
@@ -51,7 +51,7 @@ icon: material/share-circle
             title="OnionShare Send 模式產生 .onion URL 與 private key"
             class="brand-frame">
     </a>
-    <capture>Send 模式啟動分享後，OnionShare 會產生 .onion 網址與 private key。把網址跟 private key 透過不同安全管道交給對方，可避免中間人替換。</capture>
+    <figcaption>Send 模式啟動分享後，OnionShare 會產生 .onion 網址與 private key。把網址跟 private key 透過不同安全管道交給對方，可避免中間人替換。</figcaption>
 </figure>
 
 <figure markdown="span">
@@ -61,7 +61,7 @@ icon: material/share-circle
             title="接收方在 Tor Browser 看到的 OnionShare 下載頁"
             class="brand-frame">
     </a>
-    <capture>接收方取得 .onion 網址後，在 Tor Browser 開啟看到的是預設的下載頁面，外觀像一般靜態網站，不必額外學習。</capture>
+    <figcaption>接收方取得 .onion 網址後，在 Tor Browser 開啟看到的是預設的下載頁面，外觀像一般靜態網站，不必額外學習。</figcaption>
 </figure>
 
 ### Receive（收檔）

--- a/docs/zh-TW/tools/password-manager.md
+++ b/docs/zh-TW/tools/password-manager.md
@@ -49,7 +49,7 @@ icon: material/key-variant
             title="KeePassXC 主畫面顯示金庫項目列表"
             class="brand-frame">
     </a>
-    <capture>KeePassXC 主畫面顯示金庫項目列表（圖片來源：<a href="https://keepassxc.org/docs/" target="_blank">KeePassXC 官方文件</a>）</capture>
+    <figcaption>KeePassXC 主畫面顯示金庫項目列表（圖片來源：<a href="https://keepassxc.org/docs/" target="_blank">KeePassXC 官方文件</a>）</figcaption>
 </figure>
 
 ### 雲端同步：Bitwarden
@@ -98,7 +98,7 @@ iOS 18 與 macOS Sequoia 起，Apple 把密碼功能獨立成 [Passwords](https:
             title="Bitwarden 為帳號設定 TOTP authenticator 的畫面"
             class="brand-frame">
     </a>
-    <capture>Bitwarden 為帳號設定 TOTP authenticator 的畫面（圖片來源：<a href="https://bitwarden.com/help/integrated-authenticator/" target="_blank">Bitwarden 官方說明</a>）</capture>
+    <figcaption>Bitwarden 為帳號設定 TOTP authenticator 的畫面（圖片來源：<a href="https://bitwarden.com/help/integrated-authenticator/" target="_blank">Bitwarden 官方說明</a>）</figcaption>
 </figure>
 
 ## Passkeys：取代密碼的新方案

--- a/docs/zh-TW/tools/tor-browser-advanced.md
+++ b/docs/zh-TW/tools/tor-browser-advanced.md
@@ -30,7 +30,7 @@ Tor Browser 11.5 起，**Connection Assist**[^1] 達到穩定版本：偵測你�
             title="Tor Browser 的 Connection Assist 與橋接設定"
             class="brand-frame">
     </a>
-    <capture>Tor Browser 的 Connection Assist 與橋接設定（詳見 <a href="https://support.torproject.org/zh-TW/bridges/" target="_blank">Tor 官方說明：橋接</a>）</capture>
+    <figcaption>Tor Browser 的 Connection Assist 與橋接設定（詳見 <a href="https://support.torproject.org/zh-TW/bridges/" target="_blank">Tor 官方說明：橋接</a>）</figcaption>
 </figure>
 
 ## 安全等級（Security Level）
@@ -50,7 +50,7 @@ Tor Browser 提供三段安全等級，從網址列旁的盾牌圖示點開「Ch
             title="Tor Browser Security Level slider 的三段選項"
             class="brand-frame">
     </a>
-    <capture>Tor Browser Security Level slider 的三段選項（詳見 <a href="https://support.torproject.org/zh-TW/security-settings/" target="_blank">Tor 官方說明：安全性等級</a>）</capture>
+    <figcaption>Tor Browser Security Level slider 的三段選項（詳見 <a href="https://support.torproject.org/zh-TW/security-settings/" target="_blank">Tor 官方說明：安全性等級</a>）</figcaption>
 </figure>
 
 ## 身分隔離：New Identity 與 New Tor Circuit
@@ -74,7 +74,7 @@ Tor Browser 預設啟用 First Party Isolation，每個分頁的 cookies、cache
             title="Tor Browser 漢堡選單顯示 New Identity 與 New Tor Circuit for this Site"
             class="brand-frame">
     </a>
-    <capture>Tor Browser 漢堡選單顯示 New Identity 與 New Tor Circuit for this Site（詳見 <a href="https://support.torproject.org/zh-TW/managing-identities/" target="_blank">Tor 官方說明：管理身分</a>）</capture>
+    <figcaption>Tor Browser 漢堡選單顯示 New Identity 與 New Tor Circuit for this Site（詳見 <a href="https://support.torproject.org/zh-TW/managing-identities/" target="_blank">Tor 官方說明：管理身分</a>）</figcaption>
 </figure>
 
 ## Tor Circuit 檢視
@@ -94,7 +94,7 @@ Tor Browser 預設啟用 First Party Isolation，每個分頁的 cookies、cache
             title="Tor Browser 顯示當前 Tor Circuit 的三層中繼節點與所在國家"
             class="brand-frame">
     </a>
-    <capture>Tor Browser 顯示當前 Tor Circuit 的三層中繼節點與所在國家（詳見 <a href="https://support.torproject.org/zh-TW/managing-identities/" target="_blank">Tor 官方說明：管理身分</a>）</capture>
+    <figcaption>Tor Browser 顯示當前 Tor Circuit 的三層中繼節點與所在國家（詳見 <a href="https://support.torproject.org/zh-TW/managing-identities/" target="_blank">Tor 官方說明：管理身分</a>）</figcaption>
 </figure>
 
 ## Onion 站點偏好
@@ -116,7 +116,7 @@ Tor Browser 預設啟用 First Party Isolation，每個分頁的 cookies、cache
             title="Tor Browser 對 .onion-Location 的提示與 onion 站點偏好設定"
             class="brand-frame">
     </a>
-    <capture>Tor Browser 對 .onion-Location 的提示與 onion 站點偏好設定（詳見 <a href="https://support.torproject.org/zh-TW/onion-services/" target="_blank">Tor 官方說明：洋蔥服務</a>）</capture>
+    <figcaption>Tor Browser 對 .onion-Location 的提示與 onion 站點偏好設定（詳見 <a href="https://support.torproject.org/zh-TW/onion-services/" target="_blank">Tor 官方說明：洋蔥服務</a>）</figcaption>
 </figure>
 
 ## 指紋抗性與視窗大小

--- a/docs/zh-TW/tools/what-is-tails.md
+++ b/docs/zh-TW/tools/what-is-tails.md
@@ -26,7 +26,7 @@ Tails 真正的價值在三個刻意的設計選擇所組合出來的工作環�
             style="width: 80%;"
         >
     </a>
-    <capture>Tails 關閉後會自動遺忘，重啟後如同全新的環境不留下蹤跡[^1]</capture>
+    <figcaption>Tails 關閉後會自動遺忘，重啟後如同全新的環境不留下蹤跡[^1]</figcaption>
 </figure>
 
 Tails 完全運作於記憶體裡，不寫硬碟。關機時記憶體清空，這台電腦沒有任何使用紀錄、沒有瀏覽歷史、沒有開過的檔案、沒有暫存。下次開機是全新環境。
@@ -45,7 +45,7 @@ Tails 完全運作於記憶體裡，不寫硬碟。關機時記憶體清空，�
             style="height: 350px;"
         >
     </a>
-    <capture>Tails 在網際網路上不留下蹤跡[^1]</capture>
+    <figcaption>Tails 在網際網路上不留下蹤跡[^1]</figcaption>
 </figure>
 
 Tails 的所有網路流量都經過 [Tor](./what-is-tor.md)。任何應用程式試圖繞過 Tor 直接連網，會被防火牆攔下並顯示警告。這跟「自己裝 Tor Browser 但其他應用走一般網路」的差別很大：你在 Tails 裡看到的網站不知道你的真實 IP、你下載的 Email 不洩漏連線位置、你連的雲端硬碟看不到你在哪。
@@ -62,7 +62,7 @@ Tails 的所有網路流量都經過 [Tor](./what-is-tor.md)。任何應用程�
             style="width: 80%;"
         >
     </a>
-    <capture>Tails 可運行在 USB 隨身碟或外接硬碟中[^1]</capture>
+    <figcaption>Tails 可運行在 USB 隨身碟或外接硬碟中[^1]</figcaption>
 </figure>
 
 Tails 運作於 USB 上，開機選擇從 USB 啟動，主機原本的硬碟不會被讀寫。這意味著：


### PR DESCRIPTION
## 起因

在審 PR #167（你今天開的 `fix/i18n-figcaption`）時注意到，它修的是 `<caption>` → `<figcaption>`。但站上還有一個**更大、而且更明確錯誤**的同類問題沒被涵蓋。

`<caption>` 至少是真實的 HTML 元素（只是屬於 `<table>`，放在 `<figure>` 裡不對）。**`<capture>` 根本不存在**。

## 影響

瀏覽器把未知元素當成 inline 處理，所以**文字看得到**，肉眼檢查不會發現異常。實際輸出：

```html
</a> <capture>Freedom House「Freedom on the Net」互動地圖（…）</capture> </figure>
```

問題在於它拿不到 `<figcaption>` 的語意，**螢幕閱讀器無法把說明文字關聯到圖片**。這對一個談可近用與弱勢讀者保護的站台不太合適。

## 範圍

三語系合計 **54 處、19 個檔案**：

| 語系 | 處數 | 主要檔案 |
|---|---:|---|
| zh-TW | 23 | tor-browser-advanced (5)、onionoo-mcp (4)、onionshare (3)、what-is-tails (3)、internet-freedom (3) |
| zh-CN | 23 | 同上對應 |
| en | 8 | onionoo-mcp (4)、internet-freedom (3)、2026-onionoo-mcp-public (1) |

檢查過**全部 54 處都在 `<figure>` 內**，開閉標籤全部成對，所以 `<figcaption>` 是正確的替換而非猜測。

日文版的 3 處已在 PR #165 的分支上另外修掉（那是我翻譯時照抄原文造成的）。

## 順帶補一處 PR #167 漏掉的

`docs/en/blog/posts/updates-202508.md` 有一個 `<caption>`。PR #167 修了 zh-TW 與 zh-CN 的同一支檔案，漏掉 en。

這是這個 repo 反覆出現的模式（PR #163 我自己也犯過），值得留意。

## 不是新訂慣例

站上原本就有 3 處正確用法：

- `docs/zh-TW/event-workshop-2025.md:148`
- `docs/zh-TW/event-workshop-2025-prepare.md:238`
- `docs/zh-TW/tools/what-is-cryptpad.md:22`

這次是把其餘統一過去。

## 與 PR #167 的關係

**零檔案重疊**（#167 觸及 12 檔，本 PR 觸及 20 檔，交集為空），兩者可以獨立合併，順序不拘。

## 驗證

- zh-TW、zh-CN、en 三棵樹 `-s` strict 建置，全部 0 warning
- 輸出 HTML 實測：三語系的 internet-freedom 頁面 `<figcaption>` 各 3 個、`<capture>` 各 0 個
- 替換前確認 54 處全在 `<figure>` 內、開閉成對

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmENQmBjZvrVE9abzz971T
