### PR TITLE
docs(blog): 用 CVE-2026-10702 講解如何判讀 Firefox 漏洞是否影響 Tor Browser

### DIFF
--- a/docs/en/blog/posts/2026-firefox-jit-cve-tor-browser.md
+++ b/docs/en/blog/posts/2026-firefox-jit-cve-tor-browser.md
@@ -1,0 +1,175 @@
+---
+date: 2026-07-30
+authors:
+    - anoni-net
+categories:
+    - Technology
+    - Tor
+    - Privacy
+slug: 2026-firefox-jit-cve-tor-browser
+image: "assets/images/tor.webp"
+summary: "Tor Browser stable is not affected by CVE-2026-10702, the Firefox JIT flaw. The buggy code landed in Firefox 147, and stable follows the 140 ESR branch, which never carried it. The researchers say they also pwned Tor Browser, but never named a version or channel, and the headlines did not add that distinction. This post gives you a three-step method for deciding whether any Firefox CVE reaches your Tor Browser, then explains the bug and the IonStack chain."
+description: "CVE-2026-10702 is a type confusion flaw in Firefox's JIT compiler, chained by researchers into IonStack, a browser-to-root exploit chain on Android. This post explains how the ESR and Rapid Release split determines whether a Firefox CVE affects Tor Browser, with an affected-versions table, the technical root cause, and concrete actions for security levels and kernel updates."
+---
+
+# Is Your Tor Browser Affected? CVE-2026-10702 and Firefox's Two Branches
+
+![Tor](./assets/images/tor.webp){style="border-radius: 10px;"}
+
+In late July 2026 several security outlets ran variations of the same headline: researchers had shown that visiting a single malicious web page could compromise Tor Browser.[^1] The CVE behind those headlines is CVE-2026-10702, a flaw in the JIT compiler of Firefox's JavaScript engine. The demo page published by the research team, Nebula Security, is specific about its target: a Firefox for Android 151.0 build (installer `fenix-151.0.multi.android-arm64-v8a.apk`) running on an ARM64 Android 17 device, with no mention of Tor Browser anywhere on the page.[^2] Their technical writeup, however, contains the line "We also used it to pwn Tor Browser". The claim about Tor Browser comes from the researchers themselves, and that writeup never says which version, which channel, or which platform.[^3]
+
+Putting the sources side by side, Tor Browser stable is not affected. Stable is built on the Firefox ESR branch, and the code behind this flaw only landed in Firefox 147, so 140 ESR never carried it. No primary source shows this flaw being exploited in the wild either: the SSVC assessment that CISA added to the CVE record marks Exploitation as none.[^4]
+
+!!! tip "First, check which build you have"
+
+    If you downloaded Tor Browser from torproject.org and let it update itself, you are on stable and this flaw does not affect you. To read your version number, open the hamburger menu at the top right, choose Help, then About Tor Browser. The 15.0.x number is your Tor Browser version. Unless you deliberately downloaded a build labelled Alpha, you are on stable.
+
+    The other number on that screen, 140.13.0esr, is the Firefox version underneath. That is the number that decides whether a Firefox CVE reaches you, and it is the one this post keeps coming back to.
+
+<!-- more -->
+
+## ESR and Rapid Release are two separate branches
+
+Tor Browser stable follows Firefox ESR (Extended Support Release). The 15.0.x series is built on 140 ESR, and 15.0.19, released on 21 July 2026, moved that base to 140.13.0esr, with GeckoView on Android moving to the same base.[^5]
+
+Tor Browser Alpha took a different path. In a December 2025 post, the Tor Project announced that the Alpha channel would follow Firefox Rapid Release starting with 16.0a1, and spelled out the trade-off: shipping upstream features to users quickly also means shipping upstream bugs to them quickly. The same post is blunt about who should stay away: "If you are an at-risk user, concerned about your privacy, or just need a reliably working web-browser, you SHOULD NOT use Tor Browser Alpha."[^6] The base actually changed with 16.0a6 on 7 May 2026, whose release notes state "Tor Browser Alphas are now based on Firefox's betas" and move the base to Firefox 150.0a1. Alphas before that were still built on ESR.[^7] On 23 July 2026, 16.0a9 moved back to ESR, this time Firefox 153.0esr, in preparation for the next stable series.[^8]
+
+Mozilla fixed the flaw in Firefox 151.0.3, released on 2 June 2026.[^9] When the code arrived in Firefox is a matter of public record: Bugzilla `1995077` ("Replace Object.keys with specialized iterator in Scalar Replacement") has a target milestone of 147 Branch and `firefox147` marked fixed, while the esr140 tracking field is empty.[^10] The ESR advisory from the same period, MFSA-2026-58 (Firefox ESR 140.12, 16 June), lists 28 CVEs and this is not one of them.[^11] Red Hat's CSAF VEX document marks the firefox packages across RHEL 6 through 10 as `known_not_affected`, and what RHEL ships is the ESR build.[^12] Three independent lines of evidence point the same way: the 140 ESR branch never carried this code. Laid out by target:
+
+| Target | Firefox base | Affected? | What to do |
+|---|---|---|---|
+| Not sure which build you have | Almost certainly stable, 140 ESR | Not affected | Let it finish updating, then confirm on the About screen |
+| Tor Browser 15.0.x stable | 140 ESR | Not affected | Stay on the latest release |
+| Tor Browser for Android stable | GeckoView 140.13.0esr | Not affected | Stay on the latest release |
+| Tor Browser Alpha 16.0a6 (2026-05-07) | Firefox 150.0a1 | Affected | Move to 16.0a8 or later, or switch back to stable |
+| Tor Browser Alpha 16.0a7 (2026-06-03) | Firefox 151.0a1 | Affected | Move to 16.0a8 or later, or switch back to stable |
+| Tor Browser Alpha 16.0a8 (2026-07-02) | Firefox 152.0a1 | Not affected | Stay on the latest release |
+| Tor Browser Alpha 16.0a9 onwards (2026-07-23) | Firefox 153.0esr | Not affected | Stay on the latest release |
+| Firefox desktop and Android, general | Rapid Release, 151.0.2 and earlier | Affected | Update to 151.0.3 or later |
+| Tor Browser inside Tails | Tails 7.10 ships 15.0.19 | Not affected | Update with Tails |
+
+Both 16.0a6 and 16.0a7 sit on bases that predate 151.0.3, so this post treats both as affected. Every verdict in the table is inferred from the Firefox base, because the Tor Project has never published a per-version statement about this CVE. The Tails row follows the Tails 7.10 release notes, which ship Tor Browser 15.0.19.[^13]
+
+## A three-step method
+
+The next time you see a Firefox CVE number, work through these three checks. In most cases they are enough to reach a verdict on your own. The first two are cross-checks. If you would rather not dig through vulnerability databases, skip to step three.
+
+**Step one: check whether Mozilla published an ESR advisory at the same time.** Mozilla issues separate MFSA numbers for the ESR branch. Here, MFSA-2026-54 covers only the two CVEs fixed in Firefox 151.0.3, and the ESR advisory from the same period, MFSA-2026-58, does not include this one. A rule of thumb worth remembering: for a Firefox CVE, Tor Browser stable is usually only a concern when Mozilla ships an ESR advisory alongside it.
+
+**Step two: check Red Hat's VEX data.** RHEL ships the ESR build of Firefox, so Red Hat's verdict on a given CVE is effectively a verdict on the ESR branch. Here their CSAF VEX document marks the firefox packages across RHEL 6 through 10 as `known_not_affected`. With some luck the Mozilla Bugzilla entry is public too. In this case `1995077` shows exactly which branch the code landed on.
+
+**Step three: check the Firefox base of the Tor Browser build you are running.** For Firefox security updates, Tor Browser release notes do not enumerate individual CVEs; they only say "includes important security updates to Firefox", so you have to work backwards from the base version. Our [Tor changelog](../../changelog/tor.md) tracks the Firefox base for recent releases on both the stable and Alpha channels. The English version currently goes back to 15.0.15 and 16.0a7, with older entries available only in the traditional Chinese version. Anything earlier means going to the upstream release notes.
+
+**Do not stop at the CVSS score.** The same flaw is scored very differently across databases: on the NVD page, CISA-ADP gives it CVSS 3.1 4.3 (Medium), Red Hat gives 7.5 (High), and Mozilla rates it high.[^14] The gap comes from what CVSS measures. It scores a single flaw in isolation, and code execution inside the renderer looks limited on its own because the sandbox still stands. What makes this flaw matter is that it is the first stage of a complete chain, which is what the next two sections take apart.
+
+## Root cause: the compiler was misled by its own annotation
+
+A JIT (Just-In-Time) compiler turns repeatedly executed JavaScript into machine code, making hot paths run tens of times faster than line-by-line interpretation. To do that well, the compiler needs to know whether each operation can modify memory. If an operation only reads, the compiler can safely skip a later load from the same location and reuse the value it already has.
+
+Picture a warehouse where the manifest notes that a particular visitor will only count stock and will not move anything. That visitor in fact moves an entire rack to a new location and dismantles the old one. Everyone downstream reads the manifest, concludes that nothing has changed, and goes to the original address for their goods. The rack is gone, and someone else's crates may already be stacked in its place.
+
+In SpiderMonkey, Firefox's JavaScript engine, the `MObjectToIterator` operation was annotated as read-only when `skipRegistration` was set. That annotation did not match its behaviour: while resolving a lazy property, the operation can allocate a new dynamic slots buffer and free the old one.
+
+The optimisation stage that runs next is global value numbering, whose job is to find and eliminate redundant computation. Reading an annotation that said nothing had changed, it concluded that the later load of the slots pointer was redundant and reused the earlier pointer, which by then referred to freed memory. The generated machine code therefore read and wrote memory through a dangling pointer, giving an attacker an arbitrary read and write primitive and code execution inside the renderer process. Global value numbering belongs to the IonMonkey optimisation pipeline; the chain is called IonStack, and the researchers never explained the name.
+
+At this point the attacker's code is still confined to the renderer sandbox. Reaching your files and everything else takes a second flaw.
+
+Mozilla's fix removed the alias set that branched on `skipRegistration`, so the operation is always treated as one that can modify memory. The advisory is MFSA-2026-54, rated high, crediting Nebula Security. The flaw is classified under both CWE-843 (type confusion) and CWE-733 (compiler optimisation removal or modification of security-critical code); the latter is a precise description of a bug that lives in an optimisation decision. Bugzilla `2040903` is still access-restricted, so the account above of the mechanism and the fix comes from the researchers' public writeup.[^3]
+
+## The IonStack chain: from browser to root
+
+The researchers place this flaw at the first stage of a chain: it provides code execution inside the browser's renderer sandbox, and a second stage breaks out of that sandbox to take over the device. Together they are called IonStack, demonstrated on an ARM64 Android 17 device.
+
+The second stage is CVE-2026-43499, known as GhostLock, in the futex priority inheritance code of the Linux kernel, the machinery behind glibc's `PTHREAD_PRIO_INHERIT` mutexes. When a lock operation fails and unwinds, the cleanup path clears the wrong side's record, and the waiting task returns to userspace still holding a pointer into its own kernel stack. That stack memory is then reused by something else, and a later walk of the priority chain lands on freed stack, a use-after-free. The researchers call it a stack-UAF and note that bugs of this class usually live on the heap, making the kernel stack an unusual place to find one.[^15]
+
+This stage attacks your operating system, not your browser. The affected file is `kernel/locking/rtmutex.c`, the bug has been present since Linux 2.6.39 in 2011 through v7.1-rc1, and mainline fixed it in 7.1.[^16] The only condition is a kernel built with `CONFIG_FUTEX_PI`, which in practice every distribution enables, so treat everything as affected. On Google's kernelCTF x86 target (lts-6.12.80, with `RANDOMIZE_KSTACK_OFFSET` off), the exploit goes from unprivileged code to root in roughly five seconds at about 97% reliability, and works from inside a container running a standard kernel. Upstream received the report on 18 April, fixed it on 20 April, backported on 4 May, and the research went public on 7 July. A crash introduced by the first fix was briefly assigned CVE-2026-53166, fixed on 2 June, and that identifier was later withdrawn by the Linux CNA on 10 July.[^17]
+
+As long as the kernel goes unpatched, any future browser flaw that yields code execution in a renderer can be chained onto the same escalation. Fixing the browser only closes this particular entry point.
+
+## What to do now
+
+**Update Tor Browser to the current release.** Leave the browser open and let it update itself, or download it again from torproject.org. This flaw does not reach stable, but 15.0.19 still carries other security fixes backported from Firefox 153.
+
+**Update regular Firefox to 151.0.3 or later.** Both desktop and Android.
+
+**Do not use the Alpha channel as a daily browser.** That is the Tor Project's own advice, and this is a good illustration of why.
+
+**Setting the Security Level to Safer or Safest blocks this entire class of JIT flaw.** Both levels turn off `javascript.options.ion` and `javascript.options.baselinejit`, which disables the JIT outright and removes any chance of triggering a compiler-level defect.[^18] To change it, click the shield icon next to the address bar, choose Change, then pick a level. You do not need to touch `about:config`. Know the cost first: Safer disables JavaScript on HTTP sites along with some fonts, and Safest disables JavaScript by default on all sites, which means some forms will not submit. Our [Tor Browser advanced settings](../../tools/tor-browser-advanced.md) page covers the trade-offs in more detail.
+
+**After changing the Security Level, close every Tor Browser window and start it again.** The Tor Project's own security levels page never mentions the JIT, listing only the changes to JavaScript, fonts and media, so official documentation alone will not tell you this. In May 2025, Privacy Guides tested Tor Browser 14.5.1 and found the JIT still running when the browser had not been restarted, even though the interface already showed Safer.[^19] Tor Browser 15.x on desktop has since fixed that silent failure and prompts for a restart when you switch levels (tor-browser issue `43783`); the equivalent integration on Android only landed for 16.0. The principle is unchanged: change the level, then restart.
+
+**On Windows and macOS, the steps above are all you need.** The second stage of the chain is a Linux kernel flaw and does not apply to either platform.
+
+**On Linux desktops, update the kernel and reboot.** A kernel update does nothing until you reboot, and that is the step people skip. Afterwards, run `uname -r` to confirm what is actually running, and check your distribution's advisory status for CVE-2026-43499 rather than assuming it has been handled. Build-time mitigations such as `CONFIG_STATIC_USERMODE_HELPER` require recompiling the kernel and are out of reach for ordinary desktop users. If you run your own servers or relays, consider the `randomize_kstack_offset=on` boot parameter, which only works if your distribution's kernel was built with `CONFIG_RANDOMIZE_KSTACK_OFFSET`. It adds roughly five bits of guessing cost, so treat it as delay rather than a fix.
+
+**On Android, you are waiting on your device vendor.** There is no user-side remedy for a kernel-level escalation, and when the update arrives depends on the vendor and the carrier.
+
+## A CVE number alone cannot tell you the blast radius
+
+Once one codebase is split across two release lines, those lines are two different bodies of code. This flaw's code only landed in Firefox 147, so the 140 ESR branch that stable follows never had it, while the Alpha channel that follows the rapid line did. That is the question the three-step method answers: did Mozilla publish an ESR advisory, what did Red Hat say about the ESR packages, and what Firefox base is under the build in your hands.
+
+The claim that Tor Browser was compromised comes from the researchers themselves. They did not name a version or a channel, and the headlines did not add that distinction. A reader is left with a CVE number and an unversioned claim, and everything after that is their own to check. The next time a headline like this appears, start by asking which branch it is talking about.
+
+## What this post could not establish
+
+- The researchers never say which Tor Browser build they compromised. "We also used it to pwn Tor Browser" in IonStack Part I is the whole of it, with no version, channel or platform, and neither the demo page nor the press coverage adds any. That leaves open the possibility that it was an Alpha build, and it leaves other possibilities open too.
+- The Firefox bases of Tor Browser 16.0a6 and 16.0a7 predate the 151.0.3 fix, which is why this post lists them as affected. Those builds are no longer on the dist directory, so the binaries cannot be checked for the fix.
+- Which channel the Tor Browser inside Whonix follows could not be established from any official page, so Whonix is not in the table above. The Whonix documentation only recommends using the stable release.
+- The Tor Project has published no statement of any kind about this CVE.
+- Bugzilla `2040903` is access-restricted, so the original patch could not be read.
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| JIT (Just-In-Time) | Compiling frequently executed code to machine code at runtime for speed |
+| SpiderMonkey | Firefox's JavaScript engine |
+| IonMonkey, Warp | SpiderMonkey's optimising compiler pipeline; Warp is the front end, IonMonkey handles later optimisation and code generation |
+| global value numbering | An optimisation stage that finds and eliminates redundant computation |
+| lazy property | An object property that is only materialised when something accesses it |
+| dynamic slots | The dynamically sized storage for an object's property values, reallocated when it runs out of room |
+| dangling pointer | A pointer to memory that has already been freed |
+| use-after-free | Using memory after it has been freed, a common exploitable bug class |
+| stack-UAF | A use-after-free where the freed memory lives on the kernel stack rather than the heap |
+| type confusion | Treating data of one type as if it were another |
+| renderer process | The browser process that parses and draws page content, confined by a sandbox |
+| privilege escalation | Gaining higher privileges than you started with |
+| ESR (Extended Support Release) | Firefox's long-lived branch: slow feature changes, long security support |
+| Rapid Release | Firefox's fast-moving channel, roughly one version every four weeks as of July 2026 |
+| channel | A distinct release line of the same software, such as stable versus Alpha |
+| rebase | Moving Tor Browser onto a newer Firefox version as its base |
+| backport | Porting a newer fix back onto an older maintenance branch |
+| futex | Fast userspace mutex, the Linux userspace locking primitive |
+| priority inheritance | A locking mechanism that stops high-priority work from being blocked behind low-priority work |
+| CWE | The classification scheme for what kind of defect a flaw is |
+| CVSS | A scoring system that rates severity from 0 to 10 |
+| SSVC | Another vulnerability assessment framework; CISA uses it to record fields such as whether exploitation has been observed |
+| VEX | Vulnerability Exploitability eXchange, how vendors state whether their products are affected by a CVE |
+| MFSA | Mozilla Foundation Security Advisory, Mozilla's advisory identifier |
+
+## Related reading
+
+- [Tor Browser advanced settings](../../tools/tor-browser-advanced.md)
+- [Tor changelog](../../changelog/tor.md)
+- [Tails vs Whonix vs Qubes](../../tools/tails-vs-whonix-vs-qubes.md)
+- [Building a threat model](../../basics/threat-model.md)
+
+[^1]: [Researchers Show a Single Malicious Webpage Visit Can Compromise Tor Browser, The Hacker News 2026-07](https://thehackernews.com/2026/07/researchers-show-single-malicious.html){target="_blank"}
+[^2]: [IonStack demo page, Nebula Security](https://rootme.nebusec.io/){target="_blank"}
+[^3]: [IonStack Part I: CVE-2026-10702, Nebula Security](https://nebusec.ai/research/ionstack-part-1-cve-2026-10702/){target="_blank"}
+[^4]: [CVE-2026-10702 record, including CISA-ADP's SSVC assessment, CVE Program](https://cveawg.mitre.org/api/cve/CVE-2026-10702){target="_blank"}
+[^5]: [New Release: Tor Browser 15.0.19, The Tor Project 2026-07-21](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}
+[^6]: [The Future of Tor Browser Alpha, The Tor Project 2025-12-01](https://blog.torproject.org/future-of-tor-browser-alpha/){target="_blank"}
+[^7]: [New Alpha Release: Tor Browser 16.0a6, The Tor Project 2026-05-07](https://blog.torproject.org/new-alpha-release-tor-browser-160a6/){target="_blank"}
+[^8]: [New Alpha Release: Tor Browser 16.0a9, The Tor Project 2026-07-23](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}
+[^9]: [Security Vulnerabilities fixed in Firefox 151.0.3 (MFSA-2026-54), Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-54/){target="_blank"}
+[^10]: [Bug 1995077: Replace Object.keys with specialized iterator in Scalar Replacement, Mozilla Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1995077){target="_blank"}
+[^11]: [Security Vulnerabilities fixed in Firefox ESR 140.12 (MFSA-2026-58), Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-58/){target="_blank"}
+[^12]: [CVE-2026-10702 CSAF VEX, Red Hat](https://security.access.redhat.com/data/csaf/v2/vex/2026/cve-2026-10702.json){target="_blank"}
+[^13]: [Tails 7.10, Tails 2026-07-23](https://blog.torproject.org/new-release-tails-7_10/){target="_blank"}
+[^14]: [NVD - CVE-2026-10702](https://nvd.nist.gov/vuln/detail/CVE-2026-10702){target="_blank"}
+[^15]: [IonStack Part II: GhostLock, Nebula Security](https://nebusec.ai/research/ionstack-part-2/){target="_blank"}
+[^16]: [CVE-2026-43499, Linux kernel CNA](https://git.kernel.org/pub/scm/linux/security/vulns.git/plain/cve/published/2026/CVE-2026-43499.mbox){target="_blank"}
+[^17]: [CVE-2026-53166, withdrawn, CVE Program](https://cveawg.mitre.org/api/cve/CVE-2026-53166){target="_blank"}
+[^18]: [SecurityLevel.sys.mjs, Tor Browser 15.0.19 source, The Tor Project](https://gitlab.torproject.org/tpo/applications/tor-browser/-/blob/tor-browser-140.13.0esr-15.0-1-build2/toolkit/components/securitylevel/SecurityLevel.sys.mjs){target="_blank"}
+[^19]: [A Flaw With the Security Level Slider in Tor Browser, Privacy Guides 2025-05-02](https://www.privacyguides.org/articles/2025/05/02/tor-security-slider-flaw/){target="_blank"}

--- a/docs/zh-CN/blog/posts/2026-firefox-jit-cve-tor-browser.md
+++ b/docs/zh-CN/blog/posts/2026-firefox-jit-cve-tor-browser.md
@@ -1,0 +1,180 @@
+---
+date: 2026-07-30
+authors:
+    - anoni-net
+categories:
+    - 技术
+    - Tor
+    - 隐私
+slug: 2026-firefox-jit-cve-tor-browser
+image: "assets/images/tor.webp"
+summary: "Tor Browser 稳定版没有受 Firefox 的 JIT 漏洞 CVE-2026-10702 影响，这段代码在 Firefox 147 才进入，稳定版跟随的 140 ESR 没有它。研究团队说他们也用这个漏洞攻陷了 Tor Browser，却没有指明版本与通道，媒体标题也没补上这个区分。这篇文章整理一套三步判读法，让你下次看到 Firefox 的 CVE 编号时能自己判断手上的 Tor Browser 是否受影响，后半说明漏洞原理与 IonStack 攻击链。"
+description: "CVE-2026-10702 是 Firefox JIT 编译器的类型混淆漏洞，被研究者串成 Android 的浏览器到 root 完整攻击链 IonStack。本文说明如何用 ESR 与 Rapid Release 的分支差异判断一个 Firefox CVE 会不会影响 Tor Browser，附上受影响对照表、漏洞原理，以及安全等级与 kernel 更新的具体行动建议。"
+---
+
+# 你的 Tor Browser 受影响吗：CVE-2026-10702 与 Firefox 的两条分支
+
+![Tor](./assets/images/tor.webp){style="border-radius: 10px;"}
+
+2026 年 7 月底，几家安全媒体同时出现类似的标题，说研究者证明访问一个恶意网页就能攻陷 Tor Browser。[^1] 标题说的漏洞编号是 CVE-2026-10702，一个 Firefox JavaScript 引擎的 JIT 编译器缺陷。研究团队 Nebula Security 的演示页把对象写得很明确，是一个 Firefox for Android 151.0（安装包 `fenix-151.0.multi.android-arm64-v8a.apk`），运行在 Android 17 的 ARM64 设备上，该页没有提到 Tor Browser。[^2] 不过他们的技术文章里有一句「We also used it to pwn Tor Browser」，攻陷 Tor Browser 的说法出自研究者本人，而那篇文章没有说是哪一版、哪一个通道、哪个平台。[^3]
+
+对照各方资料，Tor Browser 稳定版没有受这个漏洞影响，原因在于稳定版建立在 Firefox ESR 这条分支上，而这个漏洞的代码在 Firefox 147 才进入，140 ESR 没有它。目前也没有一手资料显示这个漏洞在野利用（exploited in the wild），CVE 记录里 CISA 的 SSVC 评估把 Exploitation 标为 none。[^4]
+
+!!! tip "先确认你手上这一版"
+
+    从 torproject.org 下载、平常让它自动更新的人，用的就是稳定版，没有受这个漏洞影响。要确认版本号，打开右上角的汉堡菜单，选 Help，再选 About Tor Browser，画面上的 15.0.x 就是你的版本。除非你刻意去下载过标示 Alpha 的测试版，你的就是稳定版。
+
+    画面上另外那组 140.13.0esr 是它内部使用的 Firefox 版本，判读漏洞影响范围时看的是这一组，本文后面会用到。
+
+<!-- more -->
+
+## ESR 与 Rapid Release 是两条分支
+
+Tor Browser 稳定版跟随 Firefox ESR（Extended Support Release，延长支持版本），15.0.x 系列建立在 140 ESR 上，2026 年 7 月 21 日的 15.0.19 把基础版本换到 140.13.0esr，Android 版的 GeckoView 同步换成同一个基础版本。[^5]
+
+Tor Browser Alpha 走另一条路。Tor Project 在 2025 年 12 月的公告里宣布，Alpha 通道自 16.0a1 起改成跟随 Firefox 的快速发布线，并写下这个取舍，快速把上游功能送给用户，也会快速把上游的错误一起送过去。同一份公告写得更直接：「如果你是高风险用户、在意自己的隐私，或只是需要一个稳定可用的浏览器，你不应该使用 Tor Browser Alpha。」[^6] 实际换基础版本发生在 2026 年 5 月 7 日的 16.0a6，该版公告写着「Tor Browser Alphas are now based on Firefox's betas」，基础版本换成 Firefox 150.0a1，在此之前的 Alpha 仍建立在 ESR 上。[^7] 2026 年 7 月 23 日的 16.0a9 又换回 ESR，基础版本是 Firefox 153.0esr，衔接下一代稳定版。[^8]
+
+Mozilla 在 2026 年 6 月 2 日发布的 Firefox 151.0.3 修掉这个漏洞。[^9] 这段代码何时进入 Firefox 有一手记录可查，Bugzilla `1995077`（Replace Object.keys with specialized iterator in Scalar Replacement）的 target milestone 是 147 Branch，`firefox147` 标记为 fixed，而 esr140 的追踪字段是空的。[^10] 同期的 ESR 公告 MFSA-2026-58（Firefox ESR 140.12，6 月 16 日）列了 28 个 CVE，没有这一个。[^11] Red Hat 的 CSAF VEX 也把 RHEL 6 到 10 的 firefox 软件包全部标记为 `known_not_affected`，而 RHEL 附带的正是 ESR 版。[^12] 三条独立线索指向同一个结论，140 ESR 这条线没有这段代码。把各个对象排开来看：
+
+| 对象 | Firefox 基础版本 | 是否受影响 | 你要做什么 |
+|---|---|---|---|
+| 不确定自己用哪一版 | 几乎都是稳定版，140 ESR | 未受影响 | 让它更新完，再用 About 画面确认一次 |
+| Tor Browser 15.0.x 稳定版 | 140 ESR | 未受影响 | 保持最新版 |
+| Tor Browser for Android 稳定版 | GeckoView 140.13.0esr | 未受影响 | 保持最新版 |
+| Tor Browser Alpha 16.0a6（2026-05-07） | Firefox 150.0a1 | 受影响 | 升到 16.0a8 以上，或换回稳定版 |
+| Tor Browser Alpha 16.0a7（2026-06-03） | Firefox 151.0a1 | 受影响 | 升到 16.0a8 以上，或换回稳定版 |
+| Tor Browser Alpha 16.0a8（2026-07-02） | Firefox 152.0a1 | 未受影响 | 保持最新版 |
+| Tor Browser Alpha 16.0a9 起（2026-07-23） | Firefox 153.0esr | 未受影响 | 保持最新版 |
+| 一般 Firefox 桌面版与 Android 版 | Rapid Release，151.0.2 以前 | 受影响 | 升到 151.0.3 以上 |
+| Tails 内置的 Tor Browser | Tails 7.10 内含 15.0.19 | 未受影响 | 随 Tails 更新 |
+
+16.0a6 与 16.0a7 的基础版本都早于修补落地的 151.0.3，两版一律当成受影响处理。表格里的判定都是从基础版本反推而来，Tor Project 没有逐版说明过。Tails 那一行依据 Tails 7.10 的公告，该版内含 Tor Browser 15.0.19。[^13]
+
+## 三步判读法
+
+下次看到一个 Firefox 的 CVE 编号，依序检查这三件事，多数情况能自己得出结论。前两步是交叉验证，若你不想查英文数据库，直接看第三步。
+
+**第一步，看 Mozilla 有没有同时发 ESR 公告。** Mozilla 为 ESR 分支发布独立的 MFSA 编号。这次 MFSA-2026-54 只列出 Firefox 151.0.3 的两个 CVE，而同期的 ESR 公告 MFSA-2026-58 不含这一个。换成一句好记的判断：Tor Browser 稳定版遇到 Firefox 的 CVE，通常只有在 Mozilla 同时发 ESR 公告时才需要紧张。
+
+**第二步，看 Red Hat 的 VEX 数据。** RHEL 附带的 Firefox 是 ESR 版本，所以 Red Hat 对某个 CVE 的判定，实质上就是对 ESR 分支的判定。这次 Red Hat 的 CSAF VEX 文件把 RHEL 6 到 10 的 firefox 软件包全部标记为 `known_not_affected`。若运气好，Mozilla 的 Bugzilla 编号也可能是公开的，像这次的 `1995077` 就能直接看到代码落在哪一个 Branch。
+
+**第三步，看手上这个 Tor Browser 版本的 Firefox 基础版本。** Tor Browser 的公告在 Firefox 安全更新这一项不列个别 CVE 编号，一律只写「includes important security updates to Firefox」，所以需自己从基础版本反推。本站的 [Tor 更新日志](../../changelog/tor.md) 整理了近期版本的 Firefox 基础版本，稳定版与 Alpha 通道都有。简体版目前回溯到 15.0.15 与 16.0a7，更早的条目只在正体中文版提供，再往前需回上游的 release notes 查。
+
+**别只看 CVSS 分数。** 同一个漏洞在不同数据库的评分差距很大，NVD 页面上 CISA-ADP 给的 CVSS 3.1 是 4.3（Medium），Red Hat 给 7.5（High），Mozilla 自己评 High。[^14] 差距来自评分方法本身，CVSS 只评估单个漏洞在孤立情况下的影响，而 renderer 内的代码执行看起来影响有限，因为沙箱还在。这个漏洞的实际分量来自它是一条完整攻击链的第一段，把它放回链里看才准确，后面两节就在拆解这条链。
+
+## 漏洞原理：编译器被自己的标记骗了
+
+JIT（Just-In-Time，即时编译）的工作是把反复执行的 JavaScript 转成机器码，让热点代码的运行速度比逐行解释快上数十倍。要编得快，编译器必须知道每个操作会不会改动内存。若某个操作只读取数据，后面再次读取同一个位置时，编译器可以放心省略那次载入，直接沿用先前获取的值。
+
+仓库的管理员在清单上注明某位访客只会清点货物、不会搬动任何东西。这位访客实际上把整柜货搬到新位置，还把旧柜子拆了。后面的人依照清单判断「反正没人动过」，继续照原地址去取货，那个位置已经拆掉，还可能已经堆上别人搬进来的箱子。
+
+Firefox 的 JavaScript 引擎 SpiderMonkey 里的 `MObjectToIterator` 操作，在 `skipRegistration` 开启时被标记成只会读取数据。实际行为并非如此，它在解析延迟属性（lazy property）的过程中会分配一块新的动态存储区（dynamic slots）缓冲区，并且释放掉旧的那一块。
+
+接手的优化阶段称为 global value numbering（全局值编号），职责是找出重复计算并消除。它看到标记写着这里什么都没改，于是判断后面那次载入 slots 指针的动作是多余的，直接沿用先前那个指针，而那个指针指向的内存已经被释放。编译出来的机器码因此握着一个悬空指针（dangling pointer）读写内存，攻击者由此获取任意读写能力，在 renderer 进程内执行自己的代码。global value numbering 属于 IonMonkey 这条优化管线，攻击链名为 IonStack，研究者没有解释命名由来。
+
+到这一步，攻击者的代码仍被关在 renderer 的沙箱里，要碰到你的文件与其他数据，还需要第二个漏洞。
+
+Mozilla 的修补移除了那个依 `skipRegistration` 分岔的别名集合，让这个操作一律被当成会改动内存。公告编号 MFSA-2026-54，评级 High，报告者记为 Nebula Security。分类上这个漏洞同时对应 CWE-843（类型混淆，type confusion）与 CWE-733（编译器优化移除或改动安全关键代码），后者精准描述了问题出在优化决策本身。对应的 Bugzilla 编号 `2040903` 目前仍限制访问，上面的机制描述与修补内容来自研究者公开的技术文章。[^3]
+
+## 攻击链 IonStack：从浏览器一路到 root
+
+研究团队把这个漏洞放在攻击链的第一段，负责在浏览器的 renderer 沙箱内获取代码执行能力，第二段负责跳出沙箱、取得整台设备的控制权。两段合起来称为 IonStack，演示平台是 Android 17 的 ARM64 设备。
+
+第二段是 CVE-2026-43499，别名 GhostLock，位置在 Linux kernel 的 futex 优先级继承（priority inheritance）代码，也就是 glibc `PTHREAD_PRIO_INHERIT` 互斥锁背后的机制。加锁操作失败并回退时，清理代码清掉了错误那一方的记录，等待中的 task 带着一个仍指向自己内核栈的指针返回用户空间。那块栈内存随后被别的东西用掉，后续遍历优先级链时就落在已释放的栈上，属于释放后使用（use-after-free）。研究者自己把它称为 stack-UAF，并指出这类漏洞多半发生在堆上，落在内核栈的少见。[^15]
+
+这一段攻击的是你的操作系统，与浏览器无关。受影响文件是 `kernel/locking/rtmutex.c`，问题从 2011 年的 Linux 2.6.39 就存在，一路到 v7.1-rc1，主线在 7.1 修好。[^16] 唯一的条件是 kernel 编译时开了 `CONFIG_FUTEX_PI`，实务上等同每个发行版都开，可以直接当成全部受影响。在 Google kernelCTF 的 x86 靶机上（lts-6.12.80，且未开启 `RANDOMIZE_KSTACK_OFFSET`），这个 exploit 从普通权限取得 root 约需 5 秒，稳定性约 97%，在使用标准 kernel 的容器内同样有效。上游 4 月 18 日收到报告、4 月 20 日修好，5 月 4 日 backport，7 月 7 日公开。第一版修补引入的崩溃问题曾另编为 CVE-2026-53166，6 月 2 日修好，该编号后于 7 月 10 日被 Linux CNA 撤销。[^17]
+
+只要 kernel 没有更新，未来任何一个能在 renderer 内执行代码的浏览器漏洞，都能接上同一段提权。修好浏览器只挡掉了这一次的入口。
+
+## 现在该做的事
+
+**Tor Browser 更新到最新版。** 开着浏览器让它自己更新，或从 torproject.org 重新下载。这个漏洞影响不到稳定版，15.0.19 仍带了从 Firefox 153 backport 的其他安全修补。
+
+**一般 Firefox 升到 151.0.3 以上。** 桌面版与 Android 版都要。
+
+**Alpha 通道不要当日常浏览器用。** 这是 Tor Project 自己的建议，这次刚好是实例。
+
+**安全等级调到 Safer 或 Safest 可以挡掉整类 JIT 漏洞。** 这两个等级会关闭 `javascript.options.ion` 与 `javascript.options.baselinejit`，JIT 直接停用，编译器层的缺陷就失去触发机会。[^18] 操作是点地址栏旁的盾牌图标，选 Change，再选等级，不需要进 `about:config` 改任何设置。代价要先知道：Safer 会关掉 HTTP 站点的 JavaScript 与部分字体，Safest 默认关闭全站 JavaScript，部分网站的表单会送不出去。更详细的取舍可以参考本站的 [Tor Browser 进阶设置](../../tools/tor-browser-advanced.md)。
+
+**改完安全等级要关掉所有 Tor Browser 窗口再重新打开。** Tor Project 官方的安全等级说明页没有提到 JIT，只列出 JavaScript 与字体、音视频的变化，所以光看官方文件不会知道 JIT 这件事。Privacy Guides 在 2025 年 5 月测 Tor Browser 14.5.1 时发现，没有重新启动的话 JIT 仍在运作，界面却已经显示成 Safer。[^19] 15.x 桌面版已经修掉这个沉默失败，切换等级会提示重启（tor-browser issue `43783`），Android 版的同一套整合到 16.0 才完成。原则不变，改完就重启。
+
+**Windows 与 macOS 用户只需做上面这些。** 攻击链的第二段是 Linux kernel 的漏洞，这两个平台不适用。
+
+**Linux 桌面用户更新 kernel，并且重启。** kernel 更新没有重启不会生效，这一步最常被漏掉。更新后用 `uname -r` 确认正在运行的版本，并对照发行版对 CVE-2026-43499 的公告状态，不要假设已经处理好。编译期的缓解选项（例如 `CONFIG_STATIC_USERMODE_HELPER`）需重新编译 kernel，一般桌面用户做不到。自行维护服务器或 relay 的人可以评估启动参数 `randomize_kstack_offset=on`，前提是发行版的 kernel 已带入 `CONFIG_RANDOMIZE_KSTACK_OFFSET`，它只增加约 5 个 bit 的猜测成本，算是拖延而非修补。
+
+**Android 用户需等设备厂商的系统更新。** kernel 层的提权在用户端没有自救方式，更新何时送达取决于设备厂商与运营商。
+
+## 一个 CVE 编号不足以判断影响范围
+
+同一份源代码分成两条发布线之后，两条线就是两份不同的代码。这个漏洞的代码在 Firefox 147 才进入，稳定版跟随的 140 ESR 没有它，而跟随快速发布线的 Alpha 通道有。三步判读法要回答的就是这件事，看 Mozilla 有没有发 ESR 公告、看 Red Hat 对 ESR 版软件包的判定、看手上这个版本的 Firefox 基础版本。
+
+攻陷 Tor Browser 的说法出自研究者本人，他们没有指明版本与通道，媒体标题也没有补上这个区分。读者手上只有一个 CVE 编号与一句没有版本的宣称，剩下的只能自己往下查。下次遇到类似的标题，先问它说的是哪一条分支。
+
+## 没有把握的部分
+
+- 研究者没有说明他们攻陷的是哪一版 Tor Browser。〈IonStack Part I〉只有「We also used it to pwn Tor Browser」这一句，没有版本、通道与平台，演示页与媒体报道也都没有。这无法排除他们攻陷的是 Alpha 通道，也无法排除其他可能。
+- Tor Browser 16.0a6 与 16.0a7 的 Firefox 基础版本早于修补落地的 151.0.3，本文据此列为受影响。dist 目录已不再提供这两版，无法对二进制文件验证是否含有修补。
+- Whonix 内置的 Tor Browser 走哪一条通道，查不到可以支撑的官方页面，所以没有列进对照表。Whonix 的文件只建议使用稳定版。
+- Tor Project 至今没有针对这个 CVE 发过任何公开说明。
+- Bugzilla 编号 `2040903` 需要权限才能访问，无法读到原始修补内容。
+
+## 名词对照
+
+正文出现的英文词与缩写都收在这里，读到卡住时可以回来查。
+
+| 名词 | 说明 |
+|---|---|
+| JIT（Just-In-Time） | 即时编译，把反复执行的代码转成机器码以加速 |
+| SpiderMonkey | Firefox 的 JavaScript 引擎 |
+| IonMonkey、Warp | SpiderMonkey 里负责优化编译的管线，Warp 是前端，IonMonkey 负责后续优化与生成机器码 |
+| global value numbering | 全局值编号，找出重复计算并消除的优化阶段 |
+| lazy property（延迟属性） | 等到被访问时才真正建立的对象属性 |
+| dynamic slots（动态存储区） | 对象属性值的动态存储区，容量不足时会重新分配 |
+| dangling pointer（悬空指针） | 指向已被释放内存的指针 |
+| use-after-free（释放后使用） | 内存释放后仍被使用，常见的可利用漏洞类型 |
+| stack-UAF | 释放后使用的一种，被释放的内存位于内核栈而非堆 |
+| type confusion（类型混淆） | 程序把某类型的数据当成另一类型处理 |
+| sandbox（沙箱） | 限制程序能碰到哪些资源的隔离机制，浏览器用它把网页内容关起来 |
+| renderer 进程 | 浏览器负责解析与绘制网页内容的进程，受沙箱限制 |
+| root | 操作系统的最高权限账号，取得它等于控制整台设备 |
+| 提权（privilege escalation） | 从低权限取得高权限的攻击手法 |
+| exploit | 实际利用某个漏洞的程序或步骤 |
+| ESR（Extended Support Release） | Firefox 的延长支持版本，功能更新慢、修补期长 |
+| Rapid Release | Firefox 的快速发布通道，2026 年 7 月时约四周一个版本 |
+| 通道（channel） | 同一个软件的不同发布线，例如稳定版与 Alpha 测试版 |
+| 基础版本、rebase | Tor Browser 建立在某个 Firefox 版本之上，换到新版本的动作称为 rebase |
+| backport | 把新版的修补移植回旧的维护分支 |
+| futex | fast userspace mutex，Linux 的用户空间锁定机制 |
+| priority inheritance（优先级继承） | 避免高优先级任务被低优先级任务卡住的锁定机制 |
+| CWE | 漏洞类型的分类编号系统，描述问题属于哪一类 |
+| CVSS | 漏洞评分系统，给出 0 到 10 的严重度分数 |
+| SSVC | 另一套漏洞评估框架，CISA 用它标记是否已遭利用等字段 |
+| VEX | 漏洞可利用性交换格式，厂商用来声明自家产品是否受某个 CVE 影响 |
+| MFSA | Mozilla Foundation Security Advisory，Mozilla 的安全公告编号 |
+
+## 相关阅读
+
+- [Tor Browser 进阶设置](../../tools/tor-browser-advanced.md)
+- [Tor 更新日志](../../changelog/tor.md)
+- [什么是 Tor](../../tools/what-is-tor.md)
+- [威胁模型如何建立](../../basics/threat-model.md)
+
+[^1]: [Researchers Show a Single Malicious Webpage Visit Can Compromise Tor Browser, The Hacker News 2026-07](https://thehackernews.com/2026/07/researchers-show-single-malicious.html){target="_blank"}
+[^2]: [IonStack 演示页, Nebula Security](https://rootme.nebusec.io/){target="_blank"}
+[^3]: [IonStack Part I：CVE-2026-10702, Nebula Security](https://nebusec.ai/research/ionstack-part-1-cve-2026-10702/){target="_blank"}
+[^4]: [CVE-2026-10702 记录（含 CISA-ADP 的 SSVC 评估）, CVE Program](https://cveawg.mitre.org/api/cve/CVE-2026-10702){target="_blank"}
+[^5]: [New Release: Tor Browser 15.0.19, The Tor Project 2026-07-21](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}
+[^6]: [The Future of Tor Browser Alpha, The Tor Project 2025-12-01](https://blog.torproject.org/future-of-tor-browser-alpha/){target="_blank"}
+[^7]: [New Alpha Release: Tor Browser 16.0a6, The Tor Project 2026-05-07](https://blog.torproject.org/new-alpha-release-tor-browser-160a6/){target="_blank"}
+[^8]: [New Alpha Release: Tor Browser 16.0a9, The Tor Project 2026-07-23](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}
+[^9]: [Security Vulnerabilities fixed in Firefox 151.0.3（MFSA-2026-54）, Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-54/){target="_blank"}
+[^10]: [Bug 1995077：Replace Object.keys with specialized iterator in Scalar Replacement, Mozilla Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1995077){target="_blank"}
+[^11]: [Security Vulnerabilities fixed in Firefox ESR 140.12（MFSA-2026-58）, Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-58/){target="_blank"}
+[^12]: [CVE-2026-10702 CSAF VEX, Red Hat](https://security.access.redhat.com/data/csaf/v2/vex/2026/cve-2026-10702.json){target="_blank"}
+[^13]: [Tails 7.10, Tails 2026-07-23](https://blog.torproject.org/new-release-tails-7_10/){target="_blank"}
+[^14]: [NVD - CVE-2026-10702](https://nvd.nist.gov/vuln/detail/CVE-2026-10702){target="_blank"}
+[^15]: [IonStack Part II：GhostLock, Nebula Security](https://nebusec.ai/research/ionstack-part-2/){target="_blank"}
+[^16]: [CVE-2026-43499, Linux kernel CNA](https://git.kernel.org/pub/scm/linux/security/vulns.git/plain/cve/published/2026/CVE-2026-43499.mbox){target="_blank"}
+[^17]: [CVE-2026-53166（已撤销）, CVE Program](https://cveawg.mitre.org/api/cve/CVE-2026-53166){target="_blank"}
+[^18]: [SecurityLevel.sys.mjs（Tor Browser 15.0.19 源代码）, The Tor Project](https://gitlab.torproject.org/tpo/applications/tor-browser/-/blob/tor-browser-140.13.0esr-15.0-1-build2/toolkit/components/securitylevel/SecurityLevel.sys.mjs){target="_blank"}
+[^19]: [A Flaw With the Security Level Slider in Tor Browser, Privacy Guides 2025-05-02](https://www.privacyguides.org/articles/2025/05/02/tor-security-slider-flaw/){target="_blank"}

--- a/docs/zh-TW/blog/posts/2026-firefox-jit-cve-tor-browser.md
+++ b/docs/zh-TW/blog/posts/2026-firefox-jit-cve-tor-browser.md
@@ -32,9 +32,9 @@ description: "CVE-2026-10702 是 Firefox JIT 編譯器的類型混淆漏洞，�
 
 Tor Browser 穩定版跟隨 Firefox ESR（Extended Support Release，延長支援版本），15.0.x 系列建立在 140 ESR 上，2026 年 7 月 21 日的 15.0.19 把基底換到 140.13.0esr，Android 版的 GeckoView 同步換成同一個基底。[^5]
 
-Tor Browser Alpha 走另一條路。Tor Project 在 2025 年 12 月的公告裡宣布，Alpha 通道自 16.0a1 起改成跟隨 Firefox 的快速發布線，並寫下這個取捨，快速把上游功能送給使用者，也會快速把上游的錯誤一起送過去。同一份公告寫得更直接：「如果你是高風險使用者、在意自己的隱私，或只是需要一個穩定可用的瀏覽器，你不應該使用 Tor Browser Alpha。」[^6] 依本站 [Tor 更新日誌](../../changelog/tor.md) 的記錄，實際換基底發生在 2026 年 5 月 7 日的 16.0a6，該版起改以 Firefox beta 通道為基底，在此之前的 Alpha 仍建立在 ESR 上。2026 年 7 月 23 日的 16.0a9 又換回 ESR，基底是 Firefox 153.0esr，銜接下一代穩定版。[^7]
+Tor Browser Alpha 走另一條路。Tor Project 在 2025 年 12 月的公告裡宣布，Alpha 通道自 16.0a1 起改成跟隨 Firefox 的快速發布線，並寫下這個取捨，快速把上游功能送給使用者，也會快速把上游的錯誤一起送過去。同一份公告寫得更直接：「如果你是高風險使用者、在意自己的隱私，或只是需要一個穩定可用的瀏覽器，你不應該使用 Tor Browser Alpha。」[^6] 實際換基底發生在 2026 年 5 月 7 日的 16.0a6，該版公告寫著「Tor Browser Alphas are now based on Firefox's betas」，基底換成 Firefox 150.0a1，在此之前的 Alpha 仍建立在 ESR 上。[^7] 2026 年 7 月 23 日的 16.0a9 又換回 ESR，基底是 Firefox 153.0esr，銜接下一代穩定版。[^8]
 
-Mozilla 在 2026 年 6 月 2 日發布的 Firefox 151.0.3 修掉這支漏洞。[^8] 這段程式碼何時進入 Firefox 有一手記錄可查，Bugzilla `1995077`（Replace Object.keys with specialized iterator in Scalar Replacement）的 target milestone 是 147 Branch，`firefox147` 標記為 fixed，而 esr140 的追蹤欄位是空的。[^9] 同期的 ESR 公告 MFSA-2026-58（Firefox ESR 140.12，6 月 16 日）列了 28 支 CVE，沒有這一支。[^10] Red Hat 的 CSAF VEX 也把 RHEL 6 到 10 的 firefox 套件全部標記為 `known_not_affected`，而 RHEL 隨附的正是 ESR 版。[^11] 三條獨立線索指向同一個結論，140 ESR 這條線沒有這段程式碼。把各個對象排開來看：
+Mozilla 在 2026 年 6 月 2 日發布的 Firefox 151.0.3 修掉這支漏洞。[^9] 這段程式碼何時進入 Firefox 有一手記錄可查，Bugzilla `1995077`（Replace Object.keys with specialized iterator in Scalar Replacement）的 target milestone 是 147 Branch，`firefox147` 標記為 fixed，而 esr140 的追蹤欄位是空的。[^10] 同期的 ESR 公告 MFSA-2026-58（Firefox ESR 140.12，6 月 16 日）列了 28 支 CVE，沒有這一支。[^11] Red Hat 的 CSAF VEX 也把 RHEL 6 到 10 的 firefox 套件全部標記為 `known_not_affected`，而 RHEL 隨附的正是 ESR 版。[^12] 三條獨立線索指向同一個結論，140 ESR 這條線沒有這段程式碼。把各個對象排開來看：
 
 | 對象 | Firefox 基底 | 是否受影響 | 你要做什麼 |
 |---|---|---|---|
@@ -48,7 +48,7 @@ Mozilla 在 2026 年 6 月 2 日發布的 Firefox 151.0.3 修掉這支漏洞。[
 | 一般 Firefox 桌面版與 Android 版 | Rapid Release，151.0.2 以前 | 受影響 | 升到 151.0.3 以上 |
 | Tails 內建的 Tor Browser | Tails 7.10 內含 15.0.19 | 未受影響 | 隨 Tails 更新 |
 
-16.0a6 與 16.0a7 的基底都早於修補落地的 151.0.3，兩版一律當成受影響處理。表格裡的判定都是從基底版本反推而來，Tor Project 沒有逐版說明過。Tails 那一列依據 Tails 7.10 的公告，該版內含 Tor Browser 15.0.19。[^12]
+16.0a6 與 16.0a7 的基底都早於修補落地的 151.0.3，兩版一律當成受影響處理。表格裡的判定都是從基底版本反推而來，Tor Project 沒有逐版說明過。Tails 那一列依據 Tails 7.10 的公告，該版內含 Tor Browser 15.0.19。[^13]
 
 ## 三步判讀法
 
@@ -60,7 +60,7 @@ Mozilla 在 2026 年 6 月 2 日發布的 Firefox 151.0.3 修掉這支漏洞。[
 
 **第三步，看手上這個 Tor Browser 版本的 Firefox 基底。** Tor Browser 的公告在 Firefox 安全更新這一項不列個別 CVE 編號，一律只寫「includes important security updates to Firefox」，所以需自己從基底版本反推。本站的 [Tor 更新日誌](../../changelog/tor.md) 整理了近期版本的 Firefox 基底，穩定版與 Alpha 通道都有，目前回溯到 15.0.11。更舊的版本需回上游的 release notes 查。
 
-**別只看 CVSS 分數。** 同一支漏洞在不同資料庫的評分差距很大，NVD 頁面上 CISA-ADP 給的 CVSS 3.1 是 4.3（Medium），Red Hat 給 7.5（High），Mozilla 自己評 High。[^13] 差距來自評分方法本身，CVSS 只評估單一漏洞在孤立情況下的影響，而 renderer 內的程式碼執行看起來影響有限，因為沙箱還在。這支漏洞的實際份量來自它是一條完整攻擊鏈的第一段，把它放回鏈裡看才準確，後面兩節就在拆解這條鏈。
+**別只看 CVSS 分數。** 同一支漏洞在不同資料庫的評分差距很大，NVD 頁面上 CISA-ADP 給的 CVSS 3.1 是 4.3（Medium），Red Hat 給 7.5（High），Mozilla 自己評 High。[^14] 差距來自評分方法本身，CVSS 只評估單一漏洞在孤立情況下的影響，而 renderer 內的程式碼執行看起來影響有限，因為沙箱還在。這支漏洞的實際份量來自它是一條完整攻擊鏈的第一段，把它放回鏈裡看才準確，後面兩節就在拆解這條鏈。
 
 ## 漏洞原理：編譯器被自己的標記騙了
 
@@ -80,9 +80,9 @@ Mozilla 的修補移除了那個依 `skipRegistration` 分岔的別名集合，�
 
 研究團隊把這支漏洞放在攻擊鏈的第一段，負責在瀏覽器的 renderer 沙箱內取得程式執行能力，第二段負責跳出沙箱、取得整台裝置的控制權。兩段合起來稱為 IonStack，示範平台是 Android 17 的 ARM64 裝置。
 
-第二段是 CVE-2026-43499，別名 GhostLock，位置在 Linux kernel 的 futex 優先權繼承（priority inheritance）程式碼，也就是 glibc `PTHREAD_PRIO_INHERIT` 互斥鎖背後的機制。上鎖操作失敗並回退時，清理程式碼清掉了錯誤那一方的紀錄，等待中的 task 帶著一個仍指向自己核心堆疊的指標返回使用者空間。那塊堆疊記憶體隨後被別的東西用掉，後續走訪優先權鏈時就踩在已釋放的堆疊上，屬於釋放後使用（use-after-free）。研究者自己把它稱為 stack-UAF，並指出這類漏洞多半發生在堆積上，落在核心堆疊的少見。[^14]
+第二段是 CVE-2026-43499，別名 GhostLock，位置在 Linux kernel 的 futex 優先權繼承（priority inheritance）程式碼，也就是 glibc `PTHREAD_PRIO_INHERIT` 互斥鎖背後的機制。上鎖操作失敗並回退時，清理程式碼清掉了錯誤那一方的紀錄，等待中的 task 帶著一個仍指向自己核心堆疊的指標返回使用者空間。那塊堆疊記憶體隨後被別的東西用掉，後續走訪優先權鏈時就踩在已釋放的堆疊上，屬於釋放後使用（use-after-free）。研究者自己把它稱為 stack-UAF，並指出這類漏洞多半發生在堆積上，落在核心堆疊的少見。[^15]
 
-這一段攻擊的是你的作業系統，與瀏覽器無關。受影響檔案是 `kernel/locking/rtmutex.c`，問題從 2011 年的 Linux 2.6.39 就存在，一路到 v7.1-rc1，主線在 7.1 修好。[^15] 唯一的條件是 kernel 編譯時開了 `CONFIG_FUTEX_PI`，實務上等同每個發行版都開，可以直接當成全部受影響。在 Google kernelCTF 的 x86 靶機上（lts-6.12.80，且未開啟 `RANDOMIZE_KSTACK_OFFSET`），這支 exploit 從一般權限取得 root 約需 5 秒，穩定度約 97%，在使用標準 kernel 的容器內同樣有效。上游 4 月 18 日收到回報、4 月 20 日修好，5 月 4 日 backport，7 月 7 日公開。第一版修補引入的當機問題曾另編為 CVE-2026-53166，6 月 2 日修好，該編號後於 7 月 10 日被 Linux CNA 撤回。[^16]
+這一段攻擊的是你的作業系統，與瀏覽器無關。受影響檔案是 `kernel/locking/rtmutex.c`，問題從 2011 年的 Linux 2.6.39 就存在，一路到 v7.1-rc1，主線在 7.1 修好。[^16] 唯一的條件是 kernel 編譯時開了 `CONFIG_FUTEX_PI`，實務上等同每個發行版都開，可以直接當成全部受影響。在 Google kernelCTF 的 x86 靶機上（lts-6.12.80，且未開啟 `RANDOMIZE_KSTACK_OFFSET`），這支 exploit 從一般權限取得 root 約需 5 秒，穩定度約 97%，在使用標準 kernel 的容器內同樣有效。上游 4 月 18 日收到回報、4 月 20 日修好，5 月 4 日 backport，7 月 7 日公開。第一版修補引入的當機問題曾另編為 CVE-2026-53166，6 月 2 日修好，該編號後於 7 月 10 日被 Linux CNA 撤回。[^17]
 
 只要 kernel 沒有更新，未來任何一支能在 renderer 內執行程式碼的瀏覽器漏洞，都能接上同一段提權。修好瀏覽器只擋掉了這一次的入口。
 
@@ -94,9 +94,9 @@ Mozilla 的修補移除了那個依 `skipRegistration` 分岔的別名集合，�
 
 **Alpha 通道不要當日常瀏覽器用。** 這是 Tor Project 自己的建議，這次剛好是實例。
 
-**安全等級調到 Safer 或 Safest 可以擋掉整類 JIT 漏洞。** 這兩個等級會關閉 `javascript.options.ion` 與 `javascript.options.baselinejit`，JIT 直接停用，編譯器層的缺陷就失去觸發機會。[^17] 操作是點網址列旁的盾牌圖示，選 Change，再選等級，不需要進 `about:config` 改任何設定。代價要先知道：Safer 會關掉 HTTP 站點的 JavaScript 與部分字型，Safest 預設關閉全站 JavaScript，部分網站的表單會送不出去。更詳細的取捨可以參考本站的 [Tor Browser 進階設定](../../tools/tor-browser-advanced.md)。
+**安全等級調到 Safer 或 Safest 可以擋掉整類 JIT 漏洞。** 這兩個等級會關閉 `javascript.options.ion` 與 `javascript.options.baselinejit`，JIT 直接停用，編譯器層的缺陷就失去觸發機會。[^18] 操作是點網址列旁的盾牌圖示，選 Change，再選等級，不需要進 `about:config` 改任何設定。代價要先知道：Safer 會關掉 HTTP 站點的 JavaScript 與部分字型，Safest 預設關閉全站 JavaScript，部分網站的表單會送不出去。更詳細的取捨可以參考本站的 [Tor Browser 進階設定](../../tools/tor-browser-advanced.md)。
 
-**改完安全等級要關掉所有 Tor Browser 視窗再重新開啟。** Tor Project 官方的安全等級說明頁沒有提到 JIT，只列出 JavaScript 與字型、影音的變化，所以光看官方文件不會知道 JIT 這件事。Privacy Guides 在 2025 年 5 月測 Tor Browser 14.5.1 時發現，沒有重新啟動的話 JIT 仍在運作，介面卻已經顯示成 Safer。[^18] 15.x 桌面版已經修掉這個沉默失敗，切換等級會提示重啟（tor-browser issue `43783`），Android 版的同一套整合到 16.0 才完成。原則不變，改完就重啟。
+**改完安全等級要關掉所有 Tor Browser 視窗再重新開啟。** Tor Project 官方的安全等級說明頁沒有提到 JIT，只列出 JavaScript 與字型、影音的變化，所以光看官方文件不會知道 JIT 這件事。Privacy Guides 在 2025 年 5 月測 Tor Browser 14.5.1 時發現，沒有重新啟動的話 JIT 仍在運作，介面卻已經顯示成 Safer。[^19] 15.x 桌面版已經修掉這個沉默失敗，切換等級會提示重啟（tor-browser issue `43783`），Android 版的同一套整合到 16.0 才完成。原則不變，改完就重啟。
 
 **Windows 與 macOS 使用者只需做上面這些。** 攻擊鏈的第二段是 Linux kernel 的漏洞，這兩個平台不適用。
 
@@ -165,15 +165,16 @@ Mozilla 的修補移除了那個依 `skipRegistration` 分岔的別名集合，�
 [^4]: [CVE-2026-10702 記錄（含 CISA-ADP 的 SSVC 評估）, CVE Program](https://cveawg.mitre.org/api/cve/CVE-2026-10702){target="_blank"}
 [^5]: [New Release: Tor Browser 15.0.19, The Tor Project 2026-07-21](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}
 [^6]: [The Future of Tor Browser Alpha, The Tor Project 2025-12-01](https://blog.torproject.org/future-of-tor-browser-alpha/){target="_blank"}
-[^7]: [New Alpha Release: Tor Browser 16.0a9, The Tor Project 2026-07-23](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}
-[^8]: [Security Vulnerabilities fixed in Firefox 151.0.3（MFSA-2026-54）, Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-54/){target="_blank"}
-[^9]: [Bug 1995077：Replace Object.keys with specialized iterator in Scalar Replacement, Mozilla Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1995077){target="_blank"}
-[^10]: [Security Vulnerabilities fixed in Firefox ESR 140.12（MFSA-2026-58）, Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-58/){target="_blank"}
-[^11]: [CVE-2026-10702 CSAF VEX, Red Hat](https://security.access.redhat.com/data/csaf/v2/vex/2026/cve-2026-10702.json){target="_blank"}
-[^12]: [Tails 7.10, Tails 2026-07-23](https://blog.torproject.org/new-release-tails-7_10/){target="_blank"}
-[^13]: [NVD - CVE-2026-10702](https://nvd.nist.gov/vuln/detail/CVE-2026-10702){target="_blank"}
-[^14]: [IonStack Part II：GhostLock, Nebula Security](https://nebusec.ai/research/ionstack-part-2/){target="_blank"}
-[^15]: [CVE-2026-43499, Linux kernel CNA](https://git.kernel.org/pub/scm/linux/security/vulns.git/plain/cve/published/2026/CVE-2026-43499.mbox){target="_blank"}
-[^16]: [CVE-2026-53166（已撤回）, CVE Program](https://cveawg.mitre.org/api/cve/CVE-2026-53166){target="_blank"}
-[^17]: [SecurityLevel.sys.mjs（Tor Browser 15.0.19 原始碼）, The Tor Project](https://gitlab.torproject.org/tpo/applications/tor-browser/-/blob/tor-browser-140.13.0esr-15.0-1-build2/toolkit/components/securitylevel/SecurityLevel.sys.mjs){target="_blank"}
-[^18]: [A Flaw With the Security Level Slider in Tor Browser, Privacy Guides 2025-05-02](https://www.privacyguides.org/articles/2025/05/02/tor-security-slider-flaw/){target="_blank"}
+[^7]: [New Alpha Release: Tor Browser 16.0a6, The Tor Project 2026-05-07](https://blog.torproject.org/new-alpha-release-tor-browser-160a6/){target="_blank"}
+[^8]: [New Alpha Release: Tor Browser 16.0a9, The Tor Project 2026-07-23](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}
+[^9]: [Security Vulnerabilities fixed in Firefox 151.0.3（MFSA-2026-54）, Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-54/){target="_blank"}
+[^10]: [Bug 1995077：Replace Object.keys with specialized iterator in Scalar Replacement, Mozilla Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1995077){target="_blank"}
+[^11]: [Security Vulnerabilities fixed in Firefox ESR 140.12（MFSA-2026-58）, Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-58/){target="_blank"}
+[^12]: [CVE-2026-10702 CSAF VEX, Red Hat](https://security.access.redhat.com/data/csaf/v2/vex/2026/cve-2026-10702.json){target="_blank"}
+[^13]: [Tails 7.10, Tails 2026-07-23](https://blog.torproject.org/new-release-tails-7_10/){target="_blank"}
+[^14]: [NVD - CVE-2026-10702](https://nvd.nist.gov/vuln/detail/CVE-2026-10702){target="_blank"}
+[^15]: [IonStack Part II：GhostLock, Nebula Security](https://nebusec.ai/research/ionstack-part-2/){target="_blank"}
+[^16]: [CVE-2026-43499, Linux kernel CNA](https://git.kernel.org/pub/scm/linux/security/vulns.git/plain/cve/published/2026/CVE-2026-43499.mbox){target="_blank"}
+[^17]: [CVE-2026-53166（已撤回）, CVE Program](https://cveawg.mitre.org/api/cve/CVE-2026-53166){target="_blank"}
+[^18]: [SecurityLevel.sys.mjs（Tor Browser 15.0.19 原始碼）, The Tor Project](https://gitlab.torproject.org/tpo/applications/tor-browser/-/blob/tor-browser-140.13.0esr-15.0-1-build2/toolkit/components/securitylevel/SecurityLevel.sys.mjs){target="_blank"}
+[^19]: [A Flaw With the Security Level Slider in Tor Browser, Privacy Guides 2025-05-02](https://www.privacyguides.org/articles/2025/05/02/tor-security-slider-flaw/){target="_blank"}

--- a/docs/zh-TW/blog/posts/2026-firefox-jit-cve-tor-browser.md
+++ b/docs/zh-TW/blog/posts/2026-firefox-jit-cve-tor-browser.md
@@ -8,8 +8,8 @@ categories:
     - 隱私
 slug: 2026-firefox-jit-cve-tor-browser
 image: "assets/images/tor.webp"
-summary: "Tor Browser 穩定版沒有受 Firefox 的 JIT 漏洞 CVE-2026-10702 影響，關鍵在於穩定版建立在 Firefox ESR 分支上，而這支漏洞的程式碼只存在於 Rapid Release 那條線。7 月底幾家安全媒體的標題寫著造訪一個惡意網頁就能攻陷 Tor Browser，說的就是這支漏洞。這篇文章說明漏洞原理與 IonStack 攻擊鏈，並整理一套三步判讀法，讓你下次看到 Firefox 的 CVE 編號時能自己判斷手上的 Tor Browser 是否受影響。"
-description: "CVE-2026-10702 是 Firefox JIT 編譯器的類型混淆漏洞，被研究者串成 Android 的瀏覽器到 root 完整攻擊鏈 IonStack。本文說明漏洞原理、攻擊鏈組成，以及如何用 ESR 與 Rapid Release 的分支差異判斷一支 Firefox CVE 會不會影響 Tor Browser，附上安全等級與 kernel 更新的具體行動建議。"
+summary: "Tor Browser 穩定版沒有受 Firefox 的 JIT 漏洞 CVE-2026-10702 影響，關鍵在於穩定版建立在 Firefox ESR 分支上，而這支漏洞的程式碼只存在於 Rapid Release 那條線。7 月底幾家安全媒體的標題寫著造訪一個惡意網頁就能攻陷 Tor Browser，說的就是這支漏洞。這篇文章整理一套三步判讀法，讓你下次看到 Firefox 的 CVE 編號時能自己判斷手上的 Tor Browser 是否受影響，後半說明漏洞原理與 IonStack 攻擊鏈。"
+description: "CVE-2026-10702 是 Firefox JIT 編譯器的類型混淆漏洞，被研究者串成 Android 的瀏覽器到 root 完整攻擊鏈 IonStack。本文說明如何用 ESR 與 Rapid Release 的分支差異判斷一支 Firefox CVE 會不會影響 Tor Browser，附上受影響對照表、漏洞原理，以及安全等級與 kernel 更新的具體行動建議。"
 ---
 
 # 你的 Tor Browser 受影響嗎：CVE-2026-10702 與 Firefox 的兩條分支
@@ -28,6 +28,39 @@ description: "CVE-2026-10702 是 Firefox JIT 編譯器的類型混淆漏洞，�
 
 <!-- more -->
 
+## ESR 與 Rapid Release 是兩條分支
+
+Tor Browser 穩定版跟隨 Firefox ESR（Extended Support Release，延長支援版本），15.0.x 系列建立在 140 ESR 上，2026 年 7 月 21 日的 15.0.19 把基底換到 140.13.0esr，Android 版的 GeckoView 同步換成同一個基底。[^5]
+
+Tor Browser Alpha 走另一條路。Tor Project 在 2025 年 12 月的公告裡宣布，Alpha 通道自 16.0a1 起改成跟隨 Firefox 的快速發布線，並寫下這個取捨，快速把上游功能送給使用者，也會快速把上游的錯誤一起送過去。同一份公告寫得更直接：「如果你是高風險使用者、在意自己的隱私，或只是需要一個穩定可用的瀏覽器，你不應該使用 Tor Browser Alpha。」[^6] 依本站 [Tor 更新日誌](../../changelog/tor.md) 的記錄，實際換基底發生在 2026 年 5 月 7 日的 16.0a6，該版起改以 Firefox beta 通道為基底，在此之前的 Alpha 仍建立在 ESR 上。
+
+Mozilla 在 2026 年 6 月 2 日發布的 Firefox 151.0.3 修掉這支漏洞[^3]，而 Mozilla 沒有為 ESR 分支發布對應公告，Red Hat 也把隨附的 ESR 版 Firefox 標記為未受影響，兩者都指向同一個結論，CVE-2026-10702 的程式碼在 140 ESR 分支切出去之後才進入 Firefox。把各個對象排開來看：
+
+| 對象 | Firefox 基底 | 是否受影響 | 你要做什麼 |
+|---|---|---|---|
+| 不確定自己用哪一版 | 幾乎都是穩定版，140 ESR | 未受影響 | 讓它更新完，再用 About 畫面確認一次 |
+| Tor Browser 15.0.x 穩定版 | 140 ESR | 未受影響 | 保持最新版 |
+| Tor Browser for Android 穩定版 | GeckoView 140.13.0esr | 未受影響 | 保持最新版 |
+| Tor Browser Alpha 16.0a6（2026-05-07） | Firefox 150.0a1 | 受影響 | 升到 16.0a8 以上，或換回穩定版 |
+| Tor Browser Alpha 16.0a7（2026-06-03） | Firefox 151.0a1 | 受影響 | 升到 16.0a8 以上，或換回穩定版 |
+| Tor Browser Alpha 16.0a8 起（2026-07-02） | Firefox 152.0a1 | 未受影響 | 保持最新版 |
+| 一般 Firefox 桌面版與 Android 版 | Rapid Release，151.0.2 以前 | 受影響 | 升到 151.0.3 以上 |
+| Tails 與 Whonix 內建的 Tor Browser | 與穩定版同一條 ESR 線 | 未受影響 | 隨發行版更新 |
+
+16.0a6 與 16.0a7 的基底都早於修補落地的 151.0.3，兩版一律當成受影響處理。
+
+## 三步判讀法
+
+下次看到一支 Firefox 的 CVE 編號，依序檢查這三件事，多數情況能自己得出結論。前兩步是交叉驗證，若你不想查英文資料庫，直接看第三步。
+
+**第一步，看 Mozilla 有沒有同時發 ESR 公告。** Mozilla 為 ESR 分支發布獨立的 MFSA 編號。這次 MFSA-2026-54 只列出 Firefox 151.0.3，沒有任何對應的 ESR 公告。換成一句好記的判斷：Tor Browser 穩定版遇到 Firefox 的 CVE，通常只有在 Mozilla 同時發 ESR 公告時才需要緊張。
+
+**第二步，看 Red Hat 的 VEX 資料。** RHEL 隨附的 Firefox 是 ESR 版本，所以 Red Hat 對某支 CVE 的判定，實質上就是對 ESR 分支的判定。這次 Red Hat 的 CSAF VEX 文件把 RHEL 6 到 10 的 firefox 套件全部標記為 `known_not_affected`。[^7] Mozilla 沒發 ESR 公告、Red Hat 標記未受影響，兩個獨立來源指向同一個結論。
+
+**第三步，看手上這個 Tor Browser 版本的 Firefox 基底。** Tor Project 的更新日誌從不列出個別 CVE 編號，一律只寫「includes important security updates to Firefox」，所以需自己從基底版本反推。本站的 [Tor 更新日誌](../../changelog/tor.md) 整理了近期版本的 Firefox 基底，穩定版與 Alpha 通道都有，目前回溯到 15.0.11。更舊的版本需回上游的 release notes 查。
+
+**別只看 CVSS 分數。** 同一支漏洞在不同資料庫的評分差距很大，NVD 頁面上 CISA-ADP 給的 CVSS 3.1 是 4.3（Medium）[^8]，Red Hat 給 7.5（High）[^7]，Mozilla 自己評 High[^3]。差距來自評分方法本身，CVSS 只評估單一漏洞在孤立情況下的影響，而 renderer 內的程式碼執行看起來影響有限，因為沙箱還在。這支漏洞的實際份量來自它是一條完整攻擊鏈的第一段，把它放回鏈裡看才準確，後面兩節就在拆解這條鏈。
+
 ## 漏洞原理：編譯器被自己的標記騙了
 
 JIT（Just-In-Time，即時編譯）的工作是把反覆執行的 JavaScript 轉成機器碼，讓熱點程式碼的執行速度比逐行解譯快上數十倍。要編得快，編譯器必須知道每個操作會不會改動記憶體。若某個操作只讀取資料，後面再次讀取同一個位置時，編譯器可以放心省略那次載入，直接沿用先前取得的值。
@@ -40,53 +73,15 @@ Firefox 的 JavaScript 引擎 SpiderMonkey 裡的 `MObjectToIterator` 操作，�
 
 到這一步，攻擊者的程式碼仍被關在 renderer 的沙箱裡，要碰到你的檔案與其他資料，還需要第二支漏洞。
 
-Mozilla 在 2026 年 6 月 2 日發布 Firefox 151.0.3 修掉這支漏洞，公告編號 MFSA-2026-54，評級 High，回報者記為 Nebula Security。[^3] 修補方式是移除那個錯誤的唯讀標記處理。分類上這支同時對應 CWE-843（類型混淆，type confusion）與 CWE-733（編譯器最佳化移除或改動安全關鍵程式碼），後者精準描述了問題出在最佳化決策本身。對應的 Bugzilla 編號 `2040903` 目前仍限制存取，所以以下機制描述來自研究者與媒體的公開分析。
+Mozilla 的修補方式是移除那個錯誤的唯讀標記處理，公告編號 MFSA-2026-54，評級 High，回報者記為 Nebula Security。分類上這支同時對應 CWE-843（類型混淆，type confusion）與 CWE-733（編譯器最佳化移除或改動安全關鍵程式碼），後者精準描述了問題出在最佳化決策本身。對應的 Bugzilla 編號 `2040903` 目前仍限制存取，所以上面的機制描述來自研究者與媒體的公開分析。
 
 ## 攻擊鏈 IonStack：從瀏覽器一路到 root
 
 研究團隊把這支漏洞放在攻擊鏈的第一段，負責在瀏覽器的 renderer 沙箱內取得程式執行能力，第二段負責跳出沙箱、取得整台裝置的控制權。兩段合起來稱為 IonStack，示範平台是 Android 17 的 ARM64 裝置。
 
-第二段是 CVE-2026-43499，別名 GhostLock，一支 Linux kernel 的釋放後使用（use-after-free）漏洞。位置在 futex 的優先權繼承（priority inheritance）程式碼，也就是 glibc `PTHREAD_PRIO_INHERIT` 互斥鎖背後的機制。當一次上鎖操作失敗並回退時，清理程式碼在回退路徑上釋放了仍被參照的 task 結構，kernel 於是握著一個指向已釋放記憶體的指標。[^4]
-
-這一段攻擊的是你的作業系統，與瀏覽器無關。GhostLock 從 2011 年 5 月的 Linux 2.6.39-rc1 就存在，一路到 v7.1-rc1 都在，唯一的前提是編譯選項 `CONFIG_FUTEX_PI=y`，主流發行版預設都開啟。Nebula Security 公開的 exploit 從一般權限取得 root 約需 5 秒，成功率約 97%，在使用標準 kernel 的容器內同樣有效。上游在 2026 年 4 月 20 日以 commit `3bfdc63936dd` 修好，5 月 4 日 backport，7 月 7 日公開。第一版修補引入了新的當機問題，另外編為 CVE-2026-53166，截至 7 月初，這個回歸（regression）的後續修補尚未穩定。
+第二段是 CVE-2026-43499，別名 GhostLock，位置在 Linux kernel 的 futex 優先權繼承（priority inheritance）程式碼，也就是 glibc `PTHREAD_PRIO_INHERIT` 互斥鎖背後的機制。上鎖操作失敗並回退時，清理程式碼釋放了仍被參照的 task 結構，kernel 於是握著一個指向已釋放記憶體的指標，屬於釋放後使用（use-after-free）。這一段攻擊的是你的作業系統，與瀏覽器無關。它從 2011 年的 Linux 2.6.39-rc1 就存在，前提是編譯選項 `CONFIG_FUTEX_PI=y`，主流發行版預設都開啟。Nebula Security 公開的 exploit 從一般權限取得 root 約需 5 秒，成功率約 97%，在使用標準 kernel 的容器內同樣有效。上游在 2026 年 4 月修好並 backport，7 月 7 日公開，第一版修補引入的當機問題另外編為 CVE-2026-53166，截至 7 月初這個回歸（regression）的後續修補尚未穩定。[^4]
 
 只要 kernel 沒有更新，未來任何一支能在 renderer 內執行程式碼的瀏覽器漏洞，都能接上同一段提權。修好瀏覽器只擋掉了這一次的入口。
-
-## 判讀關鍵：ESR 與 Rapid Release 是兩條分支
-
-Tor Browser 穩定版跟隨 Firefox ESR（Extended Support Release，延長支援版本），15.0.x 系列建立在 140 ESR 上，2026 年 7 月 21 日的 15.0.19 把基底換到 140.13.0esr，Android 版的 GeckoView 同步換成同一個基底。[^5]
-
-Tor Browser Alpha 走另一條路。Tor Project 在 2025 年 12 月的公告裡宣布，Alpha 通道自 16.0a1 起改成跟隨 Firefox 的快速發布線，並寫下這個取捨，快速把上游功能送給使用者，也會快速把上游的錯誤一起送過去。同一份公告寫得更直接：「如果你是高風險使用者、在意自己的隱私，或只是需要一個穩定可用的瀏覽器，你不應該使用 Tor Browser Alpha。」[^6] 依本站 [Tor 更新日誌](../../changelog/tor.md) 的記錄，實際換基底發生在 2026 年 5 月 7 日的 16.0a6，該版起改以 Firefox beta 通道為基底，在此之前的 Alpha 仍建立在 ESR 上。
-
-Mozilla 沒有為 ESR 分支發布對應公告，Red Hat 也把隨附的 ESR 版 Firefox 標記為未受影響，兩者都指向同一個結論，CVE-2026-10702 的程式碼在 140 ESR 分支切出去之後才進入 Firefox。把各個對象排開來看：
-
-| 對象 | Firefox 基底 | 是否受影響 |
-|---|---|---|
-| Tor Browser 15.0.x 穩定版 | 140 ESR | 未受影響 |
-| Tor Browser for Android 穩定版 | GeckoView 140.13.0esr | 未受影響 |
-| Tor Browser Alpha 16.0a6（2026-05-07） | Firefox 150.0a1 | 受影響，請升級 |
-| Tor Browser Alpha 16.0a7（2026-06-03） | Firefox 151.0a1 | 受影響，請升級 |
-| Tor Browser Alpha 16.0a8 起（2026-07-02） | Firefox 152.0a1 | 未受影響（已越過修補點） |
-| 一般 Firefox 桌面版與 Android 版 | Rapid Release，151.0.2 以前 | 受影響，需升到 151.0.3 以上 |
-| Tails 與 Whonix 內建的 Tor Browser | 與穩定版同一條 ESR 線 | 未受影響 |
-
-16.0a6 與 16.0a7 的基底都早於修補落地的 151.0.3，兩版一律當成受影響處理。Alpha 使用者升到 16.0a8 以上，或換回穩定版。
-
-### 三步判讀法
-
-下次看到一支 Firefox 的 CVE 編號，依序檢查這三件事，多數情況能自己得出結論。前兩步是交叉驗證，若你不想查英文資料庫，直接看第三步。
-
-**第一步，看 Mozilla 有沒有同時發 ESR 公告。** Mozilla 為 ESR 分支發布獨立的 MFSA 編號。這次 MFSA-2026-54 只列出 Firefox 151.0.3，沒有任何對應的 ESR 公告。換成一句好記的判斷：Tor Browser 穩定版遇到 Firefox 的 CVE，通常只有在 Mozilla 同時發 ESR 公告時才需要緊張。
-
-**第二步，看 Red Hat 的 VEX 資料。** RHEL 隨附的 Firefox 是 ESR 版本，所以 Red Hat 對某支 CVE 的判定，實質上就是對 ESR 分支的判定。這次 Red Hat 的 CSAF VEX 文件把 RHEL 6 到 10 的 firefox 套件全部標記為 `known_not_affected`。[^7] Mozilla 沒發 ESR 公告、Red Hat 標記未受影響，兩個獨立來源指向同一個結論。
-
-**第三步，看手上這個 Tor Browser 版本的 Firefox 基底。** Tor Project 的更新日誌從不列出個別 CVE 編號，一律只寫「includes important security updates to Firefox」，所以需自己從基底版本反推。本站的 [Tor 更新日誌](../../changelog/tor.md) 整理了近期版本的 Firefox 基底，穩定版與 Alpha 通道都有，目前回溯到 15.0.11。更舊的版本需回上游的 release notes 查。
-
-## CVSS 分數在這個案例會誤導人
-
-同一支漏洞在不同資料庫的評分差距很大，NVD 頁面上 CISA-ADP 給的 CVSS 3.1 是 4.3（Medium）[^8]，Red Hat 給 7.5（High）[^7]，Mozilla 自己評 High[^3]。只看 NVD 首頁那個 4.3 會嚴重低估這支漏洞的實際風險。
-
-差距來自評分方法本身，CVSS 只評估單一漏洞在孤立情況下的影響，而 renderer 內的程式碼執行看起來影響有限，因為沙箱還在。一旦接上 GhostLock，一次網頁造訪就換成裝置的 root 權限。讀 CVE 的時候，把它放回攻擊鏈裡看，比單看分數準確得多。
 
 ## 現在該做的事
 
@@ -105,6 +100,12 @@ Mozilla 沒有為 ESR 分支發布對應公告，Red Hat 也把隨附的 ESR 版
 **Linux 桌面使用者更新 kernel，並且重新開機。** kernel 更新沒有重開機不會生效，這一步最常被漏掉。更新後用 `uname -r` 確認正在運作的版本，並對照發行版對 CVE-2026-43499 與 CVE-2026-53166 的公告狀態，不要假設已經處理好。編譯期的緩解選項（例如 `CONFIG_STATIC_USERMODE_HELPER`）需重新編譯 kernel，一般桌面使用者做不到，自行維運伺服器或 relay 的人可以評估用開機參數 `randomize_kstack_offset=on` 開啟 kernel 堆疊位移隨機化。這些都是緩解措施，並非修補。
 
 **Android 使用者需等裝置廠商的系統更新。** kernel 層的提權在使用者端沒有自救方式，更新何時送達取決於裝置廠商與電信商。
+
+## 一支 CVE 編號不足以判斷影響範圍
+
+同一份原始碼分成兩條發布線之後，兩條線就是兩份不同的程式碼。這支漏洞在 140 ESR 切出去之後才進入 Firefox，因此穩定版從來沒有這段程式碼，而跟隨快速發布線的 Alpha 通道有。三步判讀法要回答的就是這件事，看 Mozilla 有沒有發 ESR 公告、看 Red Hat 對 ESR 版套件的判定、看手上這個版本的 Firefox 基底。
+
+媒體標題會寫成攻陷 Tor Browser，一部分原因在於把「Firefox 的漏洞」直接推論成「所有建立在 Firefox 上的瀏覽器都中」。另一部分來自資訊落差，Tor Project 的更新日誌不列個別 CVE 編號，也沒有針對這支漏洞發過公開說明，外界只能自己推論，推論就有機會出錯。下次遇到類似的標題，先問它說的是哪一條分支。
 
 ## 沒有把握的部分
 

--- a/docs/zh-TW/blog/posts/2026-firefox-jit-cve-tor-browser.md
+++ b/docs/zh-TW/blog/posts/2026-firefox-jit-cve-tor-browser.md
@@ -8,104 +8,114 @@ categories:
     - 隱私
 slug: 2026-firefox-jit-cve-tor-browser
 image: "assets/images/tor.webp"
-summary: "7 月底幾家安全媒體的標題寫著造訪一個惡意網頁就能攻陷 Tor Browser，指的是 Firefox 的 JIT 漏洞 CVE-2026-10702。查下去會發現 Tor Browser 穩定版並未受影響，關鍵在於它建立在 Firefox ESR 分支上，而這支漏洞只存在於 Rapid Release 那條線。這篇文章講解漏洞原理與 IonStack 攻擊鏈，並整理一套三步判讀法，讓你下次看到 Firefox 的 CVE 編號時能自己判斷手上的 Tor Browser 有沒有中。"
+summary: "Tor Browser 穩定版沒有受 Firefox 的 JIT 漏洞 CVE-2026-10702 影響，關鍵在於穩定版建立在 Firefox ESR 分支上，而這支漏洞的程式碼只存在於 Rapid Release 那條線。7 月底幾家安全媒體的標題寫著造訪一個惡意網頁就能攻陷 Tor Browser，說的就是這支漏洞。這篇文章說明漏洞原理與 IonStack 攻擊鏈，並整理一套三步判讀法，讓你下次看到 Firefox 的 CVE 編號時能自己判斷手上的 Tor Browser 是否受影響。"
 description: "CVE-2026-10702 是 Firefox JIT 編譯器的類型混淆漏洞，被研究者串成 Android 的瀏覽器到 root 完整攻擊鏈 IonStack。本文說明漏洞原理、攻擊鏈組成，以及如何用 ESR 與 Rapid Release 的分支差異判斷一支 Firefox CVE 會不會影響 Tor Browser，附上安全等級與 kernel 更新的具體行動建議。"
 ---
 
-# Firefox 的漏洞會不會打到 Tor Browser：用 CVE-2026-10702 練一次判讀
+# 你的 Tor Browser 受影響嗎：CVE-2026-10702 與 Firefox 的兩條分支
 
 ![Tor](./assets/images/tor.webp){style="border-radius: 10px;"}
 
-2026 年 7 月底，幾家安全媒體同時出現類似的標題，說研究者證明造訪一個惡意網頁就能攻陷 Tor Browser。標題所指的漏洞編號是 CVE-2026-10702，一支 Firefox JavaScript 引擎的 JIT 編譯器缺陷。翻開研究團隊 Nebula Security 自己的公開頁面，示範對象寫得相當清楚，是一支檔名為 `fenix-151.0.multi.android-arm64-v8a.apk` 的 Firefox for Android，執行在 Android 17 的 ARM64 裝置上，整個頁面沒有出現 Tor Browser。[^1]
+2026 年 7 月底，幾家安全媒體同時出現類似的標題，說研究者證明造訪一個惡意網頁就能攻陷 Tor Browser。標題說的漏洞編號是 CVE-2026-10702，一支 Firefox JavaScript 引擎的 JIT 編譯器缺陷。打開研究團隊 Nebula Security 自己的公開頁面，示範對象寫得很明確，是一支 Firefox for Android 151.0（安裝檔 `fenix-151.0.multi.android-arm64-v8a.apk`），執行在 Android 17 的 ARM64 裝置上。整個頁面沒有出現 Tor Browser。[^1]
 
-對照各方資料之後，結論是 Tor Browser 穩定版沒有受這支漏洞影響。理由與漏洞本身的嚴重程度無關，在於 Tor Browser 穩定版建立在 Firefox ESR 這條分支上，而這支漏洞的程式碼只存在於 Rapid Release 那條線。
+對照各方資料，Tor Browser 穩定版沒有受這支漏洞影響，原因在於穩定版建立在 Firefox ESR 這條分支上，而這支漏洞的程式碼只存在於 Rapid Release 那條線。截至 2026 年 7 月 28 日，一手資料也沒有顯示這支漏洞在野利用（exploited in the wild）。
 
-這篇文章用這個案例走一遍完整流程：漏洞原理如何運作、攻擊鏈怎麼串起來，以及最能重複使用的那部分，下次看到一個 Firefox 的 CVE 編號時，如何自己判斷它會不會打到你手上的 Tor Browser。
+!!! tip "先確認你手上這一版"
+
+    從 torproject.org 下載、平常讓它自動更新的人，用的就是穩定版，沒有受這支漏洞影響。要確認版本號，開啟右上角的漢堡選單，選 Help，再選 About Tor Browser，畫面上的 15.0.x 就是你的版本。除非你刻意去下載過標示 Alpha 的測試版，你的就是穩定版。
+
+    畫面上另外那組 140.13.0esr 是它內部使用的 Firefox 版本，判讀漏洞影響範圍時看的是這一組，本文後面會用到。
 
 <!-- more -->
 
 ## 漏洞原理：編譯器被自己的標記騙了
 
-JIT（Just-In-Time，即時編譯）的工作是把反覆執行的 JavaScript 轉成機器碼，讓熱點程式碼的執行速度比逐行解譯快上數十倍。要編得快，編譯器需知道每個操作會不會改動記憶體。若某個操作只讀取資料，後面再次讀取同一個位置時，編譯器可以放心省略那次載入，直接沿用先前取得的值。這種省略是最佳化的主要來源，也是這次出問題的地方。
+JIT（Just-In-Time，即時編譯）的工作是把反覆執行的 JavaScript 轉成機器碼，讓熱點程式碼的執行速度比逐行解譯快上數十倍。要編得快，編譯器必須知道每個操作會不會改動記憶體。若某個操作只讀取資料，後面再次讀取同一個位置時，編譯器可以放心省略那次載入，直接沿用先前取得的值。
 
-Firefox 的 JavaScript 引擎 SpiderMonkey 裡有一個名為 `MObjectToIterator` 的操作。在 `skipRegistration` 開啟的情況下，它被標記成只會讀取資料。實際行為並非如此，它在解析 lazy property（延遲解析屬性）的過程中會配置一塊新的 dynamic slots 緩衝區，並且釋放掉舊的那一塊。
+倉庫的管理員在清單上註明某位訪客只會清點貨物、不會搬動任何東西。這位訪客實際上把整櫃貨搬到新位置，還把舊櫃子拆了。後面的人依照清單判斷「反正沒人動過」，繼續照原地址去取貨，那個位置已經拆掉，還可能已經堆上別人搬進來的箱子。
 
-接手的最佳化階段叫做 global value numbering（全域值編號），它的職責是找出重複計算並消除。它看到標記寫著這裡什麼都沒改，於是判斷後面那次載入 slots 指標的動作是多餘的，直接沿用先前那個指標。而那個指標指向的記憶體已經被釋放了。編譯出來的機器碼因此握著一個懸空指標讀寫記憶體，攻擊者由此取得任意讀寫能力，在 renderer 行程內執行自己的程式碼。[^2]
+Firefox 的 JavaScript 引擎 SpiderMonkey 裡的 `MObjectToIterator` 操作，在 `skipRegistration` 開啟時被標記成只會讀取資料。實際行為並非如此，它在解析延遲屬性（lazy property）的過程中會配置一塊新的動態儲存區（dynamic slots）緩衝區，並且釋放掉舊的那一塊。
 
-換成倉庫的場景比較好懂。管理員在清單上註明某位訪客只會清點貨物、不會搬動任何東西。這位訪客實際上把整櫃貨搬到新位置，還把舊櫃子拆了。後面的人依照清單判斷「反正沒人動過」，繼續照原地址去取貨，取到的是一個已經拆掉的空位。清單上的註記錯了，照著註記做最佳化的人也就跟著錯。
+接手的最佳化階段稱為 global value numbering（全域值編號），職責是找出重複計算並消除。它看到標記寫著這裡什麼都沒改，於是判斷後面那次載入 slots 指標的動作是多餘的，直接沿用先前那個指標，而那個指標指向的記憶體已經被釋放。編譯出來的機器碼因此握著一個懸空指標（dangling pointer）讀寫記憶體，攻擊者由此取得任意讀寫能力，在 renderer 行程內執行自己的程式碼。[^2] global value numbering 屬於 IonMonkey 這條最佳化管線，攻擊鏈的名字 IonStack 就從這裡來。
 
-Mozilla 在 2026 年 6 月 2 日發布 Firefox 151.0.3 修掉這支漏洞，公告編號 MFSA-2026-54，評級 High，回報者記為 Nebula Security，對應的 Bugzilla 編號 `2040903` 目前仍限制存取。[^3] 修法是移除那個錯誤的唯讀標記處理。分類上這支同時對應 CWE-843（type confusion，類型混淆）與 CWE-733（編譯器最佳化移除或改動安全關鍵程式碼），後者精準描述了問題出在最佳化決策本身。
+到這一步，攻擊者的程式碼仍被關在 renderer 的沙箱裡，要碰到你的檔案與其他資料，還需要第二支漏洞。
+
+Mozilla 在 2026 年 6 月 2 日發布 Firefox 151.0.3 修掉這支漏洞，公告編號 MFSA-2026-54，評級 High，回報者記為 Nebula Security。[^3] 修補方式是移除那個錯誤的唯讀標記處理。分類上這支同時對應 CWE-843（類型混淆，type confusion）與 CWE-733（編譯器最佳化移除或改動安全關鍵程式碼），後者精準描述了問題出在最佳化決策本身。對應的 Bugzilla 編號 `2040903` 目前仍限制存取，所以以下機制描述來自研究者與媒體的公開分析。
 
 ## 攻擊鏈 IonStack：從瀏覽器一路到 root
 
-研究團隊把這支漏洞命名為攻擊鏈的第一段。第一段負責在瀏覽器的 renderer 沙箱內取得程式執行能力，第二段負責跳出沙箱、取得整台裝置的控制權。兩段合起來稱為 IonStack，示範平台是 Android 17 的 ARM64 裝置。
+研究團隊把這支漏洞放在攻擊鏈的第一段，負責在瀏覽器的 renderer 沙箱內取得程式執行能力，第二段負責跳出沙箱、取得整台裝置的控制權。兩段合起來稱為 IonStack，示範平台是 Android 17 的 ARM64 裝置。
 
-第二段是 CVE-2026-43499，別名 GhostLock，一支 Linux kernel 的 use-after-free 漏洞，位置在 futex 的 priority inheritance（優先權繼承）程式碼，也就是 glibc `PTHREAD_PRIO_INHERIT` 互斥鎖背後的機制。當一次上鎖操作失敗並回退時，清理程式碼在錯誤的時機清掉了不該碰的 task 記錄，kernel 於是握著一個指向已釋放記憶體的指標。[^4]
+第二段是 CVE-2026-43499，別名 GhostLock，一支 Linux kernel 的釋放後使用（use-after-free）漏洞。位置在 futex 的優先權繼承（priority inheritance）程式碼，也就是 glibc `PTHREAD_PRIO_INHERIT` 互斥鎖背後的機制。當一次上鎖操作失敗並回退時，清理程式碼在回退路徑上釋放了仍被參照的 task 結構，kernel 於是握著一個指向已釋放記憶體的指標。[^4]
 
-GhostLock 的幾個數字值得記下來。它從 2011 年 5 月的 Linux 2.6.39-rc1 就存在，一路到 v7.1-rc1 都在，唯一的前提是編譯選項 `CONFIG_FUTEX_PI=y`，而這個選項在每個主流發行版都預設開啟。Nebula 公開的 exploit 從一般權限取得 root 約需 5 秒，成功率約 97%，在使用標準 kernel 的容器內同樣有效。上游在 2026 年 4 月 20 日以 commit `3bfdc63936dd` 修好，5 月 4 日 backport，7 月 7 日公開。第一版修補引入了新的當機問題，另外編為 CVE-2026-53166，7 月初時後續修補還不算完全穩定。
+這一段攻擊的是你的作業系統，與瀏覽器無關。GhostLock 從 2011 年 5 月的 Linux 2.6.39-rc1 就存在，一路到 v7.1-rc1 都在，唯一的前提是編譯選項 `CONFIG_FUTEX_PI=y`，主流發行版預設都開啟。Nebula Security 公開的 exploit 從一般權限取得 root 約需 5 秒，成功率約 97%，在使用標準 kernel 的容器內同樣有效。上游在 2026 年 4 月 20 日以 commit `3bfdc63936dd` 修好，5 月 4 日 backport，7 月 7 日公開。第一版修補引入了新的當機問題，另外編為 CVE-2026-53166，截至 7 月初，這個回歸（regression）的後續修補尚未穩定。
 
-對 Tor Browser 使用者來說，第二段有一個容易被忽略的意義。GhostLock 與瀏覽器是哪一支毫無關係，它攻擊的是作業系統的 kernel。只要 kernel 沒有更新，未來任何一支能在 renderer 內執行程式碼的瀏覽器漏洞，都能接上同一段提權。修好瀏覽器只擋掉了這一次的入口。
+只要 kernel 沒有更新，未來任何一支能在 renderer 內執行程式碼的瀏覽器漏洞，都能接上同一段提權。修好瀏覽器只擋掉了這一次的入口。
 
 ## 判讀關鍵：ESR 與 Rapid Release 是兩條分支
 
-Tor Browser 穩定版跟隨 Firefox ESR（Extended Support Release，延長支援版本）。15.0.x 系列建立在 140 ESR 上，2026 年 7 月 21 日的 15.0.19 把基底 rebase 到 140.13.0esr，Android 版的 GeckoView 同步跟上。[^5]
+Tor Browser 穩定版跟隨 Firefox ESR（Extended Support Release，延長支援版本），15.0.x 系列建立在 140 ESR 上，2026 年 7 月 21 日的 15.0.19 把基底換到 140.13.0esr，Android 版的 GeckoView 同步換成同一個基底。[^5]
 
-Tor Browser Alpha 的情況不同。從 16.0a1 起，Alpha 通道改成跟隨 Firefox Rapid Release。Tor Project 在 2025 年 12 月的公告裡自己寫下這個取捨，快速把上游功能送給使用者的副作用，是也會快速把上游的錯誤一起送給使用者。同一份公告寫得更直接：如果你是高風險使用者、在意自己的隱私、或只是需要一個穩定可用的瀏覽器，你不應該使用 Tor Browser Alpha。[^6]
+Tor Browser Alpha 走另一條路。Tor Project 在 2025 年 12 月的公告裡宣布，Alpha 通道自 16.0a1 起改成跟隨 Firefox 的快速發布線，並寫下這個取捨，快速把上游功能送給使用者，也會快速把上游的錯誤一起送過去。同一份公告寫得更直接：「如果你是高風險使用者、在意自己的隱私，或只是需要一個穩定可用的瀏覽器，你不應該使用 Tor Browser Alpha。」[^6] 依本站 [Tor 更新日誌](../../changelog/tor.md) 的記錄，實際換基底發生在 2026 年 5 月 7 日的 16.0a6，該版起改以 Firefox beta 通道為基底，在此之前的 Alpha 仍建立在 ESR 上。
 
-CVE-2026-10702 的程式碼在 140 ESR 分支切出去之後才進入 Firefox，所以 ESR 這條線從來沒有這段程式碼。把各個對象排開來看：
+Mozilla 沒有為 ESR 分支發布對應公告，Red Hat 也把隨附的 ESR 版 Firefox 標記為未受影響，兩者都指向同一個結論，CVE-2026-10702 的程式碼在 140 ESR 分支切出去之後才進入 Firefox。把各個對象排開來看：
 
 | 對象 | Firefox 基底 | 是否受影響 |
 |---|---|---|
 | Tor Browser 15.0.x 穩定版 | 140 ESR | 未受影響 |
 | Tor Browser for Android 穩定版 | GeckoView 140.13.0esr | 未受影響 |
-| Tor Browser Alpha 16.0a6（2026-05-07） | Firefox 150.0a1 | 落在受影響區間 |
-| Tor Browser Alpha 16.0a7（2026-06-03） | Firefox 151.0a1 | 無法確認，見文末保留事項 |
-| Tor Browser Alpha 16.0a8 起（2026-07-02） | Firefox 152.0a1 | 已越過修補點 |
+| Tor Browser Alpha 16.0a6（2026-05-07） | Firefox 150.0a1 | 受影響，請升級 |
+| Tor Browser Alpha 16.0a7（2026-06-03） | Firefox 151.0a1 | 受影響，請升級 |
+| Tor Browser Alpha 16.0a8 起（2026-07-02） | Firefox 152.0a1 | 未受影響（已越過修補點） |
 | 一般 Firefox 桌面版與 Android 版 | Rapid Release，151.0.2 以前 | 受影響，需升到 151.0.3 以上 |
 | Tails 與 Whonix 內建的 Tor Browser | 與穩定版同一條 ESR 線 | 未受影響 |
 
+16.0a6 與 16.0a7 的基底都早於修補落地的 151.0.3，兩版一律當成受影響處理。Alpha 使用者升到 16.0a8 以上，或換回穩定版。
+
 ### 三步判讀法
 
-下次看到一支 Firefox 的 CVE 編號，依序檢查這三件事就能得出結論。
+下次看到一支 Firefox 的 CVE 編號，依序檢查這三件事，多數情況能自己得出結論。前兩步是交叉驗證，若你不想查英文資料庫，直接看第三步。
 
-**第一步，看 Mozilla 有沒有同時發 ESR 公告。** Mozilla 為 ESR 分支發布獨立的 MFSA 編號。這次 MFSA-2026-54 只列出 Firefox 151.0.3，沒有任何對應的 ESR 公告，這是第一個訊號。
+**第一步，看 Mozilla 有沒有同時發 ESR 公告。** Mozilla 為 ESR 分支發布獨立的 MFSA 編號。這次 MFSA-2026-54 只列出 Firefox 151.0.3，沒有任何對應的 ESR 公告。換成一句好記的判斷：Tor Browser 穩定版遇到 Firefox 的 CVE，通常只有在 Mozilla 同時發 ESR 公告時才需要緊張。
 
-**第二步，看 Red Hat 的 VEX 資料。** RHEL 隨附的 Firefox 是 ESR 版本，所以 Red Hat 對某支 CVE 的判定，實質上就是對 ESR 分支的判定。這次 Red Hat 的 CSAF VEX 文件把 RHEL 6 到 10 的 firefox 套件全部標記為 `known_not_affected`。[^7] 兩個獨立來源指向同一個結論，可信度就夠了。
+**第二步，看 Red Hat 的 VEX 資料。** RHEL 隨附的 Firefox 是 ESR 版本，所以 Red Hat 對某支 CVE 的判定，實質上就是對 ESR 分支的判定。這次 Red Hat 的 CSAF VEX 文件把 RHEL 6 到 10 的 firefox 套件全部標記為 `known_not_affected`。[^7] Mozilla 沒發 ESR 公告、Red Hat 標記未受影響，兩個獨立來源指向同一個結論。
 
-**第三步，看你那個 Tor Browser 版本的 Firefox 基底。** Tor Project 的 release notes 從不列出個別 CVE 編號，一律只寫 includes important security updates to Firefox，所以需自己從基底版本反推。本站的 [Tor 更新日誌](../../changelog/tor.md) 整理了每個版本的 Firefox 基底，穩定版與 Alpha 通道都有，可以直接對照。
+**第三步，看手上這個 Tor Browser 版本的 Firefox 基底。** Tor Project 的更新日誌從不列出個別 CVE 編號，一律只寫「includes important security updates to Firefox」，所以需自己從基底版本反推。本站的 [Tor 更新日誌](../../changelog/tor.md) 整理了近期版本的 Firefox 基底，穩定版與 Alpha 通道都有，目前回溯到 15.0.11。更舊的版本需回上游的 release notes 查。
 
 ## CVSS 分數在這個案例會誤導人
 
-同一支漏洞在不同資料庫的評分差距很大。NVD 頁面上 CISA-ADP 給的 CVSS 3.1 是 4.3（Medium），Red Hat 給 7.5（High），Mozilla 自己評 High。[^8] 只看 NVD 首頁那個 4.3 會嚴重低估這支漏洞的實際份量。
+同一支漏洞在不同資料庫的評分差距很大，NVD 頁面上 CISA-ADP 給的 CVSS 3.1 是 4.3（Medium）[^8]，Red Hat 給 7.5（High）[^7]，Mozilla 自己評 High[^3]。只看 NVD 首頁那個 4.3 會嚴重低估這支漏洞的實際風險。
 
-差距的來源在於評分方法本身。CVSS 評的是單一漏洞在孤立情況下的影響，而 renderer 內的程式碼執行看起來影響有限，因為沙箱還在。一旦接上 GhostLock，整條鏈的結果是遠端存取變成裝置 root。讀 CVE 的時候，把它放回攻擊鏈裡看，比單看分數準確得多。
+差距來自評分方法本身，CVSS 只評估單一漏洞在孤立情況下的影響，而 renderer 內的程式碼執行看起來影響有限，因為沙箱還在。一旦接上 GhostLock，一次網頁造訪就換成裝置的 root 權限。讀 CVE 的時候，把它放回攻擊鏈裡看，比單看分數準確得多。
 
-## 你可以採取的行動
+## 現在該做的事
 
-**Tor Browser 升到 15.0.19 或更新版本。** 這支漏洞打不到穩定版，但 15.0.19 帶了從 Firefox 153 backport 的其他安全修補，該升的還是要升。
+**Tor Browser 更新到最新版。** 開著瀏覽器讓它自己更新，或從 torproject.org 重新下載。這支漏洞影響不到穩定版，15.0.19 仍帶了從 Firefox 153 backport 的其他安全修補。
 
-**一般 Firefox 升到 151.0.3 以上**，桌面版與 Android 版都要。
+**一般 Firefox 升到 151.0.3 以上。** 桌面版與 Android 版都要。
 
 **Alpha 通道不要當日常瀏覽器用。** 這是 Tor Project 自己的建議，這次剛好是實例。
 
-**安全等級調到 Safer 或 Safest 可以整類擋掉 JIT 漏洞。** 這兩個等級會關閉 `javascript.options.ion` 與 `javascript.options.baselinejit`，JIT 直接停用，編譯器層的缺陷就失去觸發機會。這裡有兩個坑要提醒。Tor Project 官方的安全等級說明頁完全沒有提到 JIT，只列出 JavaScript 與字型、影音的變化，所以光看官方文件不會知道這件事。另一個坑更實際，改完安全等級需完整重新啟動瀏覽器才真的生效。Privacy Guides 在 2025 年 5 月用 JavaScript 效能測試證明，沒有重新啟動的情況下 JIT 仍在運作，介面卻已經顯示成 Safer。[^9] 這個問題追蹤在 tor-browser issue `42572`。設定的操作步驟可以參考本站的 [Tor Browser 進階設定](../../tools/tor-browser-advanced.md)。
+**安全等級調到 Safer 或 Safest 可以擋掉整類 JIT 漏洞。** 這兩個等級會關閉 `javascript.options.ion` 與 `javascript.options.baselinejit`，JIT 直接停用，編譯器層的缺陷就失去觸發機會。操作是點網址列旁的盾牌圖示，選 Change，再選等級，不需要進 `about:config` 改任何設定。代價要先知道：Safer 會關掉 HTTP 站點的 JavaScript 與部分字型，Safest 關閉全部 JavaScript，部分網站的表單會送不出去。更詳細的取捨可以參考本站的 [Tor Browser 進階設定](../../tools/tor-browser-advanced.md)。
 
-**Linux 桌面使用者更新 kernel。** 更新之後確認取得的是修掉 CVE-2026-53166 回歸之後的版本，直接看套件版本號，不要假設發行版已經處理好。無法立即更新的機器可以開啟 `RANDOMIZE_KSTACK_OFFSET` 與 `STATIC_USERMODE_HELPER`，這兩者都是緩解措施，並非修補。
+**改完安全等級要關掉所有 Tor Browser 視窗再重新開啟。** Tor Project 官方的安全等級說明頁沒有提到 JIT，只列出 JavaScript 與字型、影音的變化，所以光看官方文件不會知道 JIT 這件事。更實際的限制是，沒有完整重新啟動的話設定不會生效。Privacy Guides 在 2025 年 5 月用 JavaScript 效能測試證明，沒有重新啟動的情況下 JIT 仍在運作，介面卻已經顯示成 Safer。[^9] 這個問題追蹤在 tor-browser issue `42572`。
 
-**Android 使用者需等裝置廠商的系統更新。** kernel 層的提權在使用者端沒有自救方式，這也是 Android 生態長期的結構問題。
+**Windows 與 macOS 使用者只需做上面這些。** 攻擊鏈的第二段是 Linux kernel 的漏洞，這兩個平台不適用。
 
-截至 2026 年 7 月 28 日，一手資料沒有顯示這支漏洞在真實世界遭到利用。
+**Linux 桌面使用者更新 kernel，並且重新開機。** kernel 更新沒有重開機不會生效，這一步最常被漏掉。更新後用 `uname -r` 確認正在運作的版本，並對照發行版對 CVE-2026-43499 與 CVE-2026-53166 的公告狀態，不要假設已經處理好。編譯期的緩解選項（例如 `CONFIG_STATIC_USERMODE_HELPER`）需重新編譯 kernel，一般桌面使用者做不到，自行維運伺服器或 relay 的人可以評估用開機參數 `randomize_kstack_offset=on` 開啟 kernel 堆疊位移隨機化。這些都是緩解措施，並非修補。
 
-## 這篇文章沒有把握的部分
+**Android 使用者需等裝置廠商的系統更新。** kernel 層的提權在使用者端沒有自救方式，更新何時送達取決於裝置廠商與電信商。
 
-寫這類題目時，把查不到的部分說明清楚，與把查到的說明清楚一樣重要。
+## 沒有把握的部分
 
-- 受影響的起始版本 Firefox 147 只有一個媒體來源提到。NVD、Rapid7 與 SentinelOne 都只寫「151.0.3 之前」。ESR 140 不受影響這件事有兩個獨立來源，可以放心，但確切從哪一版開始受影響，目前無法確認。
-- Tor Browser 16.0a7 的 Firefox 基底是 `151.0a1`，版本序上早於修補的 151.0.3。Tor Project 的 changelog 不列個別 CVE，無法確認該建置是否已經含有修補。
-- Tor Project 至今沒有針對這支 CVE 發過任何公開說明。媒體推論失準的空間，一部分來自這個資訊落差。
-- Bugzilla 編號 `2040903` 需要權限才能存取，無法讀到原始修補內容。漏洞機制的描述來自研究者與媒體的公開分析。
+- 受影響的起始版本 Firefox 147 只有 The Hacker News 一個來源提到。NVD、Rapid7 與 SentinelOne 都只寫「151.0.3 之前」。ESR 140 不受影響有兩個獨立來源支持，確切從哪一版開始受影響則無法確認。
+- Tor Browser 16.0a6 與 16.0a7 的 Firefox 基底早於修補落地的 151.0.3，本文據此列為受影響。Tor Project 的更新日誌不列個別 CVE，無法確認這兩個建置是否已經含有修補。
+- Tor Project 至今沒有針對這支 CVE 發過任何公開說明。媒體會出現失準的推論，一部分來自這個資訊落差。
+- Bugzilla 編號 `2040903` 需要權限才能存取，無法讀到原始修補內容。
 
 ## 名詞對照
+
+正文出現的英文詞與縮寫都收在這裡，讀到卡住時可以回來查。
 
 | 名詞 | 說明 |
 |---|---|
@@ -113,15 +123,25 @@ CVE-2026-10702 的程式碼在 140 ESR 分支切出去之後才進入 Firefox，
 | SpiderMonkey | Firefox 的 JavaScript 引擎 |
 | IonMonkey、Warp | SpiderMonkey 裡負責最佳化編譯的管線 |
 | global value numbering | 全域值編號，找出重複計算並消除的最佳化階段 |
-| lazy property | 延遲解析屬性，等到被存取時才真正建立 |
-| dynamic slots | 物件屬性值的動態儲存區，容量不足時會重新配置 |
-| use-after-free | 記憶體釋放後仍被使用，常見的可利用漏洞型態 |
-| type confusion | 類型混淆，程式把某型別的資料當成另一型別處理 |
-| renderer 行程 | 瀏覽器負責解析與繪製網頁內容的行程，通常受沙箱限制 |
+| lazy property（延遲屬性） | 等到被存取時才真正建立的物件屬性 |
+| dynamic slots（動態儲存區） | 物件屬性值的動態儲存區，容量不足時會重新配置 |
+| dangling pointer（懸空指標） | 指向已被釋放記憶體的指標 |
+| use-after-free（釋放後使用） | 記憶體釋放後仍被使用，常見的可利用漏洞型態 |
+| type confusion（類型混淆） | 程式把某型別的資料當成另一型別處理 |
+| sandbox（沙箱） | 限制程式能碰到哪些資源的隔離機制，瀏覽器用它把網頁內容關起來 |
+| renderer 行程 | 瀏覽器負責解析與繪製網頁內容的行程，受沙箱限制 |
+| root | 作業系統的最高權限帳號，取得它等於控制整台裝置 |
+| 提權（privilege escalation） | 從低權限取得高權限的攻擊手法 |
+| exploit | 實際利用某支漏洞的程式或步驟 |
 | ESR（Extended Support Release） | Firefox 的延長支援版本，功能更新慢、修補期長 |
 | Rapid Release | Firefox 的快速發布通道，約四週一個版本 |
+| 通道（channel） | 同一個軟體的不同發布線，例如穩定版與 Alpha 測試版 |
+| 基底、rebase | Tor Browser 建立在某個 Firefox 版本之上，換到新版本的動作稱為 rebase |
+| backport | 把新版的修補移植回舊的維護分支 |
+| regression（回歸） | 修補引入的新問題，讓原本正常的行為出錯 |
 | futex | fast userspace mutex，Linux 的使用者空間鎖定機制 |
-| priority inheritance | 優先權繼承，避免高優先權工作被低優先權工作卡住的鎖定機制 |
+| priority inheritance（優先權繼承） | 避免高優先權工作被低優先權工作卡住的鎖定機制 |
+| CWE | 漏洞類型的分類編號系統，描述問題屬於哪一類 |
 | CVSS | 漏洞評分系統，給出 0 到 10 的嚴重度分數 |
 | VEX | 漏洞可利用性交換格式，廠商用來聲明自家產品是否受某支 CVE 影響 |
 | MFSA | Mozilla Foundation Security Advisory，Mozilla 的安全公告編號 |
@@ -132,7 +152,6 @@ CVE-2026-10702 的程式碼在 140 ESR 分支切出去之後才進入 Firefox，
 - [Tor 更新日誌](../../changelog/tor.md)
 - [什麼是 Tor](../../tools/what-is-tor.md)
 - [威脅模型如何建立](../../basics/threat-model.md)
-- [個人隱私指引研究專題](../../community/privacy-guide.md)
 
 [^1]: [IonStack, Nebula Security](https://rootme.nebusec.io/){target="_blank"}
 [^2]: [Researchers Show a Single Malicious Webpage Visit Can Compromise Tor Browser, The Hacker News 2026-07](https://thehackernews.com/2026/07/researchers-show-single-malicious.html){target="_blank"}

--- a/docs/zh-TW/blog/posts/2026-firefox-jit-cve-tor-browser.md
+++ b/docs/zh-TW/blog/posts/2026-firefox-jit-cve-tor-browser.md
@@ -1,0 +1,145 @@
+---
+date: 2026-07-30
+authors:
+    - anoni-net
+categories:
+    - 技術
+    - Tor
+    - 隱私
+slug: 2026-firefox-jit-cve-tor-browser
+image: "assets/images/tor.webp"
+summary: "7 月底幾家安全媒體的標題寫著造訪一個惡意網頁就能攻陷 Tor Browser，指的是 Firefox 的 JIT 漏洞 CVE-2026-10702。查下去會發現 Tor Browser 穩定版並未受影響，關鍵在於它建立在 Firefox ESR 分支上，而這支漏洞只存在於 Rapid Release 那條線。這篇文章講解漏洞原理與 IonStack 攻擊鏈，並整理一套三步判讀法，讓你下次看到 Firefox 的 CVE 編號時能自己判斷手上的 Tor Browser 有沒有中。"
+description: "CVE-2026-10702 是 Firefox JIT 編譯器的類型混淆漏洞，被研究者串成 Android 的瀏覽器到 root 完整攻擊鏈 IonStack。本文說明漏洞原理、攻擊鏈組成，以及如何用 ESR 與 Rapid Release 的分支差異判斷一支 Firefox CVE 會不會影響 Tor Browser，附上安全等級與 kernel 更新的具體行動建議。"
+---
+
+# Firefox 的漏洞會不會打到 Tor Browser：用 CVE-2026-10702 練一次判讀
+
+![Tor](./assets/images/tor.webp){style="border-radius: 10px;"}
+
+2026 年 7 月底，幾家安全媒體同時出現類似的標題，說研究者證明造訪一個惡意網頁就能攻陷 Tor Browser。標題所指的漏洞編號是 CVE-2026-10702，一支 Firefox JavaScript 引擎的 JIT 編譯器缺陷。翻開研究團隊 Nebula Security 自己的公開頁面，示範對象寫得相當清楚，是一支檔名為 `fenix-151.0.multi.android-arm64-v8a.apk` 的 Firefox for Android，執行在 Android 17 的 ARM64 裝置上，整個頁面沒有出現 Tor Browser。[^1]
+
+對照各方資料之後，結論是 Tor Browser 穩定版沒有受這支漏洞影響。理由與漏洞本身的嚴重程度無關，在於 Tor Browser 穩定版建立在 Firefox ESR 這條分支上，而這支漏洞的程式碼只存在於 Rapid Release 那條線。
+
+這篇文章用這個案例走一遍完整流程：漏洞原理如何運作、攻擊鏈怎麼串起來，以及最能重複使用的那部分，下次看到一個 Firefox 的 CVE 編號時，如何自己判斷它會不會打到你手上的 Tor Browser。
+
+<!-- more -->
+
+## 漏洞原理：編譯器被自己的標記騙了
+
+JIT（Just-In-Time，即時編譯）的工作是把反覆執行的 JavaScript 轉成機器碼，讓熱點程式碼的執行速度比逐行解譯快上數十倍。要編得快，編譯器需知道每個操作會不會改動記憶體。若某個操作只讀取資料，後面再次讀取同一個位置時，編譯器可以放心省略那次載入，直接沿用先前取得的值。這種省略是最佳化的主要來源，也是這次出問題的地方。
+
+Firefox 的 JavaScript 引擎 SpiderMonkey 裡有一個名為 `MObjectToIterator` 的操作。在 `skipRegistration` 開啟的情況下，它被標記成只會讀取資料。實際行為並非如此，它在解析 lazy property（延遲解析屬性）的過程中會配置一塊新的 dynamic slots 緩衝區，並且釋放掉舊的那一塊。
+
+接手的最佳化階段叫做 global value numbering（全域值編號），它的職責是找出重複計算並消除。它看到標記寫著這裡什麼都沒改，於是判斷後面那次載入 slots 指標的動作是多餘的，直接沿用先前那個指標。而那個指標指向的記憶體已經被釋放了。編譯出來的機器碼因此握著一個懸空指標讀寫記憶體，攻擊者由此取得任意讀寫能力，在 renderer 行程內執行自己的程式碼。[^2]
+
+換成倉庫的場景比較好懂。管理員在清單上註明某位訪客只會清點貨物、不會搬動任何東西。這位訪客實際上把整櫃貨搬到新位置，還把舊櫃子拆了。後面的人依照清單判斷「反正沒人動過」，繼續照原地址去取貨，取到的是一個已經拆掉的空位。清單上的註記錯了，照著註記做最佳化的人也就跟著錯。
+
+Mozilla 在 2026 年 6 月 2 日發布 Firefox 151.0.3 修掉這支漏洞，公告編號 MFSA-2026-54，評級 High，回報者記為 Nebula Security，對應的 Bugzilla 編號 `2040903` 目前仍限制存取。[^3] 修法是移除那個錯誤的唯讀標記處理。分類上這支同時對應 CWE-843（type confusion，類型混淆）與 CWE-733（編譯器最佳化移除或改動安全關鍵程式碼），後者精準描述了問題出在最佳化決策本身。
+
+## 攻擊鏈 IonStack：從瀏覽器一路到 root
+
+研究團隊把這支漏洞命名為攻擊鏈的第一段。第一段負責在瀏覽器的 renderer 沙箱內取得程式執行能力，第二段負責跳出沙箱、取得整台裝置的控制權。兩段合起來稱為 IonStack，示範平台是 Android 17 的 ARM64 裝置。
+
+第二段是 CVE-2026-43499，別名 GhostLock，一支 Linux kernel 的 use-after-free 漏洞，位置在 futex 的 priority inheritance（優先權繼承）程式碼，也就是 glibc `PTHREAD_PRIO_INHERIT` 互斥鎖背後的機制。當一次上鎖操作失敗並回退時，清理程式碼在錯誤的時機清掉了不該碰的 task 記錄，kernel 於是握著一個指向已釋放記憶體的指標。[^4]
+
+GhostLock 的幾個數字值得記下來。它從 2011 年 5 月的 Linux 2.6.39-rc1 就存在，一路到 v7.1-rc1 都在，唯一的前提是編譯選項 `CONFIG_FUTEX_PI=y`，而這個選項在每個主流發行版都預設開啟。Nebula 公開的 exploit 從一般權限取得 root 約需 5 秒，成功率約 97%，在使用標準 kernel 的容器內同樣有效。上游在 2026 年 4 月 20 日以 commit `3bfdc63936dd` 修好，5 月 4 日 backport，7 月 7 日公開。第一版修補引入了新的當機問題，另外編為 CVE-2026-53166，7 月初時後續修補還不算完全穩定。
+
+對 Tor Browser 使用者來說，第二段有一個容易被忽略的意義。GhostLock 與瀏覽器是哪一支毫無關係，它攻擊的是作業系統的 kernel。只要 kernel 沒有更新，未來任何一支能在 renderer 內執行程式碼的瀏覽器漏洞，都能接上同一段提權。修好瀏覽器只擋掉了這一次的入口。
+
+## 判讀關鍵：ESR 與 Rapid Release 是兩條分支
+
+Tor Browser 穩定版跟隨 Firefox ESR（Extended Support Release，延長支援版本）。15.0.x 系列建立在 140 ESR 上，2026 年 7 月 21 日的 15.0.19 把基底 rebase 到 140.13.0esr，Android 版的 GeckoView 同步跟上。[^5]
+
+Tor Browser Alpha 的情況不同。從 16.0a1 起，Alpha 通道改成跟隨 Firefox Rapid Release。Tor Project 在 2025 年 12 月的公告裡自己寫下這個取捨，快速把上游功能送給使用者的副作用，是也會快速把上游的錯誤一起送給使用者。同一份公告寫得更直接：如果你是高風險使用者、在意自己的隱私、或只是需要一個穩定可用的瀏覽器，你不應該使用 Tor Browser Alpha。[^6]
+
+CVE-2026-10702 的程式碼在 140 ESR 分支切出去之後才進入 Firefox，所以 ESR 這條線從來沒有這段程式碼。把各個對象排開來看：
+
+| 對象 | Firefox 基底 | 是否受影響 |
+|---|---|---|
+| Tor Browser 15.0.x 穩定版 | 140 ESR | 未受影響 |
+| Tor Browser for Android 穩定版 | GeckoView 140.13.0esr | 未受影響 |
+| Tor Browser Alpha 16.0a6（2026-05-07） | Firefox 150.0a1 | 落在受影響區間 |
+| Tor Browser Alpha 16.0a7（2026-06-03） | Firefox 151.0a1 | 無法確認，見文末保留事項 |
+| Tor Browser Alpha 16.0a8 起（2026-07-02） | Firefox 152.0a1 | 已越過修補點 |
+| 一般 Firefox 桌面版與 Android 版 | Rapid Release，151.0.2 以前 | 受影響，需升到 151.0.3 以上 |
+| Tails 與 Whonix 內建的 Tor Browser | 與穩定版同一條 ESR 線 | 未受影響 |
+
+### 三步判讀法
+
+下次看到一支 Firefox 的 CVE 編號，依序檢查這三件事就能得出結論。
+
+**第一步，看 Mozilla 有沒有同時發 ESR 公告。** Mozilla 為 ESR 分支發布獨立的 MFSA 編號。這次 MFSA-2026-54 只列出 Firefox 151.0.3，沒有任何對應的 ESR 公告，這是第一個訊號。
+
+**第二步，看 Red Hat 的 VEX 資料。** RHEL 隨附的 Firefox 是 ESR 版本，所以 Red Hat 對某支 CVE 的判定，實質上就是對 ESR 分支的判定。這次 Red Hat 的 CSAF VEX 文件把 RHEL 6 到 10 的 firefox 套件全部標記為 `known_not_affected`。[^7] 兩個獨立來源指向同一個結論，可信度就夠了。
+
+**第三步，看你那個 Tor Browser 版本的 Firefox 基底。** Tor Project 的 release notes 從不列出個別 CVE 編號，一律只寫 includes important security updates to Firefox，所以需自己從基底版本反推。本站的 [Tor 更新日誌](../../changelog/tor.md) 整理了每個版本的 Firefox 基底，穩定版與 Alpha 通道都有，可以直接對照。
+
+## CVSS 分數在這個案例會誤導人
+
+同一支漏洞在不同資料庫的評分差距很大。NVD 頁面上 CISA-ADP 給的 CVSS 3.1 是 4.3（Medium），Red Hat 給 7.5（High），Mozilla 自己評 High。[^8] 只看 NVD 首頁那個 4.3 會嚴重低估這支漏洞的實際份量。
+
+差距的來源在於評分方法本身。CVSS 評的是單一漏洞在孤立情況下的影響，而 renderer 內的程式碼執行看起來影響有限，因為沙箱還在。一旦接上 GhostLock，整條鏈的結果是遠端存取變成裝置 root。讀 CVE 的時候，把它放回攻擊鏈裡看，比單看分數準確得多。
+
+## 你可以採取的行動
+
+**Tor Browser 升到 15.0.19 或更新版本。** 這支漏洞打不到穩定版，但 15.0.19 帶了從 Firefox 153 backport 的其他安全修補，該升的還是要升。
+
+**一般 Firefox 升到 151.0.3 以上**，桌面版與 Android 版都要。
+
+**Alpha 通道不要當日常瀏覽器用。** 這是 Tor Project 自己的建議，這次剛好是實例。
+
+**安全等級調到 Safer 或 Safest 可以整類擋掉 JIT 漏洞。** 這兩個等級會關閉 `javascript.options.ion` 與 `javascript.options.baselinejit`，JIT 直接停用，編譯器層的缺陷就失去觸發機會。這裡有兩個坑要提醒。Tor Project 官方的安全等級說明頁完全沒有提到 JIT，只列出 JavaScript 與字型、影音的變化，所以光看官方文件不會知道這件事。另一個坑更實際，改完安全等級需完整重新啟動瀏覽器才真的生效。Privacy Guides 在 2025 年 5 月用 JavaScript 效能測試證明，沒有重新啟動的情況下 JIT 仍在運作，介面卻已經顯示成 Safer。[^9] 這個問題追蹤在 tor-browser issue `42572`。設定的操作步驟可以參考本站的 [Tor Browser 進階設定](../../tools/tor-browser-advanced.md)。
+
+**Linux 桌面使用者更新 kernel。** 更新之後確認取得的是修掉 CVE-2026-53166 回歸之後的版本，直接看套件版本號，不要假設發行版已經處理好。無法立即更新的機器可以開啟 `RANDOMIZE_KSTACK_OFFSET` 與 `STATIC_USERMODE_HELPER`，這兩者都是緩解措施，並非修補。
+
+**Android 使用者需等裝置廠商的系統更新。** kernel 層的提權在使用者端沒有自救方式，這也是 Android 生態長期的結構問題。
+
+截至 2026 年 7 月 28 日，一手資料沒有顯示這支漏洞在真實世界遭到利用。
+
+## 這篇文章沒有把握的部分
+
+寫這類題目時，把查不到的部分說明清楚，與把查到的說明清楚一樣重要。
+
+- 受影響的起始版本 Firefox 147 只有一個媒體來源提到。NVD、Rapid7 與 SentinelOne 都只寫「151.0.3 之前」。ESR 140 不受影響這件事有兩個獨立來源，可以放心，但確切從哪一版開始受影響，目前無法確認。
+- Tor Browser 16.0a7 的 Firefox 基底是 `151.0a1`，版本序上早於修補的 151.0.3。Tor Project 的 changelog 不列個別 CVE，無法確認該建置是否已經含有修補。
+- Tor Project 至今沒有針對這支 CVE 發過任何公開說明。媒體推論失準的空間，一部分來自這個資訊落差。
+- Bugzilla 編號 `2040903` 需要權限才能存取，無法讀到原始修補內容。漏洞機制的描述來自研究者與媒體的公開分析。
+
+## 名詞對照
+
+| 名詞 | 說明 |
+|---|---|
+| JIT（Just-In-Time） | 即時編譯，把反覆執行的程式碼轉成機器碼以加速 |
+| SpiderMonkey | Firefox 的 JavaScript 引擎 |
+| IonMonkey、Warp | SpiderMonkey 裡負責最佳化編譯的管線 |
+| global value numbering | 全域值編號，找出重複計算並消除的最佳化階段 |
+| lazy property | 延遲解析屬性，等到被存取時才真正建立 |
+| dynamic slots | 物件屬性值的動態儲存區，容量不足時會重新配置 |
+| use-after-free | 記憶體釋放後仍被使用，常見的可利用漏洞型態 |
+| type confusion | 類型混淆，程式把某型別的資料當成另一型別處理 |
+| renderer 行程 | 瀏覽器負責解析與繪製網頁內容的行程，通常受沙箱限制 |
+| ESR（Extended Support Release） | Firefox 的延長支援版本，功能更新慢、修補期長 |
+| Rapid Release | Firefox 的快速發布通道，約四週一個版本 |
+| futex | fast userspace mutex，Linux 的使用者空間鎖定機制 |
+| priority inheritance | 優先權繼承，避免高優先權工作被低優先權工作卡住的鎖定機制 |
+| CVSS | 漏洞評分系統，給出 0 到 10 的嚴重度分數 |
+| VEX | 漏洞可利用性交換格式，廠商用來聲明自家產品是否受某支 CVE 影響 |
+| MFSA | Mozilla Foundation Security Advisory，Mozilla 的安全公告編號 |
+
+## 相關閱讀
+
+- [Tor Browser 進階設定](../../tools/tor-browser-advanced.md)
+- [Tor 更新日誌](../../changelog/tor.md)
+- [什麼是 Tor](../../tools/what-is-tor.md)
+- [威脅模型如何建立](../../basics/threat-model.md)
+- [個人隱私指引研究專題](../../community/privacy-guide.md)
+
+[^1]: [IonStack, Nebula Security](https://rootme.nebusec.io/){target="_blank"}
+[^2]: [Researchers Show a Single Malicious Webpage Visit Can Compromise Tor Browser, The Hacker News 2026-07](https://thehackernews.com/2026/07/researchers-show-single-malicious.html){target="_blank"}
+[^3]: [Security Vulnerabilities fixed in Firefox 151.0.3（MFSA-2026-54）, Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-54/){target="_blank"}
+[^4]: [15-Year-Old GhostLock Flaw Enables Root and Container Escape on Most Linux Distros, The Hacker News 2026-07](https://thehackernews.com/2026/07/15-year-old-ghostlock-flaw-enables-root.html){target="_blank"}
+[^5]: [New Release: Tor Browser 15.0.19, The Tor Project 2026-07-21](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}
+[^6]: [The Future of Tor Browser Alpha, The Tor Project 2025-12-01](https://blog.torproject.org/future-of-tor-browser-alpha/){target="_blank"}
+[^7]: [CVE-2026-10702 CSAF VEX, Red Hat](https://security.access.redhat.com/data/csaf/v2/vex/2026/cve-2026-10702.json){target="_blank"}
+[^8]: [NVD - CVE-2026-10702](https://nvd.nist.gov/vuln/detail/CVE-2026-10702){target="_blank"}
+[^9]: [A Flaw With the Security Level Slider in Tor Browser, Privacy Guides 2025-05-02](https://www.privacyguides.org/articles/2025/05/02/tor-security-slider-flaw/){target="_blank"}

--- a/docs/zh-TW/blog/posts/2026-firefox-jit-cve-tor-browser.md
+++ b/docs/zh-TW/blog/posts/2026-firefox-jit-cve-tor-browser.md
@@ -8,7 +8,7 @@ categories:
     - 隱私
 slug: 2026-firefox-jit-cve-tor-browser
 image: "assets/images/tor.webp"
-summary: "Tor Browser 穩定版沒有受 Firefox 的 JIT 漏洞 CVE-2026-10702 影響，關鍵在於穩定版建立在 Firefox ESR 分支上，而這支漏洞的程式碼只存在於 Rapid Release 那條線。7 月底幾家安全媒體的標題寫著造訪一個惡意網頁就能攻陷 Tor Browser，說的就是這支漏洞。這篇文章整理一套三步判讀法，讓你下次看到 Firefox 的 CVE 編號時能自己判斷手上的 Tor Browser 是否受影響，後半說明漏洞原理與 IonStack 攻擊鏈。"
+summary: "Tor Browser 穩定版沒有受 Firefox 的 JIT 漏洞 CVE-2026-10702 影響，這段程式碼在 Firefox 147 才進入，穩定版跟隨的 140 ESR 沒有它。研究團隊說他們也用這支漏洞攻陷了 Tor Browser，卻沒有指明版本與通道，媒體標題也沒補上這個區分。這篇文章整理一套三步判讀法，讓你下次看到 Firefox 的 CVE 編號時能自己判斷手上的 Tor Browser 是否受影響，後半說明漏洞原理與 IonStack 攻擊鏈。"
 description: "CVE-2026-10702 是 Firefox JIT 編譯器的類型混淆漏洞，被研究者串成 Android 的瀏覽器到 root 完整攻擊鏈 IonStack。本文說明如何用 ESR 與 Rapid Release 的分支差異判斷一支 Firefox CVE 會不會影響 Tor Browser，附上受影響對照表、漏洞原理，以及安全等級與 kernel 更新的具體行動建議。"
 ---
 
@@ -16,9 +16,9 @@ description: "CVE-2026-10702 是 Firefox JIT 編譯器的類型混淆漏洞，�
 
 ![Tor](./assets/images/tor.webp){style="border-radius: 10px;"}
 
-2026 年 7 月底，幾家安全媒體同時出現類似的標題，說研究者證明造訪一個惡意網頁就能攻陷 Tor Browser。標題說的漏洞編號是 CVE-2026-10702，一支 Firefox JavaScript 引擎的 JIT 編譯器缺陷。打開研究團隊 Nebula Security 自己的公開頁面，示範對象寫得很明確，是一支 Firefox for Android 151.0（安裝檔 `fenix-151.0.multi.android-arm64-v8a.apk`），執行在 Android 17 的 ARM64 裝置上。整個頁面沒有出現 Tor Browser。[^1]
+2026 年 7 月底，幾家安全媒體同時出現類似的標題，說研究者證明造訪一個惡意網頁就能攻陷 Tor Browser。[^1] 標題說的漏洞編號是 CVE-2026-10702，一支 Firefox JavaScript 引擎的 JIT 編譯器缺陷。研究團隊 Nebula Security 的示範頁把對象寫得很明確，是一支 Firefox for Android 151.0（安裝檔 `fenix-151.0.multi.android-arm64-v8a.apk`），執行在 Android 17 的 ARM64 裝置上，該頁沒有提到 Tor Browser。[^2] 不過他們的技術文章裡有一句「We also used it to pwn Tor Browser」，攻陷 Tor Browser 的說法出自研究者本人，而那篇文章沒有說是哪一版、哪一個通道、哪個平台。[^3]
 
-對照各方資料，Tor Browser 穩定版沒有受這支漏洞影響，原因在於穩定版建立在 Firefox ESR 這條分支上，而這支漏洞的程式碼只存在於 Rapid Release 那條線。截至 2026 年 7 月 28 日，一手資料也沒有顯示這支漏洞在野利用（exploited in the wild）。
+對照各方資料，Tor Browser 穩定版沒有受這支漏洞影響，原因在於穩定版建立在 Firefox ESR 這條分支上，而這支漏洞的程式碼在 Firefox 147 才進入，140 ESR 沒有它。目前也沒有一手資料顯示這支漏洞在野利用（exploited in the wild），CVE 記錄裡 CISA 的 SSVC 評估把 Exploitation 標為 none。[^4]
 
 !!! tip "先確認你手上這一版"
 
@@ -32,9 +32,9 @@ description: "CVE-2026-10702 是 Firefox JIT 編譯器的類型混淆漏洞，�
 
 Tor Browser 穩定版跟隨 Firefox ESR（Extended Support Release，延長支援版本），15.0.x 系列建立在 140 ESR 上，2026 年 7 月 21 日的 15.0.19 把基底換到 140.13.0esr，Android 版的 GeckoView 同步換成同一個基底。[^5]
 
-Tor Browser Alpha 走另一條路。Tor Project 在 2025 年 12 月的公告裡宣布，Alpha 通道自 16.0a1 起改成跟隨 Firefox 的快速發布線，並寫下這個取捨，快速把上游功能送給使用者，也會快速把上游的錯誤一起送過去。同一份公告寫得更直接：「如果你是高風險使用者、在意自己的隱私，或只是需要一個穩定可用的瀏覽器，你不應該使用 Tor Browser Alpha。」[^6] 依本站 [Tor 更新日誌](../../changelog/tor.md) 的記錄，實際換基底發生在 2026 年 5 月 7 日的 16.0a6，該版起改以 Firefox beta 通道為基底，在此之前的 Alpha 仍建立在 ESR 上。
+Tor Browser Alpha 走另一條路。Tor Project 在 2025 年 12 月的公告裡宣布，Alpha 通道自 16.0a1 起改成跟隨 Firefox 的快速發布線，並寫下這個取捨，快速把上游功能送給使用者，也會快速把上游的錯誤一起送過去。同一份公告寫得更直接：「如果你是高風險使用者、在意自己的隱私，或只是需要一個穩定可用的瀏覽器，你不應該使用 Tor Browser Alpha。」[^6] 依本站 [Tor 更新日誌](../../changelog/tor.md) 的記錄，實際換基底發生在 2026 年 5 月 7 日的 16.0a6，該版起改以 Firefox beta 通道為基底，在此之前的 Alpha 仍建立在 ESR 上。2026 年 7 月 23 日的 16.0a9 又換回 ESR，基底是 Firefox 153.0esr，銜接下一代穩定版。[^7]
 
-Mozilla 在 2026 年 6 月 2 日發布的 Firefox 151.0.3 修掉這支漏洞[^3]，而 Mozilla 沒有為 ESR 分支發布對應公告，Red Hat 也把隨附的 ESR 版 Firefox 標記為未受影響，兩者都指向同一個結論，CVE-2026-10702 的程式碼在 140 ESR 分支切出去之後才進入 Firefox。把各個對象排開來看：
+Mozilla 在 2026 年 6 月 2 日發布的 Firefox 151.0.3 修掉這支漏洞。[^8] 這段程式碼何時進入 Firefox 有一手記錄可查，Bugzilla `1995077`（Replace Object.keys with specialized iterator in Scalar Replacement）的 target milestone 是 147 Branch，`firefox147` 標記為 fixed，而 esr140 的追蹤欄位是空的。[^9] 同期的 ESR 公告 MFSA-2026-58（Firefox ESR 140.12，6 月 16 日）列了 28 支 CVE，沒有這一支。[^10] Red Hat 的 CSAF VEX 也把 RHEL 6 到 10 的 firefox 套件全部標記為 `known_not_affected`，而 RHEL 隨附的正是 ESR 版。[^11] 三條獨立線索指向同一個結論，140 ESR 這條線沒有這段程式碼。把各個對象排開來看：
 
 | 對象 | Firefox 基底 | 是否受影響 | 你要做什麼 |
 |---|---|---|---|
@@ -43,23 +43,24 @@ Mozilla 在 2026 年 6 月 2 日發布的 Firefox 151.0.3 修掉這支漏洞[^3]
 | Tor Browser for Android 穩定版 | GeckoView 140.13.0esr | 未受影響 | 保持最新版 |
 | Tor Browser Alpha 16.0a6（2026-05-07） | Firefox 150.0a1 | 受影響 | 升到 16.0a8 以上，或換回穩定版 |
 | Tor Browser Alpha 16.0a7（2026-06-03） | Firefox 151.0a1 | 受影響 | 升到 16.0a8 以上，或換回穩定版 |
-| Tor Browser Alpha 16.0a8 起（2026-07-02） | Firefox 152.0a1 | 未受影響 | 保持最新版 |
+| Tor Browser Alpha 16.0a8（2026-07-02） | Firefox 152.0a1 | 未受影響 | 保持最新版 |
+| Tor Browser Alpha 16.0a9 起（2026-07-23） | Firefox 153.0esr | 未受影響 | 保持最新版 |
 | 一般 Firefox 桌面版與 Android 版 | Rapid Release，151.0.2 以前 | 受影響 | 升到 151.0.3 以上 |
-| Tails 與 Whonix 內建的 Tor Browser | 與穩定版同一條 ESR 線 | 未受影響 | 隨發行版更新 |
+| Tails 內建的 Tor Browser | Tails 7.10 內含 15.0.19 | 未受影響 | 隨 Tails 更新 |
 
-16.0a6 與 16.0a7 的基底都早於修補落地的 151.0.3，兩版一律當成受影響處理。
+16.0a6 與 16.0a7 的基底都早於修補落地的 151.0.3，兩版一律當成受影響處理。表格裡的判定都是從基底版本反推而來，Tor Project 沒有逐版說明過。Tails 那一列依據 Tails 7.10 的公告，該版內含 Tor Browser 15.0.19。[^12]
 
 ## 三步判讀法
 
 下次看到一支 Firefox 的 CVE 編號，依序檢查這三件事，多數情況能自己得出結論。前兩步是交叉驗證，若你不想查英文資料庫，直接看第三步。
 
-**第一步，看 Mozilla 有沒有同時發 ESR 公告。** Mozilla 為 ESR 分支發布獨立的 MFSA 編號。這次 MFSA-2026-54 只列出 Firefox 151.0.3，沒有任何對應的 ESR 公告。換成一句好記的判斷：Tor Browser 穩定版遇到 Firefox 的 CVE，通常只有在 Mozilla 同時發 ESR 公告時才需要緊張。
+**第一步，看 Mozilla 有沒有同時發 ESR 公告。** Mozilla 為 ESR 分支發布獨立的 MFSA 編號。這次 MFSA-2026-54 只列出 Firefox 151.0.3 的兩支 CVE，而同期的 ESR 公告 MFSA-2026-58 不含這一支。換成一句好記的判斷：Tor Browser 穩定版遇到 Firefox 的 CVE，通常只有在 Mozilla 同時發 ESR 公告時才需要緊張。
 
-**第二步，看 Red Hat 的 VEX 資料。** RHEL 隨附的 Firefox 是 ESR 版本，所以 Red Hat 對某支 CVE 的判定，實質上就是對 ESR 分支的判定。這次 Red Hat 的 CSAF VEX 文件把 RHEL 6 到 10 的 firefox 套件全部標記為 `known_not_affected`。[^7] Mozilla 沒發 ESR 公告、Red Hat 標記未受影響，兩個獨立來源指向同一個結論。
+**第二步，看 Red Hat 的 VEX 資料。** RHEL 隨附的 Firefox 是 ESR 版本，所以 Red Hat 對某支 CVE 的判定，實質上就是對 ESR 分支的判定。這次 Red Hat 的 CSAF VEX 文件把 RHEL 6 到 10 的 firefox 套件全部標記為 `known_not_affected`。若運氣好，Mozilla 的 Bugzilla 編號也可能是公開的，像這次的 `1995077` 就能直接看到程式碼落在哪一個 Branch。
 
-**第三步，看手上這個 Tor Browser 版本的 Firefox 基底。** Tor Project 的更新日誌從不列出個別 CVE 編號，一律只寫「includes important security updates to Firefox」，所以需自己從基底版本反推。本站的 [Tor 更新日誌](../../changelog/tor.md) 整理了近期版本的 Firefox 基底，穩定版與 Alpha 通道都有，目前回溯到 15.0.11。更舊的版本需回上游的 release notes 查。
+**第三步，看手上這個 Tor Browser 版本的 Firefox 基底。** Tor Browser 的公告在 Firefox 安全更新這一項不列個別 CVE 編號，一律只寫「includes important security updates to Firefox」，所以需自己從基底版本反推。本站的 [Tor 更新日誌](../../changelog/tor.md) 整理了近期版本的 Firefox 基底，穩定版與 Alpha 通道都有，目前回溯到 15.0.11。更舊的版本需回上游的 release notes 查。
 
-**別只看 CVSS 分數。** 同一支漏洞在不同資料庫的評分差距很大，NVD 頁面上 CISA-ADP 給的 CVSS 3.1 是 4.3（Medium）[^8]，Red Hat 給 7.5（High）[^7]，Mozilla 自己評 High[^3]。差距來自評分方法本身，CVSS 只評估單一漏洞在孤立情況下的影響，而 renderer 內的程式碼執行看起來影響有限，因為沙箱還在。這支漏洞的實際份量來自它是一條完整攻擊鏈的第一段，把它放回鏈裡看才準確，後面兩節就在拆解這條鏈。
+**別只看 CVSS 分數。** 同一支漏洞在不同資料庫的評分差距很大，NVD 頁面上 CISA-ADP 給的 CVSS 3.1 是 4.3（Medium），Red Hat 給 7.5（High），Mozilla 自己評 High。[^13] 差距來自評分方法本身，CVSS 只評估單一漏洞在孤立情況下的影響，而 renderer 內的程式碼執行看起來影響有限，因為沙箱還在。這支漏洞的實際份量來自它是一條完整攻擊鏈的第一段，把它放回鏈裡看才準確，後面兩節就在拆解這條鏈。
 
 ## 漏洞原理：編譯器被自己的標記騙了
 
@@ -69,17 +70,19 @@ JIT（Just-In-Time，即時編譯）的工作是把反覆執行的 JavaScript �
 
 Firefox 的 JavaScript 引擎 SpiderMonkey 裡的 `MObjectToIterator` 操作，在 `skipRegistration` 開啟時被標記成只會讀取資料。實際行為並非如此，它在解析延遲屬性（lazy property）的過程中會配置一塊新的動態儲存區（dynamic slots）緩衝區，並且釋放掉舊的那一塊。
 
-接手的最佳化階段稱為 global value numbering（全域值編號），職責是找出重複計算並消除。它看到標記寫著這裡什麼都沒改，於是判斷後面那次載入 slots 指標的動作是多餘的，直接沿用先前那個指標，而那個指標指向的記憶體已經被釋放。編譯出來的機器碼因此握著一個懸空指標（dangling pointer）讀寫記憶體，攻擊者由此取得任意讀寫能力，在 renderer 行程內執行自己的程式碼。[^2] global value numbering 屬於 IonMonkey 這條最佳化管線，攻擊鏈的名字 IonStack 就從這裡來。
+接手的最佳化階段稱為 global value numbering（全域值編號），職責是找出重複計算並消除。它看到標記寫著這裡什麼都沒改，於是判斷後面那次載入 slots 指標的動作是多餘的，直接沿用先前那個指標，而那個指標指向的記憶體已經被釋放。編譯出來的機器碼因此握著一個懸空指標（dangling pointer）讀寫記憶體，攻擊者由此取得任意讀寫能力，在 renderer 行程內執行自己的程式碼。global value numbering 屬於 IonMonkey 這條最佳化管線，攻擊鏈名為 IonStack，研究者沒有解釋命名由來。
 
 到這一步，攻擊者的程式碼仍被關在 renderer 的沙箱裡，要碰到你的檔案與其他資料，還需要第二支漏洞。
 
-Mozilla 的修補方式是移除那個錯誤的唯讀標記處理，公告編號 MFSA-2026-54，評級 High，回報者記為 Nebula Security。分類上這支同時對應 CWE-843（類型混淆，type confusion）與 CWE-733（編譯器最佳化移除或改動安全關鍵程式碼），後者精準描述了問題出在最佳化決策本身。對應的 Bugzilla 編號 `2040903` 目前仍限制存取，所以上面的機制描述來自研究者與媒體的公開分析。
+Mozilla 的修補移除了那個依 `skipRegistration` 分岔的別名集合，讓這個操作一律被當成會改動記憶體。公告編號 MFSA-2026-54，評級 High，回報者記為 Nebula Security。分類上這支同時對應 CWE-843（類型混淆，type confusion）與 CWE-733（編譯器最佳化移除或改動安全關鍵程式碼），後者精準描述了問題出在最佳化決策本身。對應的 Bugzilla 編號 `2040903` 目前仍限制存取，上面的機制描述與修補內容來自研究者公開的技術文章。[^3]
 
 ## 攻擊鏈 IonStack：從瀏覽器一路到 root
 
 研究團隊把這支漏洞放在攻擊鏈的第一段，負責在瀏覽器的 renderer 沙箱內取得程式執行能力，第二段負責跳出沙箱、取得整台裝置的控制權。兩段合起來稱為 IonStack，示範平台是 Android 17 的 ARM64 裝置。
 
-第二段是 CVE-2026-43499，別名 GhostLock，位置在 Linux kernel 的 futex 優先權繼承（priority inheritance）程式碼，也就是 glibc `PTHREAD_PRIO_INHERIT` 互斥鎖背後的機制。上鎖操作失敗並回退時，清理程式碼釋放了仍被參照的 task 結構，kernel 於是握著一個指向已釋放記憶體的指標，屬於釋放後使用（use-after-free）。這一段攻擊的是你的作業系統，與瀏覽器無關。它從 2011 年的 Linux 2.6.39-rc1 就存在，前提是編譯選項 `CONFIG_FUTEX_PI=y`，主流發行版預設都開啟。Nebula Security 公開的 exploit 從一般權限取得 root 約需 5 秒，成功率約 97%，在使用標準 kernel 的容器內同樣有效。上游在 2026 年 4 月修好並 backport，7 月 7 日公開，第一版修補引入的當機問題另外編為 CVE-2026-53166，截至 7 月初這個回歸（regression）的後續修補尚未穩定。[^4]
+第二段是 CVE-2026-43499，別名 GhostLock，位置在 Linux kernel 的 futex 優先權繼承（priority inheritance）程式碼，也就是 glibc `PTHREAD_PRIO_INHERIT` 互斥鎖背後的機制。上鎖操作失敗並回退時，清理程式碼清掉了錯誤那一方的紀錄，等待中的 task 帶著一個仍指向自己核心堆疊的指標返回使用者空間。那塊堆疊記憶體隨後被別的東西用掉，後續走訪優先權鏈時就踩在已釋放的堆疊上，屬於釋放後使用（use-after-free）。研究者自己把它稱為 stack-UAF，並指出這類漏洞多半發生在堆積上，落在核心堆疊的少見。[^14]
+
+這一段攻擊的是你的作業系統，與瀏覽器無關。受影響檔案是 `kernel/locking/rtmutex.c`，問題從 2011 年的 Linux 2.6.39 就存在，一路到 v7.1-rc1，主線在 7.1 修好。[^15] 唯一的條件是 kernel 編譯時開了 `CONFIG_FUTEX_PI`，實務上等同每個發行版都開，可以直接當成全部受影響。在 Google kernelCTF 的 x86 靶機上（lts-6.12.80，且未開啟 `RANDOMIZE_KSTACK_OFFSET`），這支 exploit 從一般權限取得 root 約需 5 秒，穩定度約 97%，在使用標準 kernel 的容器內同樣有效。上游 4 月 18 日收到回報、4 月 20 日修好，5 月 4 日 backport，7 月 7 日公開。第一版修補引入的當機問題曾另編為 CVE-2026-53166，6 月 2 日修好，該編號後於 7 月 10 日被 Linux CNA 撤回。[^16]
 
 只要 kernel 沒有更新，未來任何一支能在 renderer 內執行程式碼的瀏覽器漏洞，都能接上同一段提權。修好瀏覽器只擋掉了這一次的入口。
 
@@ -91,27 +94,28 @@ Mozilla 的修補方式是移除那個錯誤的唯讀標記處理，公告編號
 
 **Alpha 通道不要當日常瀏覽器用。** 這是 Tor Project 自己的建議，這次剛好是實例。
 
-**安全等級調到 Safer 或 Safest 可以擋掉整類 JIT 漏洞。** 這兩個等級會關閉 `javascript.options.ion` 與 `javascript.options.baselinejit`，JIT 直接停用，編譯器層的缺陷就失去觸發機會。操作是點網址列旁的盾牌圖示，選 Change，再選等級，不需要進 `about:config` 改任何設定。代價要先知道：Safer 會關掉 HTTP 站點的 JavaScript 與部分字型，Safest 關閉全部 JavaScript，部分網站的表單會送不出去。更詳細的取捨可以參考本站的 [Tor Browser 進階設定](../../tools/tor-browser-advanced.md)。
+**安全等級調到 Safer 或 Safest 可以擋掉整類 JIT 漏洞。** 這兩個等級會關閉 `javascript.options.ion` 與 `javascript.options.baselinejit`，JIT 直接停用，編譯器層的缺陷就失去觸發機會。[^17] 操作是點網址列旁的盾牌圖示，選 Change，再選等級，不需要進 `about:config` 改任何設定。代價要先知道：Safer 會關掉 HTTP 站點的 JavaScript 與部分字型，Safest 預設關閉全站 JavaScript，部分網站的表單會送不出去。更詳細的取捨可以參考本站的 [Tor Browser 進階設定](../../tools/tor-browser-advanced.md)。
 
-**改完安全等級要關掉所有 Tor Browser 視窗再重新開啟。** Tor Project 官方的安全等級說明頁沒有提到 JIT，只列出 JavaScript 與字型、影音的變化，所以光看官方文件不會知道 JIT 這件事。更實際的限制是，沒有完整重新啟動的話設定不會生效。Privacy Guides 在 2025 年 5 月用 JavaScript 效能測試證明，沒有重新啟動的情況下 JIT 仍在運作，介面卻已經顯示成 Safer。[^9] 這個問題追蹤在 tor-browser issue `42572`。
+**改完安全等級要關掉所有 Tor Browser 視窗再重新開啟。** Tor Project 官方的安全等級說明頁沒有提到 JIT，只列出 JavaScript 與字型、影音的變化，所以光看官方文件不會知道 JIT 這件事。Privacy Guides 在 2025 年 5 月測 Tor Browser 14.5.1 時發現，沒有重新啟動的話 JIT 仍在運作，介面卻已經顯示成 Safer。[^18] 15.x 桌面版已經修掉這個沉默失敗，切換等級會提示重啟（tor-browser issue `43783`），Android 版的同一套整合到 16.0 才完成。原則不變，改完就重啟。
 
 **Windows 與 macOS 使用者只需做上面這些。** 攻擊鏈的第二段是 Linux kernel 的漏洞，這兩個平台不適用。
 
-**Linux 桌面使用者更新 kernel，並且重新開機。** kernel 更新沒有重開機不會生效，這一步最常被漏掉。更新後用 `uname -r` 確認正在運作的版本，並對照發行版對 CVE-2026-43499 與 CVE-2026-53166 的公告狀態，不要假設已經處理好。編譯期的緩解選項（例如 `CONFIG_STATIC_USERMODE_HELPER`）需重新編譯 kernel，一般桌面使用者做不到，自行維運伺服器或 relay 的人可以評估用開機參數 `randomize_kstack_offset=on` 開啟 kernel 堆疊位移隨機化。這些都是緩解措施，並非修補。
+**Linux 桌面使用者更新 kernel，並且重新開機。** kernel 更新沒有重開機不會生效，這一步最常被漏掉。更新後用 `uname -r` 確認正在運作的版本，並對照發行版對 CVE-2026-43499 的公告狀態，不要假設已經處理好。編譯期的緩解選項（例如 `CONFIG_STATIC_USERMODE_HELPER`）需重新編譯 kernel，一般桌面使用者做不到。自行維運伺服器或 relay 的人可以評估開機參數 `randomize_kstack_offset=on`，前提是發行版的 kernel 已帶入 `CONFIG_RANDOMIZE_KSTACK_OFFSET`，它只增加約 5 個 bit 的猜測成本，算是拖延而非修補。
 
 **Android 使用者需等裝置廠商的系統更新。** kernel 層的提權在使用者端沒有自救方式，更新何時送達取決於裝置廠商與電信商。
 
 ## 一支 CVE 編號不足以判斷影響範圍
 
-同一份原始碼分成兩條發布線之後，兩條線就是兩份不同的程式碼。這支漏洞在 140 ESR 切出去之後才進入 Firefox，因此穩定版從來沒有這段程式碼，而跟隨快速發布線的 Alpha 通道有。三步判讀法要回答的就是這件事，看 Mozilla 有沒有發 ESR 公告、看 Red Hat 對 ESR 版套件的判定、看手上這個版本的 Firefox 基底。
+同一份原始碼分成兩條發布線之後，兩條線就是兩份不同的程式碼。這支漏洞的程式碼在 Firefox 147 才進入，穩定版跟隨的 140 ESR 沒有它，而跟隨快速發布線的 Alpha 通道有。三步判讀法要回答的就是這件事，看 Mozilla 有沒有發 ESR 公告、看 Red Hat 對 ESR 版套件的判定、看手上這個版本的 Firefox 基底。
 
-媒體標題會寫成攻陷 Tor Browser，一部分原因在於把「Firefox 的漏洞」直接推論成「所有建立在 Firefox 上的瀏覽器都中」。另一部分來自資訊落差，Tor Project 的更新日誌不列個別 CVE 編號，也沒有針對這支漏洞發過公開說明，外界只能自己推論，推論就有機會出錯。下次遇到類似的標題，先問它說的是哪一條分支。
+攻陷 Tor Browser 的說法出自研究者本人，他們沒有指明版本與通道，媒體標題也沒有補上這個區分。讀者手上只有一個 CVE 編號與一句沒有版本的宣稱，剩下的只能自己往下查。下次遇到類似的標題，先問它說的是哪一條分支。
 
 ## 沒有把握的部分
 
-- 受影響的起始版本 Firefox 147 只有 The Hacker News 一個來源提到。NVD、Rapid7 與 SentinelOne 都只寫「151.0.3 之前」。ESR 140 不受影響有兩個獨立來源支持，確切從哪一版開始受影響則無法確認。
-- Tor Browser 16.0a6 與 16.0a7 的 Firefox 基底早於修補落地的 151.0.3，本文據此列為受影響。Tor Project 的更新日誌不列個別 CVE，無法確認這兩個建置是否已經含有修補。
-- Tor Project 至今沒有針對這支 CVE 發過任何公開說明。媒體會出現失準的推論，一部分來自這個資訊落差。
+- 研究者沒有說明他們攻陷的是哪一版 Tor Browser。〈IonStack Part I〉只有「We also used it to pwn Tor Browser」這一句，沒有版本、通道與平台，示範頁與媒體報導也都沒有。這無法排除他們攻陷的是 Alpha 通道，也無法排除其他可能。
+- Tor Browser 16.0a6 與 16.0a7 的 Firefox 基底早於修補落地的 151.0.3，本文據此列為受影響。dist 目錄已不再提供這兩版，無法對二進位檔驗證是否含有修補。
+- Whonix 內建的 Tor Browser 走哪一條通道，查不到可以支撐的官方頁面，所以沒有列進對照表。Whonix 的文件只建議使用穩定版。
+- Tor Project 至今沒有針對這支 CVE 發過任何公開說明。
 - Bugzilla 編號 `2040903` 需要權限才能存取，無法讀到原始修補內容。
 
 ## 名詞對照
@@ -122,12 +126,13 @@ Mozilla 的修補方式是移除那個錯誤的唯讀標記處理，公告編號
 |---|---|
 | JIT（Just-In-Time） | 即時編譯，把反覆執行的程式碼轉成機器碼以加速 |
 | SpiderMonkey | Firefox 的 JavaScript 引擎 |
-| IonMonkey、Warp | SpiderMonkey 裡負責最佳化編譯的管線 |
+| IonMonkey、Warp | SpiderMonkey 裡負責最佳化編譯的管線，Warp 是前端，IonMonkey 負責後續最佳化與產生機器碼 |
 | global value numbering | 全域值編號，找出重複計算並消除的最佳化階段 |
 | lazy property（延遲屬性） | 等到被存取時才真正建立的物件屬性 |
 | dynamic slots（動態儲存區） | 物件屬性值的動態儲存區，容量不足時會重新配置 |
 | dangling pointer（懸空指標） | 指向已被釋放記憶體的指標 |
 | use-after-free（釋放後使用） | 記憶體釋放後仍被使用，常見的可利用漏洞型態 |
+| stack-UAF | 釋放後使用的一種，被釋放的記憶體位於核心堆疊而非堆積 |
 | type confusion（類型混淆） | 程式把某型別的資料當成另一型別處理 |
 | sandbox（沙箱） | 限制程式能碰到哪些資源的隔離機制，瀏覽器用它把網頁內容關起來 |
 | renderer 行程 | 瀏覽器負責解析與繪製網頁內容的行程，受沙箱限制 |
@@ -135,15 +140,15 @@ Mozilla 的修補方式是移除那個錯誤的唯讀標記處理，公告編號
 | 提權（privilege escalation） | 從低權限取得高權限的攻擊手法 |
 | exploit | 實際利用某支漏洞的程式或步驟 |
 | ESR（Extended Support Release） | Firefox 的延長支援版本，功能更新慢、修補期長 |
-| Rapid Release | Firefox 的快速發布通道，約四週一個版本 |
+| Rapid Release | Firefox 的快速發布通道，2026 年 7 月時約四週一個版本 |
 | 通道（channel） | 同一個軟體的不同發布線，例如穩定版與 Alpha 測試版 |
 | 基底、rebase | Tor Browser 建立在某個 Firefox 版本之上，換到新版本的動作稱為 rebase |
 | backport | 把新版的修補移植回舊的維護分支 |
-| regression（回歸） | 修補引入的新問題，讓原本正常的行為出錯 |
 | futex | fast userspace mutex，Linux 的使用者空間鎖定機制 |
 | priority inheritance（優先權繼承） | 避免高優先權工作被低優先權工作卡住的鎖定機制 |
 | CWE | 漏洞類型的分類編號系統，描述問題屬於哪一類 |
 | CVSS | 漏洞評分系統，給出 0 到 10 的嚴重度分數 |
+| SSVC | 另一套漏洞評估框架，CISA 用它標記是否已遭利用等欄位 |
 | VEX | 漏洞可利用性交換格式，廠商用來聲明自家產品是否受某支 CVE 影響 |
 | MFSA | Mozilla Foundation Security Advisory，Mozilla 的安全公告編號 |
 
@@ -154,12 +159,21 @@ Mozilla 的修補方式是移除那個錯誤的唯讀標記處理，公告編號
 - [什麼是 Tor](../../tools/what-is-tor.md)
 - [威脅模型如何建立](../../basics/threat-model.md)
 
-[^1]: [IonStack, Nebula Security](https://rootme.nebusec.io/){target="_blank"}
-[^2]: [Researchers Show a Single Malicious Webpage Visit Can Compromise Tor Browser, The Hacker News 2026-07](https://thehackernews.com/2026/07/researchers-show-single-malicious.html){target="_blank"}
-[^3]: [Security Vulnerabilities fixed in Firefox 151.0.3（MFSA-2026-54）, Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-54/){target="_blank"}
-[^4]: [15-Year-Old GhostLock Flaw Enables Root and Container Escape on Most Linux Distros, The Hacker News 2026-07](https://thehackernews.com/2026/07/15-year-old-ghostlock-flaw-enables-root.html){target="_blank"}
+[^1]: [Researchers Show a Single Malicious Webpage Visit Can Compromise Tor Browser, The Hacker News 2026-07](https://thehackernews.com/2026/07/researchers-show-single-malicious.html){target="_blank"}
+[^2]: [IonStack 示範頁, Nebula Security](https://rootme.nebusec.io/){target="_blank"}
+[^3]: [IonStack Part I：CVE-2026-10702, Nebula Security](https://nebusec.ai/research/ionstack-part-1-cve-2026-10702/){target="_blank"}
+[^4]: [CVE-2026-10702 記錄（含 CISA-ADP 的 SSVC 評估）, CVE Program](https://cveawg.mitre.org/api/cve/CVE-2026-10702){target="_blank"}
 [^5]: [New Release: Tor Browser 15.0.19, The Tor Project 2026-07-21](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}
 [^6]: [The Future of Tor Browser Alpha, The Tor Project 2025-12-01](https://blog.torproject.org/future-of-tor-browser-alpha/){target="_blank"}
-[^7]: [CVE-2026-10702 CSAF VEX, Red Hat](https://security.access.redhat.com/data/csaf/v2/vex/2026/cve-2026-10702.json){target="_blank"}
-[^8]: [NVD - CVE-2026-10702](https://nvd.nist.gov/vuln/detail/CVE-2026-10702){target="_blank"}
-[^9]: [A Flaw With the Security Level Slider in Tor Browser, Privacy Guides 2025-05-02](https://www.privacyguides.org/articles/2025/05/02/tor-security-slider-flaw/){target="_blank"}
+[^7]: [New Alpha Release: Tor Browser 16.0a9, The Tor Project 2026-07-23](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}
+[^8]: [Security Vulnerabilities fixed in Firefox 151.0.3（MFSA-2026-54）, Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-54/){target="_blank"}
+[^9]: [Bug 1995077：Replace Object.keys with specialized iterator in Scalar Replacement, Mozilla Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1995077){target="_blank"}
+[^10]: [Security Vulnerabilities fixed in Firefox ESR 140.12（MFSA-2026-58）, Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2026-58/){target="_blank"}
+[^11]: [CVE-2026-10702 CSAF VEX, Red Hat](https://security.access.redhat.com/data/csaf/v2/vex/2026/cve-2026-10702.json){target="_blank"}
+[^12]: [Tails 7.10, Tails 2026-07-23](https://blog.torproject.org/new-release-tails-7_10/){target="_blank"}
+[^13]: [NVD - CVE-2026-10702](https://nvd.nist.gov/vuln/detail/CVE-2026-10702){target="_blank"}
+[^14]: [IonStack Part II：GhostLock, Nebula Security](https://nebusec.ai/research/ionstack-part-2/){target="_blank"}
+[^15]: [CVE-2026-43499, Linux kernel CNA](https://git.kernel.org/pub/scm/linux/security/vulns.git/plain/cve/published/2026/CVE-2026-43499.mbox){target="_blank"}
+[^16]: [CVE-2026-53166（已撤回）, CVE Program](https://cveawg.mitre.org/api/cve/CVE-2026-53166){target="_blank"}
+[^17]: [SecurityLevel.sys.mjs（Tor Browser 15.0.19 原始碼）, The Tor Project](https://gitlab.torproject.org/tpo/applications/tor-browser/-/blob/tor-browser-140.13.0esr-15.0-1-build2/toolkit/components/securitylevel/SecurityLevel.sys.mjs){target="_blank"}
+[^18]: [A Flaw With the Security Level Slider in Tor Browser, Privacy Guides 2025-05-02](https://www.privacyguides.org/articles/2025/05/02/tor-security-slider-flaw/){target="_blank"}


### PR DESCRIPTION
## 這篇文章做什麼

zh-TW 先行版，走「判讀教學」方向。以 CVE-2026-10702 這支 Firefox JIT 漏洞為案例，教讀者如何自己判斷一支 Firefox 的 CVE 會不會影響手上的 Tor Browser。

新增檔案：`docs/zh-TW/blog/posts/2026-firefox-jit-cve-tor-browser.md`
產出網址：`/docs/blog/2026/07/2026-firefox-jit-cve-tor-browser/`

## 核心查證結果

Tor Browser 穩定版**未受**這支漏洞影響。漏洞程式碼只存在於 Firefox Rapid Release 線，而 15.0.x 穩定版建立在 140 ESR 上。三個獨立佐證：

1. MFSA-2026-54 只列 Firefox 151.0.3，沒有對應的 ESR 公告。
2. Red Hat CSAF VEX 把 RHEL 6 到 10 的 firefox 套件全標為 `known_not_affected`（RHEL 出的是 ESR 版）。
3. 研究團隊 Nebula Security 自己的頁面示範對象是 `fenix-151.0.multi.android-arm64-v8a.apk`，全頁未出現 Tor Browser。

受影響的是跟隨 Rapid Release 的 Alpha 通道（16.0a6 基於 150.0a1、16.0a8 起已越過修補點）以及一般 Firefox 147 到 151.0.2。多家媒體「造訪一個網頁就能攻陷 Tor Browser」的標題與研究者的實際示範對不上，文章直接處理這個落差。

## 內容涵蓋

- JIT 類型混淆原理：`MObjectToIterator` 在 `skipRegistration` 下被誤標為唯讀，global value numbering 因此沿用已釋放的 dynamic slots 指標，附倉庫清單的類比
- IonStack 攻擊鏈與第二段 GhostLock（CVE-2026-43499）的 kernel 提權，含 `CONFIG_FUTEX_PI` 前提與 CVE-2026-53166 回歸
- 三步判讀法：查 ESR 公告、查 Red Hat VEX、查 Tor Browser 的 Firefox 基底
- CVSS 分數落差（NVD 4.3 對 Red Hat 7.5）為何會誤導
- 行動建議，含安全等級關閉 `javascript.options.ion` 與 `baselinejit` 的兩個坑（官方說明頁未提 JIT、改完需完整重啟，tor-browser issue 42572）
- 明確列出查不到的保留事項（起始版本 147 單一來源、16.0a7 無法確認、Tor Project 未發聲明、Bugzilla 2040903 受限）

## 驗證

- `tools/docs_style_lint.py`：0 error、0 warn
- `mkdocs build -s`（strict）通過，exit 0，無新增告警。驗證時暫時關閉 privacy 與 social 外掛，因為本機沙箱無網路，該暫存設定未提交
- 五條站內連結與圖片路徑均確認存在，產出頁面的 9 個註腳與相對連結正常算繪

## 後續

- 其他語系（zh-CN、en）待這版內容定案後補上
- 另一個可考慮的後續：`docs/zh-TW/tools/tor-browser-advanced.md` 的安全等級一節目前沒有提到 JIT 與需重啟這兩件事，可另開 PR 補上

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkK6hpkmTPnP3FwdphQNqh