### PR TITLE
feat(pwa): 三件互動作品加進離線預快取，並加一支清單驗證

### DIFF
--- a/docs/zh-TW/sw.js
+++ b/docs/zh-TW/sw.js
@@ -11,8 +11,8 @@
  * 換版後 activate 階段會清除舊快取。
  *
  * manifest 的 id：docs/zh-TW/manifest.webmanifest 同時被 run.sh（輸出到 /docs/）
- * 與 run_zh-tw.sh（輸出到 /docs/zh-tw/）使用，兩棵樹的內容逐位元組相同。裡面的
- * id 寫成 "/docs/"，而規格上 id 是相對 origin 解析，所以兩棵樹都會得到
+ * 與 run_zh-tw.sh（輸出到 /docs/zh-tw/）使用，兩個輸出目錄的內容逐位元組相同。
+ * 裡面的 id 寫成 "/docs/"，而規格上 id 是相對 origin 解析，所以兩邊都會得到
  * https://anoni.net/docs/，瀏覽器視為同一個 App。這是刻意的：同一份內容不該
  * 出現兩個可安裝項目。en 與 zh-cn 各自有獨立的 manifest 與 id，不受影響。
  *
@@ -34,7 +34,8 @@ const SCOPE_PATH = new URL(self.registration.scope).pathname;
 
 // 各語系 build 的根路徑前綴（相對於 scope）。預設 build（zh-TW）在根。
 //
-// 這裡不放 "zh-tw/"。站台會建置四棵樹，但根路徑與 /zh-tw/ 是同一份 zh-TW 內容，
+// 這裡不放 "zh-tw/"。站台跑四次 mkdocs build（run.sh、run_zh-tw.sh、run_zh-cn.sh、
+// run_en.sh），但 run.sh 輸出的根路徑與 run_zh-tw.sh 輸出的 /zh-tw/ 是同一份內容，
 // 兩邊都預快取等於同樣的四十幾頁抓兩次。實測整份 precache 是 21.3 MB，其中
 // 6.8 MB（31%）就是這份重複。讀者很可能在受限或計量的網路下第一次造訪，這個
 // 浪費是實打實的。/zh-tw/ 的頁面若真的被造訪，runtime 快取仍會接住。
@@ -122,6 +123,8 @@ const CORE_PAGES_ZH = [
   "taiwan/tor-relay-watcher/",
   // community（社群，選錄離線可讀的工具頁）
   "community/onionoo-mcp/",
+  // 互動與呈現的索引頁。作品本體不在這裡，見下面的 GAME_APPS。
+  "games/",
 ];
 
 // en 是策展型原創軌道，頁面集合與 zh 版不同（沒有 tools/、taiwan/、advanced/、help/）。
@@ -138,6 +141,76 @@ const CORE_PAGES_EN = [
   "community/onionoo-mcp/",
   "regional/",
   "regional/tor-relay-watcher/",
+  "games/",
+];
+
+// 三件互動作品的本體。
+//
+// 跟核心章節不同，這一批只放一份，不跟著 LANG_PREFIXES 複製。三個語系的 games
+// 索引頁各自存在，但作品本身只由 run.sh 建置到根路徑 /docs/games/，其他語系是用
+// ?lang= 連過去共用同一份程式。跟著前綴複製的話，另外兩個語系會抓到 404，白繞一圈。
+//
+// 為什麼值得預快取：這是站上唯一「已經做好、有人在用，卻沒被離線策略蓋到」的東西。
+// 實際會用到的離線情境是工作坊沒有 wifi、教學現場網路很差，而那些場合正是要把畫面
+// 翻給人看的時候。網頁載得出來但地球儀空白，比整頁打不開更難解釋。
+//
+// 成本：28 個檔案、2.33 MB。加進來之前整份預快取是 14.74 MB，所以這是 +15.8%。
+// 拆開來看：
+//
+//   three.js vendor 1.05 MB（三件共用）
+//   地球儀的資料檔   0.86 MB
+//   地球儀的程式     0.30 MB
+//   另外兩件         0.12 MB
+//
+// bathymetry.json 那 426 KB 刻意不放。它是海底等深線畫出來的深淺底色，是整批裡最大
+// 的一份，而 atlas.js 抓它時帶 .catch(() => null)，最深那階的顏色又刻意等於海面的
+// 單色，所以離線時少了它畫面跟以前一模一樣，不會看起來像壞掉。用最大的檔案換一層
+// 純裝飾的質感，這個交換划算。
+//
+// 再往下砍就沒有這麼乾淨了。tw-admin（215 KB）與 countries（136 KB）是次大的兩份，
+// 但前者拿掉就沒有縣市界、放大台灣只剩空白，後者是必要的，缺了整顆球都畫不出來。
+// 那時畫面看起來像壞掉而不像少了東西，比整個不快取更糟。
+//
+// 數字用 tools/check_precache.mjs 量的，那支讀的是 apparent size，也就是實際要傳輸的
+// 位元組。不要用 du 量，這台的檔案系統會共用 extent，du report 出來只有一半。
+//
+// 身分敏感度：照 CORE_PAGES_ZH 那條判準（讀者是不是特定受威脅身分）檢查過。這三件
+// 是教學性質的視覺化，跟已經在預快取裡的 tools/what-is-tor/ 同一類，不指向特定身分，
+// 所以可以放。
+//
+// 維護：新增作品或地球儀多一份資料檔時要補進這裡，漏了的話那一份會在離線時抓不到。
+// seacable.json 刻意不在清單裡，那份沒有落地到 repo。
+const GAME_APPS = [
+  "games/onion-routing/index.html",
+  "games/onion-routing/game.js",
+  "games/onion-routing/i18n.js",
+  "games/onion-routing/levels.js",
+  "games/onion-rendezvous/index.html",
+  "games/onion-rendezvous/scene.js",
+  "games/onion-rendezvous/i18n.js",
+  "games/tor-network/index.html",
+  "games/tor-network/atlas.js",
+  "games/tor-network/i18n.js",
+  "games/tor-network/cables.json",
+  "games/tor-network/continents.json",
+  "games/tor-network/countries.json",
+  "games/tor-network/netusers.json",
+  "games/tor-network/ooni.json",
+  "games/tor-network/shutdowns.json",
+  "games/tor-network/snapshot.json",
+  "games/tor-network/torusers.json",
+  "games/tor-network/tw-admin.json",
+  "games/tor-network/tw-energy.json",
+  "games/tor-network/tw-grid.json",
+  "games/tor-network/tw-landing.json",
+  "games/tor-network/tw-power.json",
+  // three.js 是本地 vendor 的，三件共用。core 沒有寫在 importmap 裡，
+  // 是被 webgpu 那份 import 進去的，少了它三件都起不來。
+  "games/vendor/three.webgpu.min.js",
+  "games/vendor/three.core.min.js",
+  "games/vendor/three.tsl.min.js",
+  "games/vendor/jsm/tsl/display/BloomNode.js",
+  "games/vendor/jsm/tsl/display/AfterImageNode.js",
 ];
 
 // 各語系前綴對應的核心章節清單
@@ -157,6 +230,10 @@ function precacheUrls() {
     for (const asset of SHELL_ASSETS) {
       urls.push(SCOPE_PATH + prefix + asset);
     }
+  }
+  // 作品本體只在根路徑 /docs/games/ 底下，所以擺在前綴迴圈外面
+  for (const asset of GAME_APPS) {
+    urls.push(SCOPE_PATH + asset);
   }
   return urls;
 }
@@ -194,9 +271,9 @@ self.addEventListener("activate", (event) => {
 
 function offlinePathFor(pathname) {
   const rel = pathname.slice(SCOPE_PATH.length);
-  // 這裡沒有 "zh-tw/"。zh-tw 樹跟根路徑是同一份內容，precache 只收根路徑那份，
-  // 導向 /zh-tw/offline/ 會落到一個不存在於快取的頁面，讀者就吃到瀏覽器原生
-  // 的錯誤畫面。落到最後的預設值（根路徑的 offline 頁）內容完全一樣。
+  // 這裡沒有 "zh-tw/"。run_zh-tw.sh 輸出的 /zh-tw/ 跟根路徑是同一份內容，precache
+  // 只收根路徑那份，導向 /zh-tw/offline/ 會落到一個不存在於快取的頁面，讀者就吃到
+  // 瀏覽器原生的錯誤畫面。落到最後的預設值（根路徑的 offline 頁）內容完全一樣。
   for (const prefix of ["zh-cn/", "en/"]) {
     if (rel.startsWith(prefix)) return SCOPE_PATH + prefix + "offline/";
   }

--- a/tools/check_precache.mjs
+++ b/tools/check_precache.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * 檢查 PWA 預快取清單裡的每個 URL 都對得到建置產出的檔案。
+ *
+ * === 為什麼需要這支 ===
+ *
+ * sw.js 的 install 用 Promise.allSettled 逐一快取並容忍個別失敗。那是刻意的：
+ * 本地開發只有單一語系，其他語系路徑本來就會 404，不該讓整個 install 掛掉。
+ *
+ * 代價是清單裡的錯字完全不會被發現。少快取一個檔案，線上看起來一切正常，只有離線
+ * 的人會遇到破圖或空白，而那正是最難回報、也最沒辦法自己查的情境。
+ *
+ * 遊戲那一批（GAME_APPS）尤其容易漏：地球儀新增一份資料檔時要記得補進 sw.js，
+ * 漏了的話那一層在離線時就是空的，而畫面其他部分照常運作，不會有任何錯誤訊息。
+ *
+ * === 怎麼驗 ===
+ *
+ * 把 sw.js 的清單與 precacheUrls() 原地抽出來執行，拿到跟瀏覽器一模一樣的 URL 清單，
+ * 再對照 docs/output 的實際檔案。不重寫一份路徑組合邏輯，那樣只會驗到自己抄得對不對。
+ *
+ * URL 對檔案的規則跟靜態站一樣：結尾是 / 的找 index.html，其餘直接找該檔。
+ *
+ * 用法：
+ *   cd docs && sh run.sh && sh run_zh-tw.sh && sh run_zh-cn.sh && sh run_en.sh
+ *   node tools/check_precache.mjs
+ * 找不到 docs/output 時跳過並回 0（沒建置過就不該擋人）。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SW = path.join(HERE, '..', 'docs', 'zh-TW', 'sw.js');
+const OUT = path.join(HERE, '..', 'docs', 'output');
+
+if (!fs.existsSync(OUT)) {
+  console.log('  找不到 docs/output，先建置過再跑這支。跳過。');
+  process.exit(0);
+}
+
+const src = fs.readFileSync(SW, 'utf8');
+
+/** 從 sw.js 抓出宣告或函式的原始碼，不另外抄一份 */
+const grab = (re) => {
+  const m = src.match(re);
+  if (!m) throw new Error(`sw.js 裡找不到 ${re}`);
+  return m[0];
+};
+
+// SCOPE_PATH 在 sw.js 裡是從 registration.scope 算的，這裡固定成正式站的 /docs/
+const harness = `
+  const SCOPE_PATH = "/docs/";
+  ${grab(/^const LANG_PREFIXES = \[[^\]]*\];/m)}
+  ${grab(/^const SHELL_ASSETS = \[[\s\S]*?\n\];/m)}
+  ${grab(/^const CORE_PAGES_ZH = \[[\s\S]*?\n\];/m)}
+  ${grab(/^const CORE_PAGES_EN = \[[\s\S]*?\n\];/m)}
+  ${grab(/^const GAME_APPS = \[[\s\S]*?\n\];/m)}
+  ${grab(/^const CORE_PAGES_BY_PREFIX = \{[\s\S]*?\n\};/m)}
+  ${grab(/^function precacheUrls\(\) \{[\s\S]*?\n\}/m)}
+  return { urls: precacheUrls(), games: GAME_APPS.length };
+`;
+const { urls, games } = new Function(harness)();
+
+/** URL 換成 docs/output 底下的實際檔案路徑 */
+function resolve(url) {
+  const rel = url.replace(/^\/docs\//, '');
+  const p = path.join(OUT, rel);
+  return rel === '' || rel.endsWith('/') ? path.join(p, 'index.html') : p;
+}
+
+const missing = [];
+let bytes = 0;
+for (const url of urls) {
+  const f = resolve(url);
+  if (fs.existsSync(f) && fs.statSync(f).isFile()) bytes += fs.statSync(f).size;
+  else missing.push(url);
+}
+
+const mb = (n) => (n / 1024 / 1024).toFixed(2) + ' MB';
+console.log(`  預快取 ${urls.length} 個 URL，其中作品本體 ${games} 個`);
+console.log(`  合計 ${mb(bytes)}（不含 runtime 快取）`);
+
+// 作品本體單獨報一次，那是最容易漏補的一批
+const gameBytes = urls
+  .filter((u) => u.startsWith('/docs/games/') && !u.endsWith('/games/'))
+  .reduce((a, u) => a + (fs.existsSync(resolve(u)) ? fs.statSync(resolve(u)).size : 0), 0);
+console.log(`  其中三件互動作品 ${mb(gameBytes)}`);
+
+if (missing.length) {
+  console.error(`\n✗ ${missing.length} 個 URL 在 docs/output 裡找不到對應檔案：`);
+  for (const u of missing.slice(0, 20)) console.error('  ' + u);
+  if (missing.length > 20) console.error(`  ⋯ 另有 ${missing.length - 20} 個`);
+  console.error('\nsw.js 的 install 用 allSettled 容忍失敗，所以這些會被靜默跳過，');
+  console.error('線上看起來正常，只有離線的人會遇到破圖或空白。');
+  process.exit(1);
+}
+console.log('\n預快取清單裡的每個 URL 都對得到檔案。');


### PR DESCRIPTION
站上唯一「已經做好、有人在用、卻沒被離線策略蓋到」的東西就是 `games/`。這個 PR 把三件互動作品加進 PWA 的預快取，並加一支驗證清單正確性的工具。

真實會用到的離線情境是工作坊沒有 wifi、教學現場網路很差，而那些場合正是要把畫面翻給人看的時候。網頁載得出來但地球儀空白，比整頁打不開更難解釋。

---

## 兩批東西分開處理

**索引頁**進 `CORE_PAGES_ZH` 與 `CORE_PAGES_EN`，每個語系各一份，很輕。

**作品本體**另外開 `GAME_APPS`，**只在根前綴放一份**。三個語系的 `games/index.html` 各自存在，但作品只由 `run.sh` 建置到 `docs/output/` 根目錄，對應網址 `/docs/games/`。其他語系是用 `?lang=` 連過去共用同一份程式。跟著 `LANG_PREFIXES` 複製的話，另外兩個語系會抓到 404，白繞一圈。

## 身分敏感度

照 `CORE_PAGES_ZH` 那條既有判準檢查過（讀者是不是特定受威脅身分，是的話就不預快取，那是 `scenarios/journalist`、`activist` 被排除的理由）。

這三件是教學性質的視覺化，跟已經在預快取裡的 `tools/what-is-tor/` 同一類，不指向特定身分，所以可以放。

## 成本

28 個檔案 **2.33 MB**，佔加入前 14.74 MB 的 **15.8%**。

| 項目 | 大小 |
|---|---|
| three.js vendor（三件共用） | 1.05 MB |
| 地球儀的資料檔 | 0.86 MB |
| 地球儀的程式 | 0.30 MB |
| 另外兩件 | 0.12 MB |

**`bathymetry.json` 那 426 KB 刻意不放。** 它是整批裡最大的一份，而 `atlas.js` 抓它時帶 `.catch(() => null)`，最深那階的顏色又刻意等於海面單色，所以離線時少了它畫面跟以前一模一樣，不會看起來像壞掉。用最大的檔案換一層純裝飾的質感。

再往下砍就沒這麼乾淨了：`tw-admin`（215 KB）拿掉會讓放大台灣只剩空白，`countries`（136 KB）是必要的，缺了整顆球都畫不出來。那時畫面看起來像壞掉而不像少了東西，比整個不快取更糟。

## 新增 `tools/check_precache.mjs`

`sw.js` 的 install 用 `Promise.allSettled` 逐一快取並容忍個別失敗。那是刻意的，本地開發只有單一語系，其他語系路徑本來就會 404。

代價是**清單裡的錯字完全不會被發現**。少快取一個檔案，線上看起來一切正常，只有離線的人會遇到破圖或空白，而那正是最難回報、也最沒辦法自己查的情境。地球儀日後新增一份資料檔忘了補進 `sw.js`，也是同一類問題。

驗證方式是把 `sw.js` 的清單與 `precacheUrls()` 原地抽出來執行，拿到跟瀏覽器一模一樣的 URL 清單，再對照 `docs/output` 的實際檔案。不重寫一份路徑組合邏輯，那樣只會驗到自己抄得對不對。

目前 144 個 URL 全部對得到檔案。

## 過程中修掉一個自己量錯的數字

先前用 `du -sk` 量出作品是 1.63 MB，實際是 2.75 MB（含 bathymetry）。原因是這台的檔案系統會共用 extent，`du` 只報一半。要看的是 apparent size，那才是實際傳輸量。註解裡的數字全部改成量測得到的值。

## 驗證

- 四份 mkdocs 設定照 `build_docs.yml` 的順序各建置一次（`run.sh` → `run_zh-tw.sh` → `run_zh-cn.sh` → `run_en.sh`），全部通過。順序有關係，`run.sh` 輸出到 `docs/output/` 本身而 mkdocs 會先清空目標目錄，所以它必須第一個跑
- `check_precache.mjs` 144 個 URL 全綠
- `bathymetry.json` 缺席時的行為，靠 `atlas.js:3576` 的 `.catch(() => null)` 與 `atlas.js:175` 的註解確認過（最深那階等於海面單色）

### 這裡驗不到的

**實機的離線行為。**Service worker 要在真的瀏覽器裝過、斷網再開才算數，headless 起不了 WebGPU，這個環境驗不了。合併部署之後需要在真機上確認一次：安裝 PWA、關掉網路、開三件作品。

## 未處理，留給你決定

`check_precache.mjs` 需要四份 mkdocs 設定都建置過才能跑，因為它要拿 `sw.js` 產生的 URL 清單對照 `docs/output/` 底下實際存在的檔案，而那份清單橫跨四個輸出目錄。所以沒有放進 `games-checks.yml`（那支不做建置）。自然的位置是 `build_docs.yml`，那裡本來就剛建完，成本接近零。但那條是部署路徑，加上去等於「預快取清單有錯就不給部署」。我認為那是對的，但那是產品決定，沒有自作主張。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeBtxbLmnsMBxqjXu59nAw