### PR TITLE
feat(games): 互動區 SEO，移除 PoC 殘留的 noindex 並補齊索引訊號

### DIFF
--- a/docs/en/games/index.md
+++ b/docs/en/games/index.md
@@ -1,5 +1,5 @@
 ---
-title: Interactive
+title: "Interactive: 3D Tor network visualisations and games"
 description: Privacy and anonymity technology presented as 3D visuals and playable pieces. All three current works centre on Tor - a puzzle that walks you through three-hop onion routing, a live view of traffic meeting at rendezvous points, and a relay globe built from six public datasets.
 icon: material/cube-outline
 social:
@@ -123,3 +123,79 @@ Knowing JavaScript is enough to work on the copy, the level design and the inter
 ## What comes next
 
 These are the first three pieces, all focused on Tor. Plenty of other privacy topics deserve the same treatment: what metadata gives away, how a threat model shifts with your situation, what the money trail behind anonymous payments looks like. All of them are on the list. If you have an idea or want to build one with us, come find us in the [community](../community/index.md).
+
+<!-- Structured data. The three works ship their own JSON-LD in their head, since
+     they never pass through the mkdocs template, and point isPartOf back at the
+     zh-TW #collection. This block lists them as an ItemList. Keep the @id values
+     identical to the ones in each work's index.html. -->
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "CollectionPage",
+      "@id": "https://anoni.net/docs/en/games/#collection",
+      "name": "Interactive",
+      "url": "https://anoni.net/docs/en/games/",
+      "description": "Privacy and anonymity technology presented as 3D visuals and playable pieces. All three current works centre on Tor.",
+      "inLanguage": "en",
+      "publisher": { "@id": "https://anoni.net/#organization" },
+      "mainEntity": { "@id": "https://anoni.net/docs/en/games/#works" }
+    },
+    {
+      "@type": "ItemList",
+      "@id": "https://anoni.net/docs/en/games/#works",
+      "name": "The works",
+      "numberOfItems": 3,
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "item": {
+            "@type": "VideoGame",
+            "@id": "https://anoni.net/docs/games/onion-routing/#work",
+            "name": "Tor Routing Puzzle",
+            "url": "https://anoni.net/docs/games/onion-routing/?lang=en",
+            "image": "https://assets.anoni.net/games/onion-routing.png",
+            "description": "A playable puzzle. Pick three relays to form a Tor guard, middle and exit path, avoid monitored nodes, spread the three hops across different ASNs, and switch to a bridge when blocked."
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "item": {
+            "@type": "WebApplication",
+            "@id": "https://anoni.net/docs/games/onion-rendezvous/#work",
+            "name": "Tor Traffic Rendezvous",
+            "url": "https://anoni.net/docs/games/onion-rendezvous/?lang=en",
+            "image": "https://assets.anoni.net/games/onion-rendezvous.png",
+            "applicationCategory": "EducationalApplication",
+            "description": "A piece to watch rather than play. Glowing particles trace the two shapes Tor traffic takes, with .onion connections meeting at a rendezvous point picked at random."
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "item": {
+            "@type": "WebApplication",
+            "@id": "https://anoni.net/docs/games/tor-network/#work",
+            "name": "Tor Relay Globe",
+            "url": "https://anoni.net/docs/games/tor-network/?lang=en",
+            "image": "https://assets.anoni.net/games/tor-network.png",
+            "applicationCategory": "EducationalApplication",
+            "description": "A globe built from real data. Nearly ten thousand running Tor relays placed inside their own borders, layered with connectivity observations, user estimates, shutdown records and submarine cables."
+          }
+        }
+      ]
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Docs", "item": "https://anoni.net/docs/en/" },
+        { "@type": "ListItem", "position": 2, "name": "Interactive" }
+      ]
+    }
+  ]
+}
+</script>

--- a/docs/en/games/index.md
+++ b/docs/en/games/index.md
@@ -167,7 +167,7 @@ These are the first three pieces, all focused on Tor. Plenty of other privacy to
           "item": {
             "@type": "WebApplication",
             "@id": "https://anoni.net/docs/games/onion-rendezvous/#work",
-            "name": "Tor Traffic Rendezvous",
+            "name": "Tor Traffic Flow",
             "url": "https://anoni.net/docs/games/onion-rendezvous/?lang=en",
             "image": "https://assets.anoni.net/games/onion-rendezvous.png",
             "applicationCategory": "EducationalApplication",

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -32,6 +32,7 @@
   {
     "@context": "https://schema.org",
     "@type": "Organization",
+    "@id": "https://anoni.net/#organization",
     "name": "匿名網路社群 anoni.net",
     "alternateName": "anoni.net",
     "url": "https://anoni.net/",

--- a/docs/overrides/sitemap.xml
+++ b/docs/overrides/sitemap.xml
@@ -12,4 +12,25 @@
     </url>
     {%- endif -%}
 {% endfor %}
+{#-
+  互動區的三件作品是手寫的 index.html，當靜態檔放在 docs/zh-TW/games/ 底下，不是 md
+  頁面，所以不在 pages 裡，上面那個迴圈產不出它們。它們從著陸頁被連到，爬蟲遲早會找
+  到，列進來是為了讓 Search Console 能單獨追蹤這三頁的索引狀態。
+
+  只在預設語系那次建置輸出。作品的檔案只存在 zh-TW 的樹底下，output/en/games/ 與
+  output/zh-cn/games/ 都只有 index.html，列進那兩份 sitemap 會變成 404。那兩次
+  建置用的是 overrides_en 與 overrides_cn，本來就不會走到這裡。run.sh 與
+  run_zh-tw.sh 共用這個目錄，靠 site_url 分辨：只有 run.sh 結尾是 /docs/，而三件
+  作品的 canonical 都指向那個網址。
+
+  網址用 config.site_url 組出來，onion 與 IPFS 版本換了 SITE_URL 就會跟著換。
+  lastmod 留空，這三個檔的更新時間不像 md 頁有 git 外掛可以問。
+-#}
+{%- if config.site_url and config.site_url.endswith('/docs/') %}
+{%- for work in ['onion-routing', 'onion-rendezvous', 'tor-network'] %}
+    <url>
+         <loc>{{ (config.site_url ~ 'games/' ~ work ~ '/')|e }}</loc>
+    </url>
+{%- endfor %}
+{%- endif %}
 </urlset>

--- a/docs/overrides_cn/main.html
+++ b/docs/overrides_cn/main.html
@@ -32,6 +32,7 @@
   {
     "@context": "https://schema.org",
     "@type": "Organization",
+    "@id": "https://anoni.net/#organization",
     "name": "匿名网络社群 anoni.net",
     "alternateName": "anoni.net",
     "url": "https://anoni.net/",

--- a/docs/overrides_en/main.html
+++ b/docs/overrides_en/main.html
@@ -32,6 +32,7 @@
   {
     "@context": "https://schema.org",
     "@type": "Organization",
+    "@id": "https://anoni.net/#organization",
     "name": "Anonymity Network Community, anoni.net",
     "alternateName": "anoni.net",
     "url": "https://anoni.net/",

--- a/docs/zh-CN/games/index.md
+++ b/docs/zh-CN/games/index.md
@@ -1,5 +1,5 @@
 ---
-title: 互动与呈现
+title: 互动与呈现：Tor 网络的 3D 可视化与互动游戏
 description: 以 3D 影像与可操作的游戏呈现隐私与匿名技术。目前三件作品都以 Tor 为题：走一遍三跳洋葱路由的解谜、连线流量在会合点相遇的动态呈现、整合六份公开数据的全球中继地球仪。
 icon: material/cube-outline
 social:
@@ -123,3 +123,78 @@ og:
 ## 接下来
 
 这是互动区的头三件作品，主题集中在 Tor。隐私领域中值得做成画面的题材仍然很多，元数据会泄漏什么、威胁模型如何随处境改变、匿名支付的资金流样貌，都在候补名单上。有想法或想一起参与，欢迎到[社群](../community/index.md)找我们。
+
+<!-- 结构化数据。三件作品的 index.html 不经 mkdocs 模板，各自在 head 写了自己的
+     JSON-LD，并用 isPartOf 指向 zh-TW 的 #collection。这一段把三件作品列成
+     ItemList。@id 必须与各作品 index.html 里的一致。 -->
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "CollectionPage",
+      "@id": "https://anoni.net/docs/zh-cn/games/#collection",
+      "name": "互动与呈现",
+      "url": "https://anoni.net/docs/zh-cn/games/",
+      "description": "以 3D 影像与可操作的游戏呈现隐私与匿名技术。目前三件作品都以 Tor 为题。",
+      "inLanguage": "zh-Hans",
+      "publisher": { "@id": "https://anoni.net/#organization" },
+      "mainEntity": { "@id": "https://anoni.net/docs/zh-cn/games/#works" }
+    },
+    {
+      "@type": "ItemList",
+      "@id": "https://anoni.net/docs/zh-cn/games/#works",
+      "name": "作品",
+      "numberOfItems": 3,
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "item": {
+            "@type": "VideoGame",
+            "@id": "https://anoni.net/docs/games/onion-routing/#work",
+            "name": "Tor 路由解谜",
+            "url": "https://anoni.net/docs/games/onion-routing/?lang=zh-cn",
+            "image": "https://assets.anoni.net/games/onion-routing.png",
+            "description": "可操作的解谜。自行挑选 3 个中继组成 Tor 的 guard、middle、exit 路径，避开被监听的节点、将 3 跳分散到不同 ASN，遇到封锁则改走网桥。"
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "item": {
+            "@type": "WebApplication",
+            "@id": "https://anoni.net/docs/games/onion-rendezvous/#work",
+            "name": "Tor 连线流量",
+            "url": "https://anoni.net/docs/games/onion-rendezvous/?lang=zh-cn",
+            "image": "https://assets.anoni.net/games/onion-rendezvous.png",
+            "applicationCategory": "EducationalApplication",
+            "description": "以观看为主的呈现。用发光粒子与残影表现 Tor 流量的两种路径，连线 .onion 服务时双方各建一条 3 跳线路，在随机挑出的会合点相遇。"
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "item": {
+            "@type": "WebApplication",
+            "@id": "https://anoni.net/docs/games/tor-network/#work",
+            "name": "Tor 中继地球仪",
+            "url": "https://anoni.net/docs/games/tor-network/?lang=zh-cn",
+            "image": "https://assets.anoni.net/games/tor-network.png",
+            "applicationCategory": "EducationalApplication",
+            "description": "以真实数据构成的地球仪。将全球正在运行的近万台 Tor 中继落在各自的国界之内，另外整合连线受阻观测、用户估计、断网事件与海底电缆。"
+          }
+        }
+      ]
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "文档", "item": "https://anoni.net/docs/zh-cn/" },
+        { "@type": "ListItem", "position": 2, "name": "互动与呈现" }
+      ]
+    }
+  ]
+}
+</script>

--- a/docs/zh-TW/games/index.md
+++ b/docs/zh-TW/games/index.md
@@ -1,5 +1,5 @@
 ---
-title: 互動與呈現
+title: 互動與呈現：Tor 網路的 3D 視覺化與互動遊戲
 description: 以 3D 影像與可操作的遊戲呈現隱私與匿名技術。目前三件作品都以 Tor 為題：走一遍三跳洋蔥路由的解謎、連線流量在會合點相遇的動態呈現、整合六份公開資料的全球中繼地球儀。
 icon: material/cube-outline
 social:
@@ -123,3 +123,78 @@ og:
 ## 接下來
 
 這是互動區的頭三件作品，主題集中在 Tor。隱私領域中值得做成畫面的題材仍然很多，中繼資料會洩漏什麼、威脅模型如何隨處境改變、匿名支付的金流樣貌，都在候補名單上。有想法或想一起參與，歡迎到[社群](../community/index.md)找我們。
+
+<!-- 結構化資料。三件作品的 index.html 不經 mkdocs 模板，各自在 head 寫了自己的
+     JSON-LD，並用 isPartOf 指向這裡的 #collection。這一段補上另一半：把三件作品
+     列成 ItemList，讓搜尋引擎知道它們同屬一個系列。@id 兩邊必須一致。 -->
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "CollectionPage",
+      "@id": "https://anoni.net/docs/games/#collection",
+      "name": "互動與呈現",
+      "url": "https://anoni.net/docs/games/",
+      "description": "以 3D 影像與可操作的遊戲呈現隱私與匿名技術。目前三件作品都以 Tor 為題。",
+      "inLanguage": "zh-Hant",
+      "publisher": { "@id": "https://anoni.net/#organization" },
+      "mainEntity": { "@id": "https://anoni.net/docs/games/#works" }
+    },
+    {
+      "@type": "ItemList",
+      "@id": "https://anoni.net/docs/games/#works",
+      "name": "作品",
+      "numberOfItems": 3,
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "item": {
+            "@type": "VideoGame",
+            "@id": "https://anoni.net/docs/games/onion-routing/#work",
+            "name": "Tor 路由解謎",
+            "url": "https://anoni.net/docs/games/onion-routing/",
+            "image": "https://assets.anoni.net/games/onion-routing.png",
+            "description": "可操作的解謎。自行挑選 3 個中繼組成 Tor 的 guard、middle、exit 路徑，避開被監聽的節點、將 3 跳分散到不同 ASN，遇到封鎖則改走橋接。"
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "item": {
+            "@type": "WebApplication",
+            "@id": "https://anoni.net/docs/games/onion-rendezvous/#work",
+            "name": "Tor 連線流量",
+            "url": "https://anoni.net/docs/games/onion-rendezvous/",
+            "image": "https://assets.anoni.net/games/onion-rendezvous.png",
+            "applicationCategory": "EducationalApplication",
+            "description": "以觀看為主的呈現。用發光粒子與殘影表現 Tor 流量的兩種路徑，連線 .onion 服務時雙方各建一條 3 跳電路，在隨機挑出的會合點相遇。"
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "item": {
+            "@type": "WebApplication",
+            "@id": "https://anoni.net/docs/games/tor-network/#work",
+            "name": "Tor 中繼地球儀",
+            "url": "https://anoni.net/docs/games/tor-network/",
+            "image": "https://assets.anoni.net/games/tor-network.png",
+            "applicationCategory": "EducationalApplication",
+            "description": "以真實資料構成的地球儀。將全球正在運作的近萬台 Tor 中繼落在各自的國界之內，另外整合連線受阻觀測、使用者估計、斷網事件與海底電纜。"
+          }
+        }
+      ]
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "文件", "item": "https://anoni.net/docs/" },
+        { "@type": "ListItem", "position": 2, "name": "互動與呈現" }
+      ]
+    }
+  ]
+}
+</script>

--- a/docs/zh-TW/games/onion-rendezvous/i18n.js
+++ b/docs/zh-TW/games/onion-rendezvous/i18n.js
@@ -45,6 +45,9 @@ const ZH_TW = {
   blkNoGpu: '這個瀏覽器沒有 WebGPU',
   blkNoAdapter: '系統沒有給出可用的 GPU',
   blkRejected: 'WebGPU 被擋下',
+
+  // 面板底部的返回列，整段連同連結一起換語言。
+  backlink: '← <a href="../">互動與呈現</a>　延伸閱讀 <a href="../../tools/what-is-tor/">什麼是 Tor</a>、<a href="../../tools/tor-snowflake/">Tor Snowflake 橋接</a>',
 };
 
 const EN = {
@@ -90,6 +93,9 @@ const EN = {
   blkNoGpu: 'this browser has no WebGPU',
   blkNoAdapter: 'the system offered no usable GPU',
   blkRejected: 'WebGPU was refused',
+
+  // 英文站沒有 what-is-tor，改指實際存在的英文頁。
+  backlink: '← <a href="../../en/games/">Interactive</a>　Further reading: <a href="../../en/basics/anonymity-vs-privacy/">Anonymity vs privacy</a>, <a href="../../en/tools/tor-snowflake/">Tor Snowflake</a>',
 };
 
 const ZH_CN = {
@@ -135,6 +141,8 @@ const ZH_CN = {
   blkNoGpu: '这个浏览器没有 WebGPU',
   blkNoAdapter: '系统没有给出可用的 GPU',
   blkRejected: 'WebGPU 被挡下',
+
+  backlink: '← <a href="../../zh-cn/games/">互动与呈现</a>　延伸阅读 <a href="../../zh-cn/tools/what-is-tor/">什么是 Tor</a>、<a href="../../zh-cn/tools/tor-snowflake/">Tor Snowflake</a>',
 };
 
 export const STR = { 'zh-TW': ZH_TW, 'en': EN, 'zh-cn': ZH_CN };

--- a/docs/zh-TW/games/onion-rendezvous/index.html
+++ b/docs/zh-TW/games/onion-rendezvous/index.html
@@ -33,7 +33,7 @@
         "@type": "WebApplication",
         "@id": "https://anoni.net/docs/games/onion-rendezvous/#work",
         "name": "Tor 連線流量",
-        "alternateName": ["Tor Traffic Rendezvous", "Tor 连线流量"],
+        "alternateName": ["Tor Traffic Flow", "Tor 连线流量"],
         "url": "https://anoni.net/docs/games/onion-rendezvous/",
         "description": "以觀看為主的呈現。用細小發光粒子與殘影表現 Tor 流量的兩種路徑：連線 .onion 服務時雙方各建一條 3 跳電路，在隨機挑出的會合點相遇，連線明網網站則經 3 跳出口後原路往返。relay 數、電路數、已被標記的有害節點、流量都能即時調整。",
         "image": "https://assets.anoni.net/games/onion-rendezvous.png",

--- a/docs/zh-TW/games/onion-rendezvous/index.html
+++ b/docs/zh-TW/games/onion-rendezvous/index.html
@@ -3,9 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <meta name="robots" content="noindex" />
   <title>Tor 連線流量 · anoni.net</title>
   <meta name="description" content="用發光粒子與殘影看 Tor 流量的兩種路徑：連 .onion 服務在隨機會合點相遇，連明網網站則經 3 跳出口後原路往返。relay 數、電路數、流量都能即時調整。" />
+  <!-- 這頁在建置後會同時出現在 /docs/games/ 與 /docs/zh-tw/games/ 兩個網址，
+       兩份內容完全相同。canonical 指向前者，把權重集中到一個網址上。
+       語言由 ?lang= 決定，同一份檔案服務三個語系，所以正規網址不帶參數。 -->
+  <link rel="canonical" href="https://anoni.net/docs/games/onion-rendezvous/" />
   <!-- OG 寫死在這裡，因為這頁不經過 mkdocs 的模板。三個語系共用同一份程式，
        抓取預覽的爬蟲不會執行 JS，所以這裡固定用預設語系 zh-TW 的文案與正規網址。 -->
   <meta property="og:type" content="website" />
@@ -20,6 +23,60 @@
   <meta property="twitter:title" content="Tor 連線流量 · anoni.net" />
   <meta property="twitter:description" content="用發光粒子與殘影看 Tor 流量的兩種路徑：連 .onion 服務在隨機會合點相遇，連明網網站則經 3 跳出口後原路往返。relay 數、電路數、流量都能即時調整。" />
   <meta property="twitter:image" content="https://assets.anoni.net/games/onion-rendezvous.png" />
+  <!-- 結構化資料。與 OG 同樣寫死，理由相同：這頁不經 mkdocs 模板，抓取的爬蟲不執行 JS。
+       這件作品以觀看為主，沒有勝負與關卡，所以用 WebApplication 而非 VideoGame。 -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebApplication",
+        "@id": "https://anoni.net/docs/games/onion-rendezvous/#work",
+        "name": "Tor 連線流量",
+        "alternateName": ["Tor Traffic Rendezvous", "Tor 连线流量"],
+        "url": "https://anoni.net/docs/games/onion-rendezvous/",
+        "description": "以觀看為主的呈現。用細小發光粒子與殘影表現 Tor 流量的兩種路徑：連線 .onion 服務時雙方各建一條 3 跳電路，在隨機挑出的會合點相遇，連線明網網站則經 3 跳出口後原路往返。relay 數、電路數、已被標記的有害節點、流量都能即時調整。",
+        "image": "https://assets.anoni.net/games/onion-rendezvous.png",
+        "inLanguage": ["zh-Hant", "zh-Hans", "en"],
+        "applicationCategory": "EducationalApplication",
+        "applicationSubCategory": "資料視覺化",
+        "operatingSystem": "Web browser",
+        "browserRequirements": "需要支援 WebGPU 或 WebGL2 的瀏覽器，免安裝",
+        "isAccessibleForFree": true,
+        "isFamilyFriendly": true,
+        "license": "https://github.com/anoni-net/docs/blob/main/LICENSE",
+        "author": { "@id": "https://anoni.net/#organization" },
+        "publisher": { "@id": "https://anoni.net/#organization" },
+        "isPartOf": { "@id": "https://anoni.net/docs/games/#collection" },
+        "about": [
+          { "@type": "Thing", "name": "Tor", "sameAs": "https://www.torproject.org/" },
+          { "@type": "Thing", "name": "洋蔥服務（.onion）", "sameAs": "https://community.torproject.org/onion-services/" },
+          { "@type": "Thing", "name": "會合點", "sameAs": "https://spec.torproject.org/rend-spec/" }
+        ]
+      },
+      {
+        "@type": "Organization",
+        "@id": "https://anoni.net/#organization",
+        "name": "匿名網路社群 anoni.net",
+        "url": "https://anoni.net/"
+      },
+      {
+        "@type": "CollectionPage",
+        "@id": "https://anoni.net/docs/games/#collection",
+        "name": "互動與呈現",
+        "url": "https://anoni.net/docs/games/"
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "文件", "item": "https://anoni.net/docs/" },
+          { "@type": "ListItem", "position": 2, "name": "互動與呈現", "item": "https://anoni.net/docs/games/" },
+          { "@type": "ListItem", "position": 3, "name": "Tor 連線流量" }
+        ]
+      }
+    ]
+  }
+  </script>
   <style>
     :root {
       --cyan: #00aeff; --client: #38d6ff; --service: #b98cff; --bad: #ff5a5a;

--- a/docs/zh-TW/games/onion-rendezvous/index.html
+++ b/docs/zh-TW/games/onion-rendezvous/index.html
@@ -111,6 +111,9 @@
     #langs a { color: var(--muted); text-decoration: none; border-bottom: 1px solid rgba(255,255,255,.18); }
     #langs a:hover { color: #fff; border-bottom-color: rgba(255,255,255,.5); }
     #langs .on { color: #fff; font-weight: 700; }
+    #backlink { margin-top: 6px; font-size: 11px; color: var(--muted); }
+    #backlink a { color: var(--muted); text-decoration: none; border-bottom: 1px solid rgba(255,255,255,.18); }
+    #backlink a:hover { color: #fff; border-bottom-color: rgba(255,255,255,.5); }
     #langs i { margin: 0 6px; opacity: .4; font-style: normal; }
     #note { margin-top: 9px; color: var(--muted); font-size: 11.5px; line-height: 1.6; display: flex; flex-direction: column; gap: 5px; }
     #note p { margin: 0; }
@@ -179,6 +182,9 @@
           </div>
           <div id="backend">偵測中…</div>
           <div id="langs"></div>
+          <!-- 這頁對爬蟲來說原本是死路，連結一條都沒有，對使用者也沒有回去的路。
+               靜態寫死 zh-TW 版本讓爬蟲讀得到，其他語系由 i18n 換掉整段（含連結網址）。 -->
+          <div id="backlink">← <a href="../">互動與呈現</a>　延伸閱讀 <a href="../../tools/what-is-tor/">什麼是 Tor</a>、<a href="../../tools/tor-snowflake/">Tor Snowflake 橋接</a></div>
         </div>
       </div>
     </details>

--- a/docs/zh-TW/games/onion-rendezvous/scene.js
+++ b/docs/zh-TW/games/onion-rendezvous/scene.js
@@ -20,6 +20,9 @@ document.documentElement.lang = LANG === 'zh-TW' ? 'zh-Hant' : (LANG === 'zh-cn'
 function applyI18n() {
   const lb = $('langs');
   if (lb) lb.innerHTML = langLinksHTML(LANG);
+  // 返回列整段換掉，因為連結網址本身各語系不同，指向的是各自語系的文件。
+  const bl = $('backlink');
+  if (bl) bl.innerHTML = S('backlink');
   document.title = S('pageTitle') + ' · anoni.net';
   const set = (id, key) => { const el = $(id); if (el) el.textContent = S(key); };
   set('title', 'pageTitle');

--- a/docs/zh-TW/games/onion-routing/game.js
+++ b/docs/zh-TW/games/onion-routing/game.js
@@ -51,6 +51,9 @@ const el = {
 function initStaticText() {
   const lb = $('langs');
   if (lb) lb.innerHTML = langLinksHTML(LANG);
+  // 返回列整段換掉，因為連結網址本身各語系不同，指向的是各自語系的文件。
+  const bl = $('backlink');
+  if (bl) bl.innerHTML = S('backlink');
   document.title = S('gameTitle') + ' · anoni.net';
   $('brand-title').textContent = S('gameTitle');
   $('brand-tagline').textContent = S('tagline');

--- a/docs/zh-TW/games/onion-routing/i18n.js
+++ b/docs/zh-TW/games/onion-routing/i18n.js
@@ -88,10 +88,14 @@ const ZH_TW = {
   // en 站沒有 what-is-tor 與 ooni-asn-coverage，改指向英文站真的有、主題也對得上的頁。
   // tor-snowflake 原本也沒有，PR #153 合併時 main 上已經補上英文版，所以接回真正對題的那篇。
   // 總覽頁是靜態 mkdocs 頁，掛 ?lang= 沒有作用，要直接連到各語系自己那份。
-  docOverview: '../index.html',
+  docOverview: '../',
   docTor: '../../tools/what-is-tor/',
   docAsn: '../../taiwan/ooni-asn-coverage/',
   docSnowflake: '../../tools/tor-snowflake/',
+
+  // 面板底部的返回列，整段連同連結一起換語言。網址與上面的 doc* 重複，但這裡要的是
+  // 一段可以直接寫進 innerHTML 的完整片語，拆開組裝反而更難讀。改連結時兩邊都要動。
+  backlink: '← <a href="../">互動與呈現</a>　延伸閱讀 <a href="../../tools/what-is-tor/">什麼是 Tor</a>、<a href="../../taiwan/ooni-asn-coverage/">台灣 ASN 觀測涵蓋</a>',
 };
 
 const EN = {
@@ -180,6 +184,9 @@ const EN = {
   docTor: '../../en/basics/anonymity-vs-privacy/',
   docAsn: '../../en/regional/tor-relay-watcher/',
   docSnowflake: '../../en/tools/tor-snowflake/',
+
+  // 英文站沒有 what-is-tor 與 ASN 涵蓋那兩頁，所以延伸閱讀改指實際存在的英文頁。
+  backlink: '← <a href="../../en/games/">Interactive</a>　Further reading: <a href="../../en/basics/anonymity-vs-privacy/">Anonymity vs privacy</a>, <a href="../../en/regional/tor-relay-watcher/">Tor relay watcher</a>',
 };
 
 const ZH_CN = {
@@ -268,6 +275,8 @@ const ZH_CN = {
   docTor: '../../zh-cn/tools/what-is-tor/',
   docAsn: '../../zh-cn/taiwan/ooni-asn-coverage/',
   docSnowflake: '../../zh-cn/tools/tor-snowflake/',
+
+  backlink: '← <a href="../../zh-cn/games/">互动与呈现</a>　延伸阅读 <a href="../../zh-cn/tools/what-is-tor/">什么是 Tor</a>、<a href="../../zh-cn/taiwan/ooni-asn-coverage/">ASNs 自治网络观测数据分析</a>',
 };
 
 export const STR = { 'zh-TW': ZH_TW, 'en': EN, 'zh-cn': ZH_CN };

--- a/docs/zh-TW/games/onion-routing/index.html
+++ b/docs/zh-TW/games/onion-routing/index.html
@@ -3,9 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <meta name="robots" content="noindex" />
   <title>Tor 路由解謎 · anoni.net</title>
   <meta name="description" content="自己挑 3 個中繼組成 Tor 的 guard、middle、exit 路徑，避開被監聽的節點、把 3 跳分散到不同 ASN，遇到封鎖改走橋接。四個關卡各對應一項真實的選路考量。" />
+  <!-- 這頁在建置後會同時出現在 /docs/games/ 與 /docs/zh-tw/games/ 兩個網址，
+       兩份內容完全相同。canonical 指向前者，把權重集中到一個網址上。
+       語言由 ?lang= 決定，同一份檔案服務三個語系，所以正規網址不帶參數。 -->
+  <link rel="canonical" href="https://anoni.net/docs/games/onion-routing/" />
   <!-- OG 寫死在這裡，因為這頁不經過 mkdocs 的模板。三個語系共用同一份程式，
        抓取預覽的爬蟲不會執行 JS，所以這裡固定用預設語系 zh-TW 的文案與正規網址。 -->
   <meta property="og:type" content="website" />
@@ -20,6 +23,61 @@
   <meta property="twitter:title" content="Tor 路由解謎 · anoni.net" />
   <meta property="twitter:description" content="自己挑 3 個中繼組成 Tor 的 guard、middle、exit 路徑，避開被監聽的節點、把 3 跳分散到不同 ASN，遇到封鎖改走橋接。四個關卡各對應一項真實的選路考量。" />
   <meta property="twitter:image" content="https://assets.anoni.net/games/onion-routing.png" />
+  <!-- 結構化資料。與 OG 同樣寫死，理由相同：這頁不經 mkdocs 模板，抓取的爬蟲不執行 JS。
+       @id 用完整網址加片段，三件作品與著陸頁互相指涉時才能連成同一張圖。 -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "VideoGame",
+        "@id": "https://anoni.net/docs/games/onion-routing/#work",
+        "name": "Tor 路由解謎",
+        "alternateName": ["Tor Routing Puzzle", "Tor 路由解谜"],
+        "url": "https://anoni.net/docs/games/onion-routing/",
+        "description": "可操作的解謎。將訊息從你送到對岸的收件人，自行挑選 3 個中繼組成 Tor 的 guard、middle、exit 路徑，過程中要避開被監聽的節點、將 3 跳分散到不同 ASN，遇到封鎖則改走橋接。四個關卡各對應一項真實的選路考量。",
+        "image": "https://assets.anoni.net/games/onion-routing.png",
+        "inLanguage": ["zh-Hant", "zh-Hans", "en"],
+        "genre": ["解謎", "教育"],
+        "applicationCategory": "GameApplication",
+        "gamePlatform": "Web browser",
+        "playMode": "SinglePlayer",
+        "browserRequirements": "需要支援 WebGPU 或 WebGL2 的瀏覽器，免安裝",
+        "isAccessibleForFree": true,
+        "isFamilyFriendly": true,
+        "license": "https://github.com/anoni-net/docs/blob/main/LICENSE",
+        "author": { "@id": "https://anoni.net/#organization" },
+        "publisher": { "@id": "https://anoni.net/#organization" },
+        "isPartOf": { "@id": "https://anoni.net/docs/games/#collection" },
+        "about": [
+          { "@type": "Thing", "name": "Tor", "sameAs": "https://www.torproject.org/" },
+          { "@type": "Thing", "name": "洋蔥路由", "sameAs": "https://en.wikipedia.org/wiki/Onion_routing" },
+          { "@type": "Thing", "name": "自治系統（ASN）", "sameAs": "https://en.wikipedia.org/wiki/Autonomous_system_(Internet)" }
+        ]
+      },
+      {
+        "@type": "Organization",
+        "@id": "https://anoni.net/#organization",
+        "name": "匿名網路社群 anoni.net",
+        "url": "https://anoni.net/"
+      },
+      {
+        "@type": "CollectionPage",
+        "@id": "https://anoni.net/docs/games/#collection",
+        "name": "互動與呈現",
+        "url": "https://anoni.net/docs/games/"
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "文件", "item": "https://anoni.net/docs/" },
+          { "@type": "ListItem", "position": 2, "name": "互動與呈現", "item": "https://anoni.net/docs/games/" },
+          { "@type": "ListItem", "position": 3, "name": "Tor 路由解謎" }
+        ]
+      }
+    ]
+  }
+  </script>
   <style>
     :root {
       --cyan: #00aeff; --cyan-600: #009ee6; --cyan-800: #006d99;

--- a/docs/zh-TW/games/onion-routing/index.html
+++ b/docs/zh-TW/games/onion-routing/index.html
@@ -110,6 +110,9 @@
     #langs a { color: var(--muted); text-decoration: none; border-bottom: 1px solid rgba(255,255,255,.18); }
     #langs a:hover { color: #fff; border-bottom-color: rgba(255,255,255,.5); }
     #langs .on { color: #fff; font-weight: 700; }
+    #backlink { margin-top: 6px; font-size: 11px; color: var(--muted); }
+    #backlink a { color: var(--muted); text-decoration: none; border-bottom: 1px solid rgba(255,255,255,.18); }
+    #backlink a:hover { color: #fff; border-bottom-color: rgba(255,255,255,.5); }
     #langs i { margin: 0 6px; opacity: .4; font-style: normal; }
 
     /* 圖例 */
@@ -187,6 +190,9 @@
     <div id="objective">目標</div>
     <div id="backend">偵測中…</div>
     <div id="langs"></div>
+    <!-- 這頁對爬蟲來說原本是死路，站內連結一條都沒有，對使用者也沒有回去的路。
+         靜態寫死 zh-TW 版本讓爬蟲讀得到，其他語系由 i18n 換掉整段（含連結網址）。 -->
+    <div id="backlink">← <a href="../">互動與呈現</a>　延伸閱讀 <a href="../../tools/what-is-tor/">什麼是 Tor</a>、<a href="../../taiwan/ooni-asn-coverage/">台灣 ASN 觀測涵蓋</a></div>
   </div>
 
   <div id="legend-toggle" class="panel" role="button" tabindex="0">圖例</div>

--- a/docs/zh-TW/games/tor-network/atlas.js
+++ b/docs/zh-TW/games/tor-network/atlas.js
@@ -19,6 +19,9 @@ document.documentElement.lang = LANG === 'zh-TW' ? 'zh-Hant' : (LANG === 'zh-cn'
 function applyI18n() {
   const lb = $('langs');
   if (lb) lb.innerHTML = langLinksHTML(LANG);
+  // 返回列整段換掉，因為連結網址本身各語系不同，指向的是各自語系的文件。
+  const bl = $('backlink');
+  if (bl) bl.innerHTML = S('backlink');
   document.title = S('pageTitle') + ' · anoni.net';
   const set = (id, key, html) => {
     const el = $(id);

--- a/docs/zh-TW/games/tor-network/i18n.js
+++ b/docs/zh-TW/games/tor-network/i18n.js
@@ -127,6 +127,9 @@ const ZH_TW = {
   listSep: '、',
   roleTipAll: '再點一次看全部',
   roleTipOne: '只看這個角色',
+
+  // 面板底部的返回列，整段連同連結一起換語言。
+  backlink: '← <a href="../">互動與呈現</a>　延伸閱讀 <a href="../../blog/2026/07/games-globe-open-data/">地球儀的資料從哪來</a>、<a href="../../tools/what-is-tor/">什麼是 Tor</a>',
 };
 
 const EN = {
@@ -246,6 +249,8 @@ const EN = {
   listSep: ', ',
   roleTipAll: 'Click again to show all',
   roleTipOne: 'Show only this role',
+
+  backlink: '← <a href="../../en/games/">Interactive</a>　Further reading: <a href="../../en/blog/2026/07/games-globe-open-data/">Where this globe\'s data comes from</a>',
 };
 
 const ZH_CN = {
@@ -365,6 +370,8 @@ const ZH_CN = {
   listSep: '、',
   roleTipAll: '再点一次看全部',
   roleTipOne: '只看这个角色',
+
+  backlink: '← <a href="../../zh-cn/games/">互动与呈现</a>　延伸阅读 <a href="../../zh-cn/blog/2026/07/games-globe-open-data/">地球仪的数据从哪来</a>、<a href="../../zh-cn/tools/what-is-tor/">什么是 Tor</a>',
 };
 
 export const STR = { 'zh-TW': ZH_TW, 'en': EN, 'zh-cn': ZH_CN };

--- a/docs/zh-TW/games/tor-network/index.html
+++ b/docs/zh-TW/games/tor-network/index.html
@@ -3,9 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <meta name="robots" content="noindex" />
   <title>Tor 中繼地球儀 · anoni.net</title>
   <meta name="description" content="把全球近萬台運作中的 Tor 中繼灑進各自的國界，另外疊上連線受阻觀測、使用者估計、斷網事件與海底電纜。three.js 在瀏覽器裡跑，免安裝。" />
+  <!-- 這頁在建置後會同時出現在 /docs/games/ 與 /docs/zh-tw/games/ 兩個網址，
+       兩份內容完全相同。canonical 指向前者，把權重集中到一個網址上。
+       語言由 ?lang= 決定，同一份檔案服務三個語系，所以正規網址不帶參數。 -->
+  <link rel="canonical" href="https://anoni.net/docs/games/tor-network/" />
   <!-- OG 寫死在這裡，因為這頁不經過 mkdocs 的模板。三個語系共用同一份程式，
        抓取預覽的爬蟲不會執行 JS，所以這裡固定用預設語系 zh-TW 的文案與正規網址。 -->
   <meta property="og:type" content="website" />
@@ -20,6 +23,105 @@
   <meta property="twitter:title" content="Tor 中繼地球儀 · anoni.net" />
   <meta property="twitter:description" content="把全球近萬台運作中的 Tor 中繼灑進各自的國界，另外疊上連線受阻觀測、使用者估計、斷網事件與海底電纜。three.js 在瀏覽器裡跑，免安裝。" />
   <meta property="twitter:image" content="https://assets.anoni.net/games/tor-network.png" />
+  <!-- 結構化資料。與 OG 同樣寫死，理由相同：這頁不經 mkdocs 模板，抓取的爬蟲不執行 JS。
+       isBasedOn 逐筆列出六份外部資料，讓來源與授權在畫面之外也能被機器讀到，
+       內容要與畫面下方的來源聲明和根目錄 NOTICE 保持一致。 -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebApplication",
+        "@id": "https://anoni.net/docs/games/tor-network/#work",
+        "name": "Tor 中繼地球儀",
+        "alternateName": ["Tor Relay Globe", "Tor 中继地球仪"],
+        "url": "https://anoni.net/docs/games/tor-network/",
+        "description": "以真實資料構成的地球儀。將全球正在運作的近萬台 Tor 中繼落在各自的國界之內，顏色區分 guard、middle、exit，大小對應頻寬，陸地亮度依指標上色。除了中繼分布，另外整合了連線受阻觀測、使用者估計、斷網事件與海底電纜等外部資料。",
+        "image": "https://assets.anoni.net/games/tor-network.png",
+        "inLanguage": ["zh-Hant", "zh-Hans", "en"],
+        "applicationCategory": "EducationalApplication",
+        "applicationSubCategory": "資料視覺化",
+        "operatingSystem": "Web browser",
+        "browserRequirements": "需要支援 WebGPU 或 WebGL2 的瀏覽器，免安裝",
+        "isAccessibleForFree": true,
+        "isFamilyFriendly": true,
+        "license": "https://github.com/anoni-net/docs/blob/main/LICENSE",
+        "author": { "@id": "https://anoni.net/#organization" },
+        "publisher": { "@id": "https://anoni.net/#organization" },
+        "isPartOf": { "@id": "https://anoni.net/docs/games/#collection" },
+        "about": [
+          { "@type": "Thing", "name": "Tor", "sameAs": "https://www.torproject.org/" },
+          { "@type": "Thing", "name": "Tor 中繼", "sameAs": "https://community.torproject.org/relay/" },
+          { "@type": "Thing", "name": "網路審查", "sameAs": "https://en.wikipedia.org/wiki/Internet_censorship" }
+        ],
+        "isBasedOn": [
+          {
+            "@type": "Dataset",
+            "name": "Onionoo 中繼資料",
+            "url": "https://metrics.torproject.org/onionoo.html",
+            "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "creator": { "@type": "Organization", "name": "The Tor Project" }
+          },
+          {
+            "@type": "Dataset",
+            "name": "Tor Metrics 使用者與橋接估計",
+            "url": "https://metrics.torproject.org/",
+            "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "creator": { "@type": "Organization", "name": "The Tor Project" }
+          },
+          {
+            "@type": "Dataset",
+            "name": "OONI tor 測試觀測",
+            "url": "https://ooni.org/",
+            "license": "https://github.com/ooni/license/blob/master/data/LICENSE.md",
+            "creator": { "@type": "Organization", "name": "Open Observatory of Network Interference" }
+          },
+          {
+            "@type": "Dataset",
+            "name": "Access Now #KeepItOn STOP 斷網事件",
+            "url": "https://www.accessnow.org/keepiton-data-dashboard/",
+            "license": "https://creativecommons.org/licenses/by/4.0/",
+            "creator": { "@type": "Organization", "name": "Access Now" }
+          },
+          {
+            "@type": "Dataset",
+            "name": "OpenStreetMap 海底電纜路徑",
+            "url": "https://www.openstreetmap.org/copyright",
+            "license": "https://opendatacommons.org/licenses/odbl/",
+            "creator": { "@type": "Organization", "name": "OpenStreetMap contributors" }
+          },
+          {
+            "@type": "Dataset",
+            "name": "Natural Earth 國界與海岸線",
+            "url": "https://www.naturalearthdata.com/",
+            "license": "https://www.naturalearthdata.com/about/terms-of-use/",
+            "creator": { "@type": "Organization", "name": "Natural Earth" }
+          }
+        ]
+      },
+      {
+        "@type": "Organization",
+        "@id": "https://anoni.net/#organization",
+        "name": "匿名網路社群 anoni.net",
+        "url": "https://anoni.net/"
+      },
+      {
+        "@type": "CollectionPage",
+        "@id": "https://anoni.net/docs/games/#collection",
+        "name": "互動與呈現",
+        "url": "https://anoni.net/docs/games/"
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "文件", "item": "https://anoni.net/docs/" },
+          { "@type": "ListItem", "position": 2, "name": "互動與呈現", "item": "https://anoni.net/docs/games/" },
+          { "@type": "ListItem", "position": 3, "name": "Tor 中繼地球儀" }
+        ]
+      }
+    ]
+  }
+  </script>
   <style>
     :root {
       --cyan: #00aeff; --ink: #eaf6ff; --muted: #9fb6c8;

--- a/docs/zh-TW/games/tor-network/index.html
+++ b/docs/zh-TW/games/tor-network/index.html
@@ -169,6 +169,9 @@
     #langs a { color: var(--muted); text-decoration: none; border-bottom: 1px solid rgba(255,255,255,.18); }
     #langs a:hover { color: #fff; border-bottom-color: rgba(255,255,255,.5); }
     #langs .on { color: #fff; font-weight: 700; }
+    #backlink { margin-top: 6px; font-size: 11px; color: var(--muted); }
+    #backlink a { color: var(--muted); text-decoration: none; border-bottom: 1px solid rgba(255,255,255,.18); }
+    #backlink a:hover { color: #fff; border-bottom-color: rgba(255,255,255,.5); }
     #langs i { margin: 0 6px; opacity: .4; font-style: normal; }
 
     #live-box { margin: 0 0 10px; }
@@ -329,6 +332,9 @@
         </div>
         <div id="backend">偵測中…</div>
         <div id="langs"></div>
+        <!-- 這頁的連結原本全部指向站外的資料來源，站內一條都沒有，權重只出不進。
+             靜態寫死 zh-TW 版本讓爬蟲讀得到，其他語系由 i18n 換掉整段（含連結網址）。 -->
+        <div id="backlink">← <a href="../">互動與呈現</a>　延伸閱讀 <a href="../../blog/2026/07/games-globe-open-data/">地球儀的資料從哪來</a>、<a href="../../tools/what-is-tor/">什麼是 Tor</a></div>
       </div>
     </details>
   </div>


### PR DESCRIPTION
## 起因

互動區在搜尋引擎上完全不存在，原因只有一個：

```html
<meta name="robots" content="noindex" />
```

`onion-routing`、`onion-rendezvous`、`tor-network` 三件作品的 head 都有這一行。追來源分別是 `0029224`、`d6d444e`、`23a308f`，也就是每件作品最初進 repo 的那個 commit，`23a308f` 的訊息還註明「此頁尚未併入 games hub（PoC）」。那是 PoC 階段的「先別收錄」標記，作品正式上線後沒有拿掉。

這行還在的話，其他 SEO 工作全部是零，所以先處理它，再把周邊一起補齊。

## 改了什麼

### 1. 可索引性

- 三件作品移除 `noindex`
- 補 `<link rel="canonical">`。建置會產出 `/docs/games/<work>/` 與 `/docs/zh-tw/games/<work>/` 兩份完全相同的內容，兩個網址都回 `200`。一般 md 頁由 Material 依 `site_url` 產生 canonical 自動收斂，這三頁不經模板所以沒有，兩個網址一直在互相稀釋

### 2. 結構化資料

三件作品各自在 head 寫入 JSON-LD，與既有的 OG 標籤同樣寫死，理由相同：不經 mkdocs 模板，抓取的爬蟲不執行 JS。

- `onion-routing` 有關卡與勝負，用 `VideoGame`，另外兩件以觀看為主，用 `WebApplication`
- 地球儀額外用 `isBasedOn` 逐筆列出六份外部資料的來源與授權，內容與畫面下方的來源聲明、根目錄 `NOTICE` 一致
- 著陸頁補上另一半，把三件作品列成 `ItemList`，`@id` 與作品頁一致，兩邊接起來才是一張完整的圖
- 三份 `overrides/main.html` 的 `Organization` 補上 `@id`，全站的組織節點收斂成一個實體，作品頁的 `author` 與 `publisher` 才有得指

作品名與 `alternateName` 逐一比對過各作品 i18n 的三張表。過程中抓到一個錯誤：`onion-rendezvous` 的英文名實際是 `Tor Traffic Flow`，我一開始照目錄名寫成 `Tor Traffic Rendezvous`，已修正。

### 3. 站內連結

三件作品原本是爬蟲的死路。`onion-rendezvous` 整頁沒有任何 `<a>`，`onion-routing` 只有一個由 JS 填 href 的結束卡連結，`tor-network` 的連結全部指向站外的資料來源，權重只出不進。使用者的處境一樣，進了全螢幕作品之後除了按上一頁沒有別的路。

面板底部加一列返回連結，指回著陸頁並帶兩條延伸閱讀。靜態寫死 zh-TW 版本讓爬蟲讀得到，其他語系由 i18n 換掉整段，做法沿用既有 `credit*` 那批把 `<a>` 放進字串的模式。連結網址各語系不同，所以換的是整段而非只換文字。

英文站沒有 `what-is-tor` 與 ASN 涵蓋那兩頁，英文的延伸閱讀改指 `basics/anonymity-vs-privacy` 與 `regional/tor-relay-watcher`。

站內連結數：三頁各從 `0` 條增加到 `3` 條。

### 4. sitemap

作品是手寫的 `index.html`，當靜態檔放著，不是 md 頁面，所以不在 `pages` 裡，內建模板產不出它們的 `<loc>`，四份 sitemap 一份都沒收。

改在既有的 `overrides/sitemap.xml` 末尾補上，並用 `site_url` 結尾是不是 `/docs/` 來分辨，只有預設語系那次建置會輸出。作品的檔案只存在 zh-TW 的樹底下，`output/en/games/` 與 `output/zh-cn/games/` 都只有 `index.html`，列進那兩份會變成 404。網址用 `config.site_url` 組，onion 與 IPFS 版本換了 `SITE_URL` 會跟著換。

### 5. 著陸頁 title

三個語系原本分別是「互動與呈現」、「Interactive」、「互动与呈现」，沒有人會這樣搜。改成帶上主題與形式的說法。側欄不受影響，nav 標籤走 `NAV_GAMES` 環境變數，與 front matter 的 `title` 是兩回事。

## 驗證

- 四個語系都以 `mkdocs build -s`（strict）建過，`exit 0`
- 四份 sitemap 都是合法 XML。作品只出現在預設語系那份，`202` 筆變 `205` 筆，其餘三份不變
- 所有 JSON-LD 在建置產物中重新解析過，確認沒有被 markdown 處理器破壞
- headless Chrome 實際跑過三件作品 × 三個語系共九種組合，返回列都正確渲染，`document.title` 都有翻譯到位，代表插入的程式碼沒有讓後續的 i18n 中斷
- 返回列的 27 條連結全部實測 `200`
- `docs_style_lint` 對變更的 md 是 0 error、0 warn

## 沒有做的事

**沒有動 `build_docs.yml`。** 讓三個語系各有一份作品副本（各自的 canonical、hreflang、`<html lang>`）是 SEO 上更正確的解法，但那需要改建置流程加後處理腳本，風險與這次的收益不成比例。現行分工是著陸頁承擔多語系曝光（本來就有各自的 canonical、hreflang 與 sitemap 條目），作品頁承擔預設語系。

**沒有加 hreflang 到作品頁。** 同一份檔案服務三個語系，無法讓各語系各有自己的 canonical，硬加只會讓 Google 把 `?lang=` 變體併回主網址後忽略整組 hreflang。

**`onion-routing` 的靜態文字仍然只有 `119` 字。** 那頁的內容全部在 `levels.js` 與 `i18n.js` 裡由 JS 產生，是全螢幕遊戲的必然結果。內容型查詢由著陸頁承接，那頁本來就有相當完整的長文。

## 一個觀察

最後一次建置出現一次 `First revision timestamp is older than last revision timestamp for page blog/category/relay.md` 的警告，之後重跑兩次都沒有再出現，main 上建置也沒有。牽涉的是 blog 自動產生的分類頁，本 PR 沒有動過任何 blog 檔，strict 建置也是 `exit 0`。判定為偶發，記在這裡備查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeBtxbLmnsMBxqjXu59nAw
