### PR TITLE
docs(community): OONI 技術文件系列，資料結構、封鎖判定、擷取指南與測項速查表

### DIFF
--- a/docs/en/community/asn-coverage-howto.md
+++ b/docs/en/community/asn-coverage-howto.md
@@ -1,65 +1,164 @@
 ---
 title: ASN observation data retrieval and analysis
-description: Pull OONI's public measurement data from AWS S3 with the project's retrieval scripts and work out a region's ASN coverage, covering ooni.py lookback, span, and sheetrow plus ripe.py for the full ASN list.
+description: How to set up and use the OONI data retrieval scripts in anoni-net/docs, covering the S3 public dataset's path layout, the trade-offs between the three ways in, the CSV fields the scripts output, and how coverage is calculated.
 icon: material/database-search
 ---
+
 # :material-database-search: ASN observation data retrieval and analysis
 
-This page covers the tooling for retrieving OONI's public measurement data and calculating ASN coverage for a region. For what the resulting numbers mean and why ASN diversity matters, start with [ASN observation data analysis](../regional/ooni-asn-coverage.md).
+This page is the technical companion to [ASN observation data analysis](../regional/ooni-asn-coverage.md). When you want to pull OONI's public data yourself and work out the observation coverage of a region's ASNs, what follows covers how to set up and use the retrieval scripts in [anoni-net/docs](https://github.com/anoni-net/docs){target="_blank"}.
 
+Set up your environment first with [Development environment setup](./setup-repo.md).
 
-The data from tests conducted using OONI Probe is sent back for storage in OONI's [AWS S3 Open Data](https://registry.opendata.aws/ooni/){target="_blank"}. [OONI Docs](https://docs.ooni.org/data){target="_blank"} provides a simple tutorial on data retrieval, and you can also use our completed [retrieval script](https://github.com/anoni-net/docs/blob/main/asn_coverage/ooni.py){target="_blank"}. The data field structure can be referenced from [ooni/spec](https://github.com/ooni/spec){target="_blank"}.
+!!! tip "Where to run these commands"
 
-Below is a guide on how to retrieve test observation data using the [retrieval script](https://github.com/anoni-net/docs/blob/main/asn_coverage/ooni.py){target="_blank"}.
+    Every command below runs from the `anoni-net-docs/asn_coverage/` directory. On first use, `cd` into it, run `uv sync` to install dependencies, then follow the examples below using `uv run python ooni.py ...`.
 
-!!! info "Where to run these commands"
+## Three ways in
 
-    Set up the project environment first, see [Development environment setup](./setup-repo.md). All commands below run from the `asn_coverage/` directory of a cloned [anoni-net/docs](https://github.com/anoni-net/docs){target="_blank"} checkout, after `uv sync` has installed the dependencies:
+OONI's observation data has three entry points serving quite different purposes. Pick the right one before starting:
 
-    ```bash
-    cd anoni-net-docs/asn_coverage
-    uv sync
-    ```
+| Entry point | Suits | Limitation |
+|---|---|---|
+| [AWS S3 public dataset](https://registry.opendata.aws/ooni/){target="_blank"} | Bulk analysis, full-population statistics, comparison over time | You parse it yourself, and downloads run to gigabytes |
+| [OONI API](https://api.ooni.io/api/v1/measurements){target="_blank"} | Filtering by criteria, fetching one complete measurement | A cap on results per request |
+| [OONI Explorer](https://explorer.ooni.org/){target="_blank"} | Looking things up by hand, checking individual measurements | Not suited to programmatic access |
 
-```bash title="Look Back Observation Data"
-python3 ./ooni.py lookback [--units=36] [--loc=TW] [--frame=hours]
+`asn_coverage` takes the S3 route, since its purpose is coverage statistics rather than single lookups. For single measurements or small-scale filtering, [Reading an OONI measurement](./ooni-data-format.md) covers the API.
+
+## What the scripts can answer
+
+Know the tool's boundaries before starting. `ooni.py` currently does coverage statistics only, and its retrieval scope has three limits:
+
+- **It reads the `webconnectivity` directory only.** The dozen-plus other nettests in the same hour are not included, so observations from `tor`, `telegram`, `signal` and the rest never reach the statistics. For what each nettest measures, see [OONI nettest quick reference](./ooni-nettests-map.md).
+- **It takes two fields per measurement**, `probe_asn` and `annotations.network_type`. It never reads `test_keys`, where the verdict lives, so the output can answer "which ASNs have someone measuring, and how often" but not "what did the measurements see".
+- **It takes `.jsonl.gz` only**, skipping the `.tar.gz` files in the same directory.
+
+The smallest useful extension is to also read `test_keys.blocking` while parsing each line, which takes the statistics from "measurement counts" to "anomaly distribution per ASN". Note that `blocking` is the boolean `false` when no interference was observed and a string when there was, so normalise the type before counting. For how to read those verdicts, see [How OONI decides a site is blocked](./ooni-blocking-determination.md).
+
+## How the S3 dataset is laid out
+
+The bucket is `ooni-data-eu-fra` in `eu-central-1`, and public reads need no credentials. Paths nest four levels deep by date, hour, country code and nettest:
+
+```text title="Path structure"
+raw/{YYYYMMDD}/{HH}/{country}/{nettest}/{YYYYMMDDHH}_{country}_{nettest}.n{batch}.{seq}.jsonl.gz
 ```
 
-The interval unit is hours, defaulting to 36 units (36 hours), and the region is Taiwan (TW). After execution, files are stored according to the format below:
+!!! warning "Both date and hour are UTC"
+
+    The `{YYYYMMDD}` and `{HH}` in the path, along with the `date` and `hour` fields in the CSV output further down, are all UTC. The scripts take time through `arrow.Arrow.utcnow()` throughout. When analysing "the observation distribution during a given local time window", convert for your own offset first, or the whole chart shifts.
+
+The `.n{batch}.{seq}` at the end of the filename is OONI's internal batch numbering and can be ignored when parsing.
+
+You can check what is in there before installing anything:
+
+```bash title="List every nettest for one hour in Taiwan"
+curl -s "https://ooni-data-eu-fra.s3.eu-central-1.amazonaws.com/?list-type=2&prefix=raw/20260804/00/TW/&delimiter=/" \
+  | grep -oE '<Prefix>raw/[^<]+</Prefix>'
+```
+
+The response is XML on a single line, so the `grep` above pulls out just the directory names. Taiwan usually has a dozen-plus nettest directories within a single hour, with `webconnectivity` only one of them, alongside `tor`, `telegram`, `signal`, `whatsapp`, `dnscheck`, `echcheck`, `openvpn`, `psiphon`, `ndt` and `dash`.
+
+Each nettest directory packages the same batch two ways, `.jsonl.gz` and `.tar.gz`. Unpacked, `.jsonl.gz` gives one measurement per line, which suits line-by-line parsing, and it is what the scripts read. Taking Taiwan's `webconnectivity` on 2026-08-04 as an example, a single file runs around 10 MB, which scales to a substantial figure across a full month of national data, so estimate bandwidth and runtime before a real run. The scripts stream, so raw files never land on disk and only the CSV comes out at the end.
+
+For how to read each line's fields, see [Reading an OONI measurement](./ooni-data-format.md). For what the verdict fields mean, see [How OONI decides a site is blocked](./ooni-blocking-determination.md).
+
+## Retrieval and analysis commands
+
+### Look back over recent observations
+
+```bash title="Look back over the last 36 hours"
+uv run python ooni.py lookback --units=36 --loc=TW --frame=hours
+```
+
+All three arguments are optional and the example above is the default. `--frame` sets the unit for the total lookback span and accepts `hours`, `days`, `weeks` and so on. Whatever you pass, the data is always split by hour. Output filename format:
 
 - `lookback_{loc}_{YYYYMMDD}_{units}_{frame}.csv`
 
-```bash title="Retrieve Interval Data"
-python3 ./ooni.py span --start=YYYY/MM/DD --end=YYYY/MM/DD [--loc=TW]
+The `{YYYYMMDD}` in the filename is the UTC date the script ran, not the range the data covers, so check the file contents for the actual range. The file is written to the current working directory.
+
+### Retrieve a date range
+
+```bash title="Retrieve a specified range"
+uv run python ooni.py span --start=2026/08/01 --end=2026/08/03 --loc=TW --chunk=40
 ```
 
-Give a start date (`--start`) and end date (`--end`) to retrieve hourly data for the chosen region (`--loc`, defaults to `TW`).
+Give a start time (`start`) and end time (`end`) to retrieve hourly data across that period. `--chunk` controls how many hours are processed concurrently, defaulting to `40`, and should be lowered when network or memory is tight. Output filename format:
 
-```bash title="Convert to Spreadsheet Data"
-python3 ./ooni.py sheetrow --path={data_path}
+- `span_{loc}_{startYYYYMMDD}_{endYYYYMMDD}.csv`
+
+### Convert to spreadsheet rows
+
+```bash title="Expand into spreadsheet format"
+uv run python ooni.py sheetrow --path=./span_TW_20260801_20260803.csv
 ```
 
-After extracting the data, it is expanded for ease of calculation in a spreadsheet and saved as a data file prefixed with `rows_`.
+Expands data you have already retrieved so it can be worked with in a spreadsheet. The output filename is the original prefixed with `rows_`, which for the example above is `rows_span_TW_20260801_20260803.csv`.
 
-Run `Retrieve Interval Data` first, then `Convert to Spreadsheet Data`, to get how often each ASN appears along with the deduplicated counts. Combined with the full list of ASNs registered to a country, that gives you the coverage percentages.
+## The CSV output format
 
-`ripe.py` pulls that full ASN list for a country from the RIPE database, which is the denominator for the coverage figures above.
+Files produced by `lookback` and `span` have four fields, one row per hour:
 
-```bash title="ASN Statistical Calculation"
-python3 ./ripe.py save --loc=TW
+| Field | Contents |
+|---|---|
+| `loc` | Country code, for example `TW` |
+| `date` | Date as `YYYY/MM/DD`, UTC |
+| `hour` | Hour as `HH`, UTC |
+| `statistics` | That hour's statistics, held as a JSON string |
+
+`statistics` holds two counts: `counts` tallies measurements per ASN, and `network_type` tallies by connection type. Taking real data from hour `00` in Taiwan on 2026-08-04, with 551 measurements in that hour:
+
+```json title="The statistics field expanded"
+{"counts": {"AS3462": 300, "AS17716": 100, "AS18419": 100, "AS24158": 51},
+ "network_type": {"mobile": 44, "no_internet": 7}}
 ```
 
-For a worked example of the resulting statistics, see:
+The two counts not adding up to the same total is normal. `network_type` is annotated by the Probe itself, which mobile apps generally write and CLI and desktop versions mostly do not. Only 51 of the 551 measurements above carry the annotation, and the scripts skip measurements without one. Within that, `no_internet` means the Probe judged itself to be offline at measurement time. With annotation coverage below ten percent, the field suits trends rather than serving as a mobile-versus-fixed-line ratio.
+
+Nested JSON is awkward to work with in a spreadsheet, which is what `sheetrow` flattens into one row per ASN:
+
+| `loc` | `date` | `hour` | `asn` | `count` |
+|---|---|---|---|---|
+| `TW` | `2026/08/04` | `00` | `AS3462` | `300` |
+| `TW` | `2026/08/04` | `00` | `AS17716` | `100` |
+
+A worked example of the resulting spreadsheet (2023-09 to 2023-12):
 
 [:material-google-spreadsheet: 20230901-20231204-TW](https://docs.google.com/spreadsheets/d/1lMDsqX8Oa3GKW68y8TuFeKQW2nKM7X0u4z-RopfJIaA/){ .md-button .md-button--primary target="_blank" }
 
+## Calculating ASN coverage
+
+Coverage needs two numbers: the count of distinct ASNs appearing in the observation data, and the total ASNs registered to that region. Get the first from the flattened CSV in the previous section with a pivot table, and the second from RIPE NCC via `ripe.py`:
+
+```bash title="Fetch the full ASN list for a region"
+uv run python ripe.py save --loc=TW
+```
+
+The output filename is `asns_{YYYYMMDDTHH}.csv`, with six fields: `no`, `location`, `org_id`, `registrar`, `reserved` and `name`.
+
+!!! warning "The two ASN formats differ, so normalise before matching"
+
+    The `no` field `ripe.py` outputs is a plain number (`3462`), while `probe_asn` in OONI data carries an `AS` prefix (`AS3462`). A VLOOKUP across them matches nothing, so add or strip the `AS` on one side first.
+
+With both numbers in hand:
+
+```text title="Coverage formula"
+coverage = distinct ASNs appearing in observation data ÷ total ASNs registered to the region
+```
+
+Taking the 2023-12 report cited in [ASN observation data analysis](../regional/ooni-asn-coverage.md), Taiwan had roughly 437 ASNs at the time and the observation data covered 7.32% of them as distinct ASNs. You can rerun the same formula over a recent range to see whether coverage has improved.
 
 ## :fontawesome-solid-diagram-project: Where to go from here
 
+With the data retrieved, the next step is reading the fields on each line.
+
 <div class="grid cards" markdown>
 
-- [:material-access-point-network: ASN observation data analysis](../regional/ooni-asn-coverage.md) — what the coverage numbers mean
-- [:material-list-status: OONI Website Testing List](../regional/ooni-checklist.md) — the list these measurements run against
-- [:octicons-mark-github-24: Development environment setup](./setup-repo.md) — environment setup
+- [:material-code-json: Reading an OONI measurement](./ooni-data-format.md)
+- [:material-shield-search: How OONI decides a site is blocked](./ooni-blocking-determination.md)
+- [:material-table-search: OONI nettest quick reference](./ooni-nettests-map.md)
+- [:material-access-point-network: ASN observation data analysis](../regional/ooni-asn-coverage.md)
+- [:material-list-status: OONI Website Testing List](../regional/ooni-checklist.md)
+- [:octicons-mark-github-24: Development environment setup](./setup-repo.md)
 
 </div>

--- a/docs/en/community/ooni-blocking-determination.md
+++ b/docs/en/community/ooni-blocking-determination.md
@@ -1,0 +1,159 @@
+---
+title: How OONI decides a site is blocked
+description: How the blocking field in Web Connectivity is computed, what evidence backs each of the four verdicts, and why a value in blocking is not a confirmed block. Five real measurements walk through the reading method and the usual sources of misreading.
+icon: material/shield-search
+---
+
+# :material-shield-search: How OONI decides a site is blocked
+
+[Reading an OONI measurement](./ooni-data-format.md) covers where the fields live. The next question is how their values are computed. Seeing `blocking: "dns"` is usually not enough to conclude that a site is blocked in a given country.
+
+`blocking` only records that one measurement disagreed with its control, which is several steps short of a confirmed block. Below: how the verdict is reached, what evidence backs each of the four types, and what has to be added before a single measurement supports a credible conclusion.
+
+## The basis of the verdict: a two-sided comparison
+
+A Probe measuring a site on its own cannot tell "the site is being interfered with" apart from "the site is down". `web_connectivity` handles this by measuring the same URL twice, once from the Probe's network and once via an OONI test helper on an unrestricted network, then comparing the two.
+
+A test helper is a measurement server OONI runs on an unrestricted network. Its observations are collected under `test_keys.control` and cover DNS resolution, TCP connection state and the HTTP response. Every verdict field is built on the difference between the two sides:
+
+| Where the difference appears | Verdict |
+|---|---|
+| DNS resolution disagrees | `blocking: "dns"` |
+| DNS agrees, the Probe cannot connect but the test helper can | `blocking: "tcp_ip"` |
+| TCP connects, the HTTP stage fails | `blocking: "http-failure"` |
+| HTTP responds, the content differs from what the test helper got | `blocking: "http-diff"` |
+| Both sides fine and content matches | `blocking: false`, `accessible: true` |
+
+The order runs top to bottom, and a failure at the DNS stage stops the comparison there. In the first three cases all four `*_match` fields are `null`, precisely because the comparison halted at an earlier stage.
+
+!!! tip "Read `control` before `blocking`"
+
+    `blocking` is the result of a two-sided comparison, not something the Probe observed on its own. When reading any anomalous measurement, first check what the test helper saw in `test_keys.control`, then go back to `blocking`. The `tcp_ip` example in the next section shows how skipping `control` turns a site's own problem into an apparent block.
+
+## The evidence behind each verdict
+
+The five measurements cited below are all public data from 2026-08-04, and the raw content can be looked up on [OONI Explorer](https://explorer.ooni.org/){target="_blank"}.
+
+### `dns`: resolution disagrees
+
+In a Taiwanese measurement of `https://ntc.party/`, the Probe's A and AAAA queries both returned `dns_nxdomain_error` (domain does not exist) while the test helper resolved it, so `dns_consistency` was marked `inconsistent`.
+
+```json title="test_keys.queries"
+{"query_type": "A", "failure": "dns_nxdomain_error", "answers": []}
+{"query_type": "AAAA", "failure": "dns_nxdomain_error", "answers": []}
+```
+
+DNS verdicts need care about which resolver was in play. That measurement's `resolver_asn` is `AS13335` (Cloudflare) while `probe_asn` is `AS3462` (Chunghwa Telecom). When the measurer points DNS at an overseas service, an anomaly at the DNS stage does not necessarily reflect what the local carrier is doing.
+
+### `tcp_ip`: cannot reach the target address
+
+A Taiwanese measurement of `http://www.tkec.com.tw/` came back as `tcp_ip`. DNS resolved normally to `210.64.193.1`, and the Probe timed out connecting to port `80`.
+
+Reading only the Probe side invites the conclusion that it was blocked. The control tells a different story:
+
+```json title="test_keys.control.tcp_connect"
+{"210.64.193.1:443": {"status": true,  "failure": null},
+ "210.64.193.1:80":  {"status": false, "failure": "generic_timeout_error"}}
+```
+
+The test helper timed out on port `80` from the outside as well, so the site's port `80` was unreachable from anywhere, with nothing to do with the network in Taiwan. Port `443` on the same IP worked from both sides, which further points at that one port rather than the path.
+
+### `http-failure`: connects but returns nothing
+
+A Taiwanese measurement of `https://bit.ly/` came back as `http-failure`. DNS was fine, port `443` on both target IPs connected, `control` showed the same from the test helper's side, and the difference showed up as `generic_timeout_error` during the HTTP stage.
+
+A working connection layer with a failing application layer is common with server-side rate limiting, refusal of service to particular sources, and breaks at the TLS layer. Telling those apart means reading the timing in `tls_handshakes` and `network_events`.
+
+### `http-diff`: the content differs
+
+Taiwan's public data currently contains no measurement of this shape (see "What Taiwan's data looks like" below), so the example here comes from Indonesia.
+
+Of the four types only `http-diff` puts the four `*_match` fields to work. A measurement of `http://www.sportsinteraction.com/` in Indonesia is a textbook case:
+
+| Observer | Status code | Title | Body length |
+|---|---|---|---|
+| Probe | `200` | `Trustpositif` | 7,044 |
+| test helper | `403` | `Maintenance` | 7,067 |
+
+The Probe's request was redirected to `http://lamanlabuh.aduankonten.id/`, an Indonesian government content-complaint domain, and the page title `Trustpositif` is the name of the country's content filtering system. An ISP steering users to a notice page mid-connection is the most typical cause of `http-diff`.
+
+The same measurement demonstrates that no single field can be trusted alone:
+
+```text title="The four *_match fields and body_proportion"
+title_match: false        status_code_match: false
+headers_match: true       body_length_match: true
+body_proportion: 0.9967
+```
+
+`body_length_match` is `true` and `body_proportion` is close to `1` purely because the block page happens to be about as long as the control page. Reading length alone gives the wrong answer. Read all four together, and note that `title_match` and `status_code_match` usually discriminate best.
+
+## Where misreadings come from
+
+A value in `blocking` with no actual network interference behind it is normal in this dataset. The unreachable port `80` on `tkec.com.tw` above is one case. Here is a subtler one.
+
+An Egyptian measurement of `http://www.newipnow.com/` came back as `http-diff`, with three of the four `*_match` fields not matching and `body_proportion` at just `0.02`. It looks like an injected block page. The actual content:
+
+| Observer | Status code | Title |
+|---|---|---|
+| Probe | `520` | `newipnow.com \| 520: Web server is returning an unknown error` |
+| test helper | `200` | `Buy Private Proxies: $0.88 per Dedicated Premium IP - NewIPNow` |
+
+`520` is the error page Cloudflare returns when the origin server in front of the target site misbehaves, which means the site itself was failing at the time and Egyptian network controls had nothing to do with it. Worth noting too: that measurement's `probe_asn` is `AS13335` (Cloudflare), so the measuring end was also running on Cloudflare's network, which falls under the second category below.
+
+Common sources of misreading group into a few kinds:
+
+- **The origin site's own state**: server errors, maintenance pages, CDN error pages, geographic restrictions.
+- **The measurement environment**: with a VPN or Tor running, the Probe measures the network at the exit instead.
+- **Dynamic site content**: rotating ads, personalisation and A/B tests make the two sides differ by design.
+- **A failing control**: when `control_failure` has a value, the comparison has no basis.
+
+OONI handles the same class of problem at the dataset level. For how, see [OONI is guarding its data against bad measurements](../blog/posts/2026-ooni-faulty-measurements.md), which covers the heuristics OONI uses to filter anomalous submissions.
+
+## From one measurement to a credible conclusion
+
+Getting from an observation to "this site is blocked in this place" takes more than one measurement. In practice, add a few dimensions:
+
+1. **Across time**: the same URL producing the same verdict repeatedly over days or weeks rules out a one-off outage.
+2. **Across ASNs**: several carriers measuring the same result points at behaviour common to the network layer. A result confined to one ASN is more likely that operator's own configuration.
+3. **Across resolvers**: still anomalous with a different DNS resolver rules out the resolver itself.
+4. **Check the `confirmed` field**: OONI's backend matches measurements against known block-page fingerprints and marks `confirmed` as `true` on a hit. The field appears in [measurements API](https://api.ooni.io/api/v1/measurements){target="_blank"} responses as backend analysis, and is not part of the raw data the Probe produces.
+
+To run comparisons across time or across ASNs yourself, [ASN observation data retrieval and analysis](./asn-coverage-howto.md) covers bulk retrieval.
+
+!!! warning "`confirmed` being `true` does not mean `http-diff`"
+
+    The two are easily conflated. `confirmed` is based on block fingerprint matching, and DNS steered to a known blocking IP is also marked `confirmed` while the verdict type stays `dns`. At the time of writing, a spot check of 5 `confirmed` measurements each from Iran, Russia, Turkey and China put every sample at `blocking: "dns"`. The sample is small, so it shows only that the two are not the same thing, and supports no general rule.
+
+## What Taiwan's data looks like
+
+A sampled look at Taiwan's `web_connectivity` data at the time of writing recorded two things:
+
+- **Of 100 anomalous measurements checked, 0 had `confirmed` set to `true`**, consistent with what [ASN observation data analysis](../regional/ooni-asn-coverage.md) has described all along.
+- **Of 40 anomalous measurements checked for verdict distribution, 31 were `dns`, 6 `tcp_ip`, 3 `http-failure` and 0 `http-diff`.** Taiwan's public observation data currently shows no redirection to a block notice page, which is why the `http-diff` examples above have to come from Indonesia and Egypt.
+
+Both samples came from the measurements API's anomaly listing. The query is below, and you can rerun it to check whether the conclusions still hold:
+
+```bash title="List anomalous measurements from Taiwan"
+curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&anomaly=true&limit=100" \
+  | python3 -m json.tool | head -40
+```
+
+The verdict distribution needs `raw_measurement` fetched per measurement and `test_keys.blocking` tallied, which is how the 40 above were obtained.
+
+These are point-in-time samples with small sample sizes, useful for understanding the shape of the data and not enough to conclude anything about longer trends. Representative statistics need a longer span and more ASNs, and Taiwan's observations carry their own limitation in how concentrated they are across ASNs. For detail, see [ASN observation data analysis](../regional/ooni-asn-coverage.md).
+
+## Where to go from here
+
+To run your own comparisons across time and across ASNs, start with the retrieval guide.
+
+<div class="grid cards" markdown>
+
+- [:material-database-search: ASN observation data retrieval and analysis](./asn-coverage-howto.md)
+- [:material-code-json: Reading an OONI measurement](./ooni-data-format.md)
+- [:material-table-search: OONI nettest quick reference](./ooni-nettests-map.md)
+- [:material-access-point-network: ASN observation data analysis](../regional/ooni-asn-coverage.md)
+- [:material-list-status: OONI Website Testing List](../regional/ooni-checklist.md)
+
+</div>
+
+The full verdict algorithm is defined upstream in [ts-017-web-connectivity](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}, and the unified naming for failure strings is in [df-007-errors](https://github.com/ooni/spec/blob/master/data-formats/df-007-errors.md){target="_blank"}.

--- a/docs/en/community/ooni-data-format.md
+++ b/docs/en/community/ooni-data-format.md
@@ -1,0 +1,177 @@
+---
+title: Reading an OONI measurement
+description: What fields make up a single OONI measurement, and how to read "who measured from where" and "what did they find" out of it. Two real Taiwanese measurements compared side by side, each field mapped to its upstream ooni/spec document.
+icon: material/code-json
+---
+
+# :material-code-json: Reading an OONI measurement
+
+[ASN observation data retrieval and analysis](./asn-coverage-howto.md) covers how to pull OONI's public data. Once you have it, the next problem shows up: a single measurement carries more than twenty top-level fields, with another twenty-odd inside `test_keys`. Which ones matter?
+
+Below, two real measurements from Taiwan are compared side by side to explain how a Web Connectivity (`web_connectivity`) measurement is put together, and which upstream [ooni/spec](https://github.com/ooni/spec){target="_blank"} document defines each field. Once the layout is clear you can judge for yourself what a measurement says, and decide which fields your analysis code needs to read.
+
+!!! info "Where these examples come from"
+
+    Both are public measurements produced by OONI Probe in Taiwan on 2026-08-04. You can look up the raw content on [OONI Explorer](https://explorer.ooni.org/){target="_blank"}.
+
+    | | Passed | Flagged as anomalous |
+    |---|---|---|
+    | Target | `http://presidentlee.tw/` | `https://ntc.party/` |
+    | `measurement_uid` | `20260804085935.603513_TW_webconnectivity_4a5fd27dec0b32f6` | `20260804084548.416537_TW_webconnectivity_f4e7b0ab3d0251bf` |
+
+## Three layers in one measurement
+
+There is no need to memorise every field up front. A measurement reads as three layers:
+
+1. **The envelope**: who measured, from where, with which software, and when. Every nettest shares this same set of fields, defined in [df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"}.
+2. **The verdict**: the conclusion the measurement reached. These fields vary by nettest and all live under `test_keys`. For `web_connectivity` they are defined in [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}.
+3. **The evidence**: the raw record behind the conclusion, covering every DNS query, TCP connection, TLS handshake and HTTP request, plus the control's equivalent records. Also under `test_keys`, each with its own `df-` specification.
+
+The verdict layer tells you the conclusion. The evidence layer lets you check it. Read them separately and each field's role becomes clear.
+
+## Pull one for yourself
+
+Following along with a sample in hand is much faster. You do not need a local environment first, since the public API returns a single measurement directly. Start by listing measurements that match your criteria:
+
+```bash title="List recent Web Connectivity measurements from Taiwan"
+curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&limit=5" \
+  | python3 -m json.tool | head -40
+```
+
+The `measurement_uid` in the response gets you the full content:
+
+```bash title="Fetch one complete measurement"
+curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement_uid>" \
+  | python3 -m json.tool | head -60
+```
+
+The raw response is one long unbroken string, which is painful to read in a terminal, so both commands above pipe it through `python3 -m json.tool`. Adding `anomaly=true` returns only measurements flagged as anomalous, which is handy for finding contrasting examples. Swap `probe_cc` for your own region and `probe_asn` for your own network to see what has been observed locally.
+
+For bulk processing, the AWS S3 public dataset is far more efficient. See [ASN observation data retrieval and analysis](./asn-coverage-howto.md).
+
+## The envelope: who measured from where
+
+Envelope fields are identical across every nettest. These are the ones you reach for most often:
+
+| Field | Passed | Flagged as anomalous | Meaning |
+|---|---|---|---|
+| `probe_cc` | `TW` | `TW` | Country code where the measurement happened |
+| `probe_asn` | `AS3462` | `AS3462` | ASN of the network running the measurement |
+| `probe_network_name` | `Chunghwa Telecom Co., Ltd.` | `Chunghwa Telecom Co., Ltd.` | Organisation name for that ASN |
+| `resolver_asn` | `AS3462` | `AS13335` | ASN of the DNS resolver actually used |
+| `resolver_network_name` | `Chunghwa Telecom Co., Ltd.` | `Cloudflare Inc` | Organisation name for the resolver |
+| `input` | `http://presidentlee.tw/` | `https://ntc.party/` | URL being measured |
+| `test_name` | `web_connectivity` | `web_connectivity` | Nettest name |
+| `software_name` | `ooniprobe-cli` | `ooniprobe-desktop-unattended` | Which kind of Probe produced the data |
+| `software_version` | `3.29.1` | `3.26.0` | Probe version |
+| `measurement_start_time` | `2026-08-04 08:59:30` | `2026-08-04 08:45:45` | Start time in UTC |
+| `report_id` | `20260804T062033Z_webconnectivity_TW_3462_n4_uEH5rGoD07cN2oYQ` | `20260804T084446Z_webconnectivity_TW_3462_n4_dFfWCDrwouM0TsT2` | Shared by every measurement from the same run |
+
+`probe_asn` and `resolver_asn` can differ, as the table shows. Both measurements ran on Chunghwa Telecom's network, but one of the users had pointed DNS at Cloudflare. Keep the two apart in ASN analysis, because conflating them distorts any claim about what is visible on a given carrier's network.
+
+!!! note "`probe_ip` is always `127.0.0.1`"
+
+    OONI deliberately does not collect the measurer's real IP, so `probe_ip` is hardcoded to the loopback address. Tracing a measurement back to its source relies on `probe_asn` plus timing. The same privacy boundary is why [OONI Run v2 for regional measurement](../tools/ooni-run-v2.md) asks people to think about what they are asking helpers to run.
+
+## The verdict: what the measurement concluded
+
+Verdict fields all live under `test_keys`. One thing to know before reading them: `web_connectivity` reaches its verdict by comparison. After the Probe finishes, an OONI test helper on an unrestricted network measures the same URL again, and the difference between the two sides is what the verdict is built from. The test helper's side is recorded under `test_keys.control`, which is what "the control" refers to below.
+
+Eight fields carry the verdict and the content comparison. Side by side, the difference is obvious:
+
+| Field | Passed | Flagged as anomalous | Meaning |
+|---|---|---|---|
+| `blocking` | `false` | `"dns"` | Type of interference found. Possible values are `dns`, `tcp_ip`, `http-failure` and `http-diff`, or the boolean `false` when nothing was observed |
+| `accessible` | `true` | `false` | Whether a sensible response was obtained |
+| `dns_consistency` | `"consistent"` | `"inconsistent"` | Whether the Probe's DNS result agrees with the control |
+| `title_match` | `true` | `null` | Whether the page title matches the control |
+| `headers_match` | `true` | `null` | Whether response headers match |
+| `status_code_match` | `true` | `null` | Whether the HTTP status code matches |
+| `body_length_match` | `true` | `null` | Whether body lengths are close |
+| `body_proportion` | `1` | `0` | Body length as a ratio against the control |
+
+Three more fields record where things failed, and belong in the same reading:
+
+| Field | What it records |
+|---|---|
+| `dns_experiment_failure` | Failure during the DNS stage. `"dns_nxdomain_error"` in the anomalous measurement |
+| `http_experiment_failure` | Failure during the HTTP stage, for example `"generic_timeout_error"` |
+| `control_failure` | Whether the control itself failed. When this has a value, the comparison has no basis and the verdict cannot be trusted |
+
+The four values of `blocking` map to failures at different stages. `dns` means the resolution disagreed with the control, `tcp_ip` means packets never reached the target address, `http-failure` means the connection was established but the HTTP stage failed, and `http-diff` means the content retrieved differs from the control, which commonly indicates a block page. OONI's own [glossary](https://ooni.org/support/glossary/){target="_blank"} introduces these interference techniques at a conceptual level.
+
+!!! tip "Two type traps worth knowing about"
+
+    `blocking` is the boolean `false` when no interference was observed, and a string when there was. Normalise it before running statistics, or `false` and `"dns"` end up counted as two unrelated categories.
+
+    The four values are not named consistently: `tcp_ip` uses an underscore while `http-failure` and `http-diff` use hyphens. That is how upstream defines them, so copy them verbatim rather than tidying them up.
+
+All four `*_match` fields are `null` in the anomalous measurement, because the DNS stage already failed, no connection was made, and there was nothing left to compare. When you see a row of `null`, go back and find the first failure field with a value in the measurement flow. That is where the problem happened.
+
+!!! warning "Anomalous does not mean blocked"
+
+    A value in `blocking` only means this measurement disagreed with the control. Establishing that network interference actually occurred takes more evidence. In the anomalous measurement above, the Probe's A and AAAA queries for `ntc.party` both returned `dns_nxdomain_error` (domain does not exist), yet at the time of writing the domain resolved to an IPv6 address through several public resolvers. A single measurement cannot separate network interference from a resolver's momentary state or a change in the domain's own configuration.
+
+    Concluding that something is blocked needs measurements cross-referenced over time, across ASNs and across resolvers. For the full breakdown of the verdict mechanism and where misreadings come from, see [How OONI decides a site is blocked](./ooni-blocking-determination.md). For quality control at the dataset level, see [OONI is guarding its data against bad measurements](../blog/posts/2026-ooni-faulty-measurements.md).
+
+## The evidence: the raw record behind the verdict
+
+Several more fields under `test_keys` record every network operation the measurement performed. Each has its own specification:
+
+| Field | Contents | Specification |
+|---|---|---|
+| `queries` | Question, answer and failure for every DNS query | [df-002-dnst](https://github.com/ooni/spec/blob/master/data-formats/df-002-dnst.md){target="_blank"} |
+| `tcp_connect` | Target and outcome of every TCP connection attempt | [df-005-tcpconnect](https://github.com/ooni/spec/blob/master/data-formats/df-005-tcpconnect.md){target="_blank"} |
+| `tls_handshakes` | Parameters, certificates and outcome of every TLS handshake | [df-006-tlshandshake](https://github.com/ooni/spec/blob/master/data-formats/df-006-tlshandshake.md){target="_blank"} |
+| `requests` | Full content of every HTTP request and response | [df-001-httpt](https://github.com/ooni/spec/blob/master/data-formats/df-001-httpt.md){target="_blank"} |
+| `network_events` | Timed events across the connection, for analysing latency and where things broke | [df-008-netevents](https://github.com/ooni/spec/blob/master/data-formats/df-008-netevents.md){target="_blank"} |
+| `control` | The control's equivalent records, structured to mirror the Probe side. Every verdict field is derived from the difference between the two | [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} |
+| `failure` strings throughout | Unified naming for every failure reason, such as `dns_nxdomain_error`, `generic_timeout_error` and `ssl_unknown_authority` | [df-007-errors](https://github.com/ooni/spec/blob/master/data-formats/df-007-errors.md){target="_blank"} |
+
+Laying the two measurements' `queries` side by side shows exactly what the verdict rests on:
+
+```json title="Passed: address resolved"
+{
+  "hostname": "presidentlee.tw",
+  "query_type": "A",
+  "failure": null,
+  "answers": [{"answer_type": "A", "ipv4": "43.254.17.201"}]
+}
+```
+
+```json title="Anomalous: query came back empty"
+{
+  "hostname": "ntc.party",
+  "query_type": "A",
+  "failure": "dns_nxdomain_error",
+  "answers": []
+}
+```
+
+`dns_consistency` in the verdict layer is the conclusion. `queries` and `control` are what it is based on. To check whether a verdict is reasonable, go down to the evidence layer.
+
+## Versions and compatibility
+
+Checking versions before reading the spec saves a good deal of confusion:
+
+- **`data_format_version` is currently `0.2.0`.** Envelope field definitions are stable, so [df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"} can be read directly against real data.
+- **The `test_version` actually in circulation for `web_connectivity` is `0.4.3`.** [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} has been updated to describe the v0.5 algorithm, while production still runs mostly on v0.4. The spec requires a new algorithm to use different test_keys fields, so the v0.4 definitions stay compatible and the field readings above apply to both versions.
+- **Fields starting with `x_` are not in the spec.** Real data contains `x_dns_runtime`, `x_status`, `x_th_runtime` and others. They are experimental implementation extensions that come and go between versions, so analysis code should not depend on them.
+
+The spec's master branch has had no new merges since 2025-06, though issues and pull requests are still under discussion, including proposals for an ICMP data format and a DPI fragmentation nettest. The spec works well as a stable reference for now. Link back to the upstream text when citing it, rather than copying specification content that will drift once upstream moves.
+
+## Where to go from here
+
+With the fields understood, the next question is how the verdict fields are computed, and why a value does not mean a block.
+
+<div class="grid cards" markdown>
+
+- [:material-shield-search: How OONI decides a site is blocked](./ooni-blocking-determination.md)
+- [:material-table-search: OONI nettest quick reference](./ooni-nettests-map.md)
+- [:material-database-search: ASN observation data retrieval and analysis](./asn-coverage-howto.md)
+- [:material-access-point-network: ASN observation data analysis](../regional/ooni-asn-coverage.md)
+- [:material-list-status: OONI Website Testing List](../regional/ooni-checklist.md)
+
+</div>
+
+The full upstream index is at [ooni/spec](https://github.com/ooni/spec){target="_blank"}, where [data-formats](https://github.com/ooni/spec/tree/master/data-formats){target="_blank"} holds the data formats and [nettests](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} holds each nettest's algorithm definition.

--- a/docs/en/community/ooni-nettests-map.md
+++ b/docs/en/community/ooni-nettests-map.md
@@ -1,0 +1,142 @@
+---
+title: OONI nettest quick reference
+description: What each of the 41 nettests in ooni/spec measures, which ones still produce data, and which appear in Taiwan's dataset. Upstream spec links throughout, for picking a nettest or reading data you already have.
+icon: material/table-search
+---
+
+# :material-table-search: OONI nettest quick reference
+
+The `nettests` directory in [ooni/spec](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} holds 41 nettest specifications, a fair share of which are no longer in use. When picking a nettest or making sense of data you already have, knowing which ones still produce measurements is more efficient than reading every specification.
+
+This page condenses all 41 into one reference table, noting each one's upstream status, whether public data still exists, and which ones show up in Taiwan.
+
+!!! info "How to read the status columns"
+
+    **Spec status** comes from the `_status_` marker at the top of each specification, one of `current`, `experimental` or `obsolete`, reflecting how upstream positions that nettest.
+
+    **Data in circulation** is measured, snapshotted on the day of writing (2026-08-04) by surveying each nettest's most recent public measurements through the [OONI API](https://api.ooni.io/api/v1/measurements){target="_blank"}.
+
+    **Taiwan** comes from the S3 public dataset, spot-checking the nettest directories that appeared under Taiwan across five time slots on 2026-08-03.
+
+## First, one thing: a status marker is not a data supply
+
+Specification markers and actual data do disagree. Before the tables below, note the gap runs in both directions:
+
+- **Marked `current` with no data to be found**: `tlsmiddlebox`, `portfiltering` and `captiveportal`.
+- **Marked `experimental` with data every day**: `dnscheck`, `echcheck`, `openvpn`, `stunreachability` and `vanilla_tor` among others, at volumes comparable to some `current` nettests.
+
+`experimental` reflects the maturity of the specification itself and implies nothing about data volume. To judge whether a nettest suits your analysis, querying the API for data beats reading the status marker.
+
+## Grouped by purpose
+
+Arriving with a question about what to observe, pick a direction here first and then check the tables for detail:
+
+- **Website blocking detection**: `web_connectivity`
+- **Middleboxes and interference techniques**: `http_header_field_manipulation`, `http_invalid_request_line`, `sni_blocking`, `echcheck`
+- **Messaging app reachability**: `telegram`, `whatsapp`, `signal`, `facebook_messenger`
+- **Circumvention tool availability**: `tor`, `vanilla_tor`, `torsf`, `psiphon`, `riseupvpn`, `openvpn`
+- **DNS behaviour**: `dnscheck`, `dnsping`
+- **Connection performance**: `ndt`, `dash`, `stunreachability`, `quicping`
+
+## Nettests still producing data
+
+Every nettest below had public measurements available on the day of writing. These are the ones you meet most often when reading OONI data.
+
+| Nettest | What it measures | Spec status | Taiwan |
+|---|---|---|---|
+| [`web_connectivity`](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} | Website reachability and block verdicts, by far the largest nettest by volume | current | yes |
+| [`tor`](https://github.com/ooni/spec/blob/master/nettests/ts-023-tor.md){target="_blank"} | Reachability of Tor directory authorities and bridges | current | yes |
+| [`vanilla_tor`](https://github.com/ooni/spec/blob/master/nettests/ts-016-vanilla-tor.md){target="_blank"} | Whether unobfuscated Tor can bootstrap a connection | experimental | yes |
+| [`torsf`](https://github.com/ooni/spec/blob/master/nettests/ts-030-torsf.md){target="_blank"} | Tor over the Snowflake pluggable transport | experimental | no |
+| [`telegram`](https://github.com/ooni/spec/blob/master/nettests/ts-020-telegram.md){target="_blank"} | Reachability of Telegram web and its data centre endpoints | current | yes |
+| [`whatsapp`](https://github.com/ooni/spec/blob/master/nettests/ts-018-whatsapp.md){target="_blank"} | Reachability of WhatsApp endpoints and its registration service | current | yes |
+| [`signal`](https://github.com/ooni/spec/blob/master/nettests/ts-029-signal.md){target="_blank"} | Reachability of Signal service endpoints | current | yes |
+| [`facebook_messenger`](https://github.com/ooni/spec/blob/master/nettests/ts-019-facebook-messenger.md){target="_blank"} | Reachability of Facebook Messenger endpoints | current | yes |
+| [`dnscheck`](https://github.com/ooni/spec/blob/master/nettests/ts-028-dnscheck.md){target="_blank"} | Behaviour of a given DNS resolver, covering encrypted queries (DoH, DoT) | experimental | yes |
+| [`dnsping`](https://github.com/ooni/spec/blob/master/nettests/ts-035-dnsping.md){target="_blank"} | Latency and response behaviour of DNS queries | experimental | no |
+| [`echcheck`](https://github.com/ooni/spec/blob/master/nettests/ts-039-echcheck.md){target="_blank"} | Support for and interference with Encrypted Client Hello (ECH) | experimental | yes |
+| [`http_header_field_manipulation`](https://github.com/ooni/spec/blob/master/nettests/ts-006-header-field-manipulation.md){target="_blank"} | Whether middleboxes tamper with HTTP headers | current | yes |
+| [`http_invalid_request_line`](https://github.com/ooni/spec/blob/master/nettests/ts-007-http-invalid-request-line.md){target="_blank"} | How middleboxes react to malformed request lines, used to detect transparent proxies | current | yes |
+| [`openvpn`](https://github.com/ooni/spec/blob/master/nettests/ts-040-openvpn.md){target="_blank"} | Whether an OpenVPN handshake completes | experimental | yes |
+| [`psiphon`](https://github.com/ooni/spec/blob/master/nettests/ts-015-psiphon.md){target="_blank"} | Whether the Psiphon circumvention tool can establish a connection | current | yes |
+| [`riseupvpn`](https://github.com/ooni/spec/blob/master/nettests/ts-026-riseupvpn.md){target="_blank"} | Reachability of the RiseupVPN service | current | yes |
+| [`stunreachability`](https://github.com/ooni/spec/blob/master/nettests/ts-025-stun-reachability.md){target="_blank"} | Reachability of STUN servers, which affects WebRTC calls | experimental | yes |
+| [`ndt`](https://github.com/ooni/spec/blob/master/nettests/ts-022-ndt.md){target="_blank"} | Connection speed and performance diagnostics | current | yes |
+| [`dash`](https://github.com/ooni/spec/blob/master/nettests/ts-021-dash.md){target="_blank"} | Video streaming playback quality | current | yes |
+| [`browser_web`](https://github.com/ooni/spec/blob/master/nettests/ts-036-browser_web.md){target="_blank"} | Loading pages with a real browser engine | experimental | no |
+
+!!! note "Abbreviations in the table"
+
+    - **DoH, DoT**: DNS queries wrapped in HTTPS or TLS, so query contents do not cross the network in plaintext. See [Encrypted DNS](../tools/encrypted-dns.md).
+    - **ECH (Encrypted Client Hello)**: the first message of a TLS handshake normally carries the destination domain in plaintext, and ECH encrypts that field.
+    - **SNI (Server Name Indication)**: the destination domain sent in plaintext during a TLS handshake, frequently used as the basis for blocking decisions.
+    - **STUN**: a protocol that helps a device discover its own public IP and port, used when WebRTC calls set up a connection.
+    - **QUIC**: a UDP-based transport protocol that HTTP/3 is built on.
+
+## Nettests with only occasional data
+
+| Nettest | What it measures | Spec status | Most recent |
+|---|---|---|---|
+| [`quicping`](https://github.com/ooni/spec/blob/master/nettests/ts-031-quicping.md){target="_blank"} | Reachability of the QUIC protocol | experimental | 2026-07-30 |
+| [`sni_blocking`](https://github.com/ooni/spec/blob/master/nettests/ts-024-sni-blocking.md){target="_blank"} | Blocking targeted at the TLS SNI field | experimental | 2026-07-20 |
+
+## Nettests with no public data
+
+The seven nettests below return no public measurements from the API. Their specifications remain in the upstream repository and are worth reading when designing a new nettest or a research method.
+
+| Nettest | What it measures | Spec status |
+|---|---|---|
+| [`tlsmiddlebox`](https://github.com/ooni/spec/blob/master/nettests/ts-037-tlsmiddlebox.md){target="_blank"} | Middlebox behaviour along a TLS connection path | current |
+| [`portfiltering`](https://github.com/ooni/spec/blob/master/nettests/ts-038-port-filtering.md){target="_blank"} | Whether specific ports are filtered | current |
+| [`captiveportal`](https://github.com/ooni/spec/blob/master/nettests/ts-010-captive-portal.md){target="_blank"} | Whether the network requires a login to get out | current |
+| [`urlgetter`](https://github.com/ooni/spec/blob/master/nettests/ts-027-urlgetter.md){target="_blank"} | A general-purpose fetching component reused by other nettests | experimental |
+| [`tcpping`](https://github.com/ooni/spec/blob/master/nettests/ts-032-tcpping.md){target="_blank"} | Round-trip latency at the TCP layer | experimental |
+| [`tlsping`](https://github.com/ooni/spec/blob/master/nettests/ts-033-tlsping.md){target="_blank"} | Round-trip latency of a TLS handshake | experimental |
+| [`simplequicping`](https://github.com/ooni/spec/blob/master/nettests/ts-034-simplequicping.md){target="_blank"} | A simplified QUIC latency measurement | experimental |
+
+## Historical nettests marked obsolete
+
+Twelve specifications are marked `obsolete` upstream. Most of their functionality was absorbed into `web_connectivity`, or they retired as measurement methods evolved. Their records still turn up when working with historical data, and there is no reason to adopt them for new observation work.
+
+| Nettest | Specification |
+|---|---|
+| bridgeT | [ts-001](https://github.com/ooni/spec/blob/master/nettests/ts-001-bridget.md){target="_blank"} |
+| DNS Consistency | [ts-002](https://github.com/ooni/spec/blob/master/nettests/ts-002-dns-consistency.md){target="_blank"} |
+| HTTP Requests | [ts-003](https://github.com/ooni/spec/blob/master/nettests/ts-003-http-requests.md){target="_blank"} |
+| HTTP Host | [ts-004](https://github.com/ooni/spec/blob/master/nettests/ts-004-http-host.md){target="_blank"} |
+| DNS Spoof | [ts-005](https://github.com/ooni/spec/blob/master/nettests/ts-005-dns-spoof.md){target="_blank"} |
+| TCP Connect | [ts-008](https://github.com/ooni/spec/blob/master/nettests/ts-008-tcp-connect.md){target="_blank"} |
+| Multi Protocol Traceroute | [ts-009](https://github.com/ooni/spec/blob/master/nettests/ts-009-multi-protocol-traceroute.md){target="_blank"} |
+| Bridge Reachability | [ts-011](https://github.com/ooni/spec/blob/master/nettests/ts-011-bridge-reachability.md){target="_blank"} |
+| DNS Injection | [ts-012](https://github.com/ooni/spec/blob/master/nettests/ts-012-dns-injection.md){target="_blank"} |
+| Lantern | [ts-013](https://github.com/ooni/spec/blob/master/nettests/ts-013-lantern.md){target="_blank"} |
+| Meek Fronted Requests | [ts-014](https://github.com/ooni/spec/blob/master/nettests/ts-014-meek-fronted-requests.md){target="_blank"} |
+| OpenVPN Client Test (legacy) | [ts-016](https://github.com/ooni/spec/blob/master/nettests/ts-016-openvpn.md){target="_blank"} |
+
+!!! note "Two OpenVPN specifications share a number"
+
+    Upstream has two specifications numbered `ts-016`: `ts-016-openvpn.md`, marked `obsolete` in the table above, and `ts-016-vanilla-tor.md`, marked `experimental`. The current OpenVPN specification is `ts-040-openvpn.md`, so take care not to cite the old one.
+
+## Which nettests show up in Taiwan
+
+Spot-checking five time slots on 2026-08-03, 17 nettests appeared under Taiwan (written here in the API's underscore form): `web_connectivity`, `tor`, `vanilla_tor`, `telegram`, `whatsapp`, `signal`, `facebook_messenger`, `dnscheck`, `echcheck`, `http_header_field_manipulation`, `http_invalid_request_line`, `openvpn`, `psiphon`, `riseupvpn`, `stunreachability`, `ndt`, `dash`.
+
+Directory names on S3 differ from `test_name`. Directory names carry no underscores (`webconnectivity`, `vanillator`, `facebookmessenger`) while API queries need the underscore form (`web_connectivity`, `vanilla_tor`, `facebook_messenger`). For the retrieval path in detail, see [ASN observation data retrieval and analysis](./asn-coverage-howto.md).
+
+Taiwan's observations concentrate on `web_connectivity`, with small sample sizes for everything else. For widening local coverage, `tor` and `dnscheck` sit closest to the community's existing themes.
+
+There are two ways to run a specific nettest. With [OONI Probe](https://ooni.org/install/){target="_blank"} on desktop or mobile, choose which nettests to enable in the settings. To invite others to measure a fixed list of URLs, use [OONI Run v2](../tools/ooni-run-v2.md) to create a shareable link. The link ID the community currently maintains is `10328`.
+
+## Where to go from here
+
+<div class="grid cards" markdown>
+
+- [:material-code-json: Reading an OONI measurement](./ooni-data-format.md)
+- [:material-shield-search: How OONI decides a site is blocked](./ooni-blocking-determination.md)
+- [:material-database-search: ASN observation data retrieval and analysis](./asn-coverage-howto.md)
+- [:material-help-network: OONI Run v2 for regional measurement](../tools/ooni-run-v2.md)
+- [:material-list-status: OONI Website Testing List](../regional/ooni-checklist.md)
+
+</div>
+
+Each nettest's full algorithm is defined in the upstream [nettests](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} directory. The fields their output shares are defined in [data-formats](https://github.com/ooni/spec/tree/master/data-formats){target="_blank"}.

--- a/docs/en/regional/ooni-asn-coverage.md
+++ b/docs/en/regional/ooni-asn-coverage.md
@@ -106,6 +106,9 @@ If you want to retrieve and analyse OONI's public data to calculate ASN coverage
 <div class="grid cards" markdown>
 
 - [:material-list-status: OONI Website Testing List](./ooni-checklist.md) — the list these measurements are collected against, and how to help maintain it
+- [:material-code-json: Reading an OONI measurement](../community/ooni-data-format.md) — what the fields in a single measurement mean
+- [:material-shield-search: How OONI decides a site is blocked](../community/ooni-blocking-determination.md) — how the verdict is computed, and why a value is not a confirmed block
+- [:material-table-search: OONI nettest quick reference](../community/ooni-nettests-map.md) — what each nettest measures and which still produce data
 - [:material-radar: Regional Observatory](./index.md) — the rest of what we measure and publish
 - [:octicons-mark-github-24: Development environment setup](../community/setup-repo.md) — set up the environment to run the analysis yourself
 

--- a/docs/en/regional/ooni-checklist.md
+++ b/docs/en/regional/ooni-checklist.md
@@ -62,7 +62,9 @@ List maintenance is a good entry point for new contributors. It needs no program
 Where to start:
 
 - **To help with list maintenance:** say so in the anoni-net public space on Matrix, see [Community](../community/index.md) for how to join. Someone will help you pick a slice to work on.
-- **To help with the data analysis side:** see [ASN observation data analysis](./ooni-asn-coverage.md)
+- **To help with the data analysis side:** see [ASN observation data analysis](./ooni-asn-coverage.md) and [ASN observation data retrieval and analysis](../community/asn-coverage-howto.md)
+- **To read the measurement data itself:** see [Reading an OONI measurement](../community/ooni-data-format.md) and [How OONI decides a site is blocked](../community/ooni-blocking-determination.md)
+- **To see what gets measured beyond this list:** see [OONI nettest quick reference](../community/ooni-nettests-map.md)
 - **To understand how the community works:** see [How to contribute](../community/how-to-contribute.md)
 
 ## :fontawesome-solid-diagram-project: Where to go from here

--- a/docs/en/tools/ooni-run-v2.md
+++ b/docs/en/tools/ooni-run-v2.md
@@ -51,6 +51,8 @@ miniooni's `-i` treats the URL you give it as a descriptor-JSON endpoint and GET
 <div class="grid cards" markdown>
 
 - [:material-access-point-network: Regional observatory](../regional/index.md)
+- [:material-table-search: OONI nettest quick reference](../community/ooni-nettests-map.md)
+- [:material-code-json: Reading an OONI measurement](../community/ooni-data-format.md)
 - [:material-snowflake: Tor Snowflake](./tor-snowflake.md)
 - [:material-web: OONI](https://ooni.org/){target="_blank"}
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
           - community/asn-coverage-howto.md
           - community/ooni-data-format.md
           - community/ooni-blocking-determination.md
+          - community/ooni-nettests-map.md
           - community/upload-sensitive.md
           - community/pin-ipfs-mirror.md
           - community/brand-assets.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
           - community/campus-relay-faq.md
           - community/onionoo-mcp.md
           - community/asn-coverage-howto.md
+          - community/ooni-data-format.md
           - community/upload-sensitive.md
           - community/pin-ipfs-mirror.md
           - community/brand-assets.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
           - community/onionoo-mcp.md
           - community/asn-coverage-howto.md
           - community/ooni-data-format.md
+          - community/ooni-blocking-determination.md
           - community/upload-sensitive.md
           - community/pin-ipfs-mirror.md
           - community/brand-assets.md

--- a/docs/mkdocs_cn.yml
+++ b/docs/mkdocs_cn.yml
@@ -97,6 +97,9 @@ nav:
           - community/setup-tor-webtunnel.md
           - community/onionoo-mcp.md
           - community/asn-coverage-howto.md
+          - community/ooni-data-format.md
+          - community/ooni-blocking-determination.md
+          - community/ooni-nettests-map.md
           - community/upload-sensitive.md
           - community/pin-ipfs-mirror.md
           - community/brand-assets.md

--- a/docs/mkdocs_en.yml
+++ b/docs/mkdocs_en.yml
@@ -72,6 +72,9 @@ nav:
       - community/i18n.md
       - community/setup-repo.md
       - community/asn-coverage-howto.md
+      - community/ooni-data-format.md
+      - community/ooni-blocking-determination.md
+      - community/ooni-nettests-map.md
       - community/setup-tor-relay.md
       - community/setup-tor-webtunnel.md
       - community/onionoo-mcp.md

--- a/docs/zh-CN/community/asn-coverage-howto.md
+++ b/docs/zh-CN/community/asn-coverage-howto.md
@@ -1,76 +1,162 @@
 ---
 title: ASN 观测资料撷取与分析
-description: anoni-net/docs 提供的 OONI 资料撷取程序如何设置与使用，是 ASN 观测分析的延伸操作指南。
+description: anoni-net/docs 提供的 OONI 资料撷取程序如何设置与使用，包含 S3 公开资料集的路径结构、三种取用路径的取舍、程序输出的 CSV 栏位格式，以及覆盖率的计算方式。
 icon: material/database-search
 ---
 
 # :material-database-search: ASN 观测资料撷取与分析
 
-这页是 [在地脉络 → ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md) 的技术延伸：当你想自己实际操作抓 OONI 公开资料、计算特定区域 ASN 的观测覆盖率时，这篇介绍 [anoni-net/docs](https://github.com/anoni-net/docs){target="_blank"} 提供的撷取程序如何设置与使用。
+本页是 [ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md) 的技术延伸：当你想自己撷取 OONI 公开资料、计算特定区域 ASN 的观测覆盖率时，以下介绍 [anoni-net/docs](https://github.com/anoni-net/docs){target="_blank"} 提供的撷取程序如何设置与使用。
 
 开始前建议先读 [项目研究预先准备](./setup-repo.md) 把开发环境建好。
 
 !!! tip "执行位置"
 
-    下面的指令都在 `anoni-net-docs/asn_coverage/` 目录下执行。第一次使用先 `cd` 进该目录、执行 `uv sync` 装好依赖，接着用 `uv run python ooni.py ...`（或先 `source .venv/bin/activate` 再依下方范例执行）。
+    下面的指令都在 `anoni-net-docs/asn_coverage/` 目录下执行。第一次使用先 `cd` 进该目录，执行 `uv sync` 安装依赖，接着依下方范例以 `uv run python ooni.py ...` 执行。
 
-## 资料来源
+## 三种取用路径
 
-OONI Probe 的观测资料会回传到 OONI 的 [AWS S3 Open Data](https://registry.opendata.aws/ooni/){target="_blank"} 中储存。你可以：
+OONI 的观测资料有三个入口，用途差异很大，先选对再着手：
 
-- 直接读 [OONI Docs](https://docs.ooni.org/data){target="_blank"} 介绍的撷取方式
-- 或透过 [anoni-net/docs 的 asn_coverage 程序](https://github.com/anoni-net/docs/tree/main/asn_coverage){target="_blank"} 来操作
+| 入口 | 适合的情境 | 限制 |
+|---|---|---|
+| [AWS S3 公开资料集](https://registry.opendata.aws/ooni/){target="_blank"} | 批次分析、全量统计、跨时间比对 | 需自行解析，下载量以 GB 计 |
+| [OONI API](https://api.ooni.io/api/v1/measurements){target="_blank"} | 依条件筛选、取单笔完整测量 | 单次回传笔数有上限 |
+| [OONI Explorer](https://explorer.ooni.org/){target="_blank"} | 人工查阅、确认个别测量 | 不适合程序化取用 |
 
-资料栏位结构参考 [ooni/spec](https://github.com/ooni/spec){target="_blank"}。
+`asn_coverage` 采用 S3 路径，目的是统计覆盖率而非查单笔。想查单笔或做小量筛选，[OONI 测量资料结构导览](./ooni-data-format.md) 有 API 的用法。
+
+## 程序能回答什么
+
+着手之前先确认工具的边界，`ooni.py` 现阶段只做覆盖率统计，取用范围有三个限制：
+
+- **只读 `webconnectivity` 目录**。同一小时底下其他十几个测项没有纳入，`tor`、`telegram`、`signal` 等测项的观测不会出现在统计里。各测项分别测什么见 [OONI 测项速查表](./ooni-nettests-map.md)。
+- **每笔测量只取两个栏位**，`probe_asn` 与 `annotations.network_type`。判定结果所在的 `test_keys` 没有读取，因此输出能回答「哪些 ASN 有人在测、测了几次」，无法回答「测量看到了什么」。
+- **只取 `.jsonl.gz`**，同目录的 `.tar.gz` 会跳过。
+
+若要扩充，最小的一步是在逐行解析时多取 `test_keys.blocking`，统计就能从「测量笔数」延伸到「各 ASN 的异常分布」。`blocking` 未观测到干预时是布尔值 `false`、有干预时是字串，统计前要先统一类型。判读前提见 [OONI 怎么判定一个网站被封锁](./ooni-blocking-determination.md)。
+
+## S3 资料集的摆放方式
+
+Bucket 名称是 `ooni-data-eu-fra`，位于 `eu-central-1`，公开读取不需认证凭证。路径依「日期、小时、国码、测项」分成四层：
+
+```text title="路径结构"
+raw/{YYYYMMDD}/{HH}/{国码}/{测项}/{YYYYMMDDHH}_{国码}_{测项}.n{编号}.{序号}.jsonl.gz
+```
+
+!!! warning "日期与小时都是 UTC"
+
+    路径中的 `{YYYYMMDD}` 与 `{HH}`、以及后面 CSV 输出的 `date` 与 `hour` 栏位，全部使用 UTC。程序内部一律以 `arrow.Arrow.utcnow()` 取时间。要分析「台湾某个时段的观测分布」时记得加 8 小时换算，否则图表会整体偏移。
+
+文件名尾端的 `.n{编号}.{序号}` 是 OONI 内部的批次编号，解析时可以忽略。
+
+不必安装任何工具，也能先确认里面有什么：
+
+```bash title="列出台湾某小时的所有测项"
+curl -s "https://ooni-data-eu-fra.s3.eu-central-1.amazonaws.com/?list-type=2&prefix=raw/20260804/00/TW/&delimiter=/" \
+  | grep -oE '<Prefix>raw/[^<]+</Prefix>'
+```
+
+回应是未断行的 XML，上面接了 `grep` 只取出目录名称。台湾在单一小时内通常会有十几个测项目录，`webconnectivity` 只是其中之一，同层还有 `tor`、`telegram`、`signal`、`whatsapp`、`dnscheck`、`echcheck`、`openvpn`、`psiphon`、`ndt`、`dash` 等。
+
+每个测项目录底下同一批资料有两种封装，`.jsonl.gz` 与 `.tar.gz`。`.jsonl.gz` 解开后一行一笔测量，适合逐行解析，程序取用的正是 `.jsonl.gz`。以 2026-08-04 台湾的 `webconnectivity` 为例，单一文件约 10 MB，换算成整月全国资料会相当可观，实际执行前先估算频宽与执行时间。程序采串流处理，原始文件不会落地保存，最后只输出 CSV。
+
+每一行的栏位怎么读，见 [OONI 测量资料结构导览](./ooni-data-format.md)。判定栏位代表什么，见 [OONI 怎么判定一个网站被封锁](./ooni-blocking-determination.md)。
 
 ## 撷取与分析指令
 
 ### 回看观察资料
 
-```bash title="回看观察资料"
-python3 ./ooni.py lookback [--units=36] [--loc=TW] [--frame=hours]
+```bash title="回看最近 36 小时"
+uv run python ooni.py lookback --units=36 --loc=TW --frame=hours
 ```
 
-区间单位为小时，默认为 36 个单位（36 小时），区域为台湾（`TW`）。执行后会依单位储存以下格式的文件：
+三个参数都可省略，默认值即为上例。`--frame` 决定回溯总长度的单位，可填 `hours`、`days`、`weeks` 等，无论填什么，资料一律按小时切分。输出文件名格式：
 
 - `lookback_{loc}_{YYYYMMDD}_{units}_{frame}.csv`
 
+文件名中的 `{YYYYMMDD}` 是执行当日的 UTC 日期，并非资料涵盖的区间，资料范围要看文件内容。文件写在目前的工作目录。
+
 ### 取得区间资料
 
-```bash title="取得区间资料"
-python3 ./ooni.py span --start=YYYY/MM/DD --end=YYYY/MM/DD [--loc=TW]
+```bash title="取得指定区间"
+uv run python ooni.py span --start=2026/08/01 --end=2026/08/03 --loc=TW --chunk=40
 ```
 
-带入开始时间（`start`）与结束时间（`end`），取得台湾这期间各小时区间的资料。
+带入开始时间（`start`）与结束时间（`end`），取得该期间各小时区间的资料。`--chunk` 控制同时处理的小时数，默认 `40`，网络或内存不足时调小。输出文件名格式：
+
+- `span_{loc}_{开始YYYYMMDD}_{结束YYYYMMDD}.csv`
 
 ### 转换为试算表资料
 
-```bash title="转换为试算表资料"
-python3 ./ooni.py sheetrow --path={资料路径}
+```bash title="展开为试算表格式"
+uv run python ooni.py sheetrow --path=./span_TW_20260801_20260803.csv
 ```
 
-将已撷取的资料展开，方便在试算表中计算，会另存一份开头为 `rows_` 的资料文件。
+将已撷取的资料展开，方便在试算表中计算。输出文件名是原文件名前面加上 `rows_`，以上例而言是 `rows_span_TW_20260801_20260803.csv`。
 
-### 计算 ASN 统计
+## 输出的 CSV 栏位格式
 
-建议使用「取得区间资料」加「转换为试算表资料」后，可以统计各 ASN 出现的次数与不重复统计计算。再取得目前台湾所有的 ASN 资料：
+`lookback` 与 `span` 产出的文件有四个栏位，一列代表一个小时：
 
-```bash title="计算统计 ASNs"
-python3 ./ripe.py save --loc=TW
+| 栏位 | 内容 |
+|---|---|
+| `loc` | 国码，例如 `TW` |
+| `date` | 日期，格式 `YYYY/MM/DD`，UTC |
+| `hour` | 小时，格式 `HH`，UTC |
+| `statistics` | 该小时的统计结果，内容是一段 JSON |
+
+`statistics` 内含两份计数，`counts` 依 ASN 统计测量笔数，`network_type` 依连线类型统计。以 2026-08-04 台湾 `00` 时的实际资料为例，该小时共 551 笔测量：
+
+```json title="statistics 栏位展开"
+{"counts": {"AS3462": 300, "AS17716": 100, "AS18419": 100, "AS24158": 51},
+ "network_type": {"mobile": 44, "no_internet": 7}}
 ```
 
-即可计算占比等统计资料。
+两份计数的总和不一致属于正常现象。`network_type` 由 Probe 自行标记，行动版 App 通常会写入，CLI 与桌面版多半不会，上例 551 笔中只有 51 笔带标记，程序会跳过没有标记的测量。其中 `no_internet` 代表 Probe 在测量当下判定自身没有连线。标记涵盖率不到一成，适合看趋势，不适合当作行动与固网的比例依据。
 
-## 范例试算表
+巢状 JSON 不易在试算表里计算，`sheetrow` 的作用就是把它摊平成一列一个 ASN：
+
+| `loc` | `date` | `hour` | `asn` | `count` |
+|---|---|---|---|---|
+| `TW` | `2026/08/04` | `00` | `AS3462` | `300` |
+| `TW` | `2026/08/04` | `00` | `AS17716` | `100` |
 
 实际分析输出的试算表范例（2023-09 至 2023-12）：
 
 [:material-google-spreadsheet: 20230901-20231204-TW](https://docs.google.com/spreadsheets/d/1lMDsqX8Oa3GKW68y8TuFeKQW2nKM7X0u4z-RopfJIaA/){ .md-button .md-button--primary target="_blank" }
 
+## 计算 ASN 覆盖率
+
+覆盖率需要两份数字，观测资料中出现过的不重复 ASN 数，以及该区域登记在案的 ASN 总数。前者从上一节摊平后的 CSV 用枢纽分析取得，后者用 `ripe.py` 向 RIPE NCC 索取：
+
+```bash title="取得该区域的全量 ASN 清单"
+uv run python ripe.py save --loc=TW
+```
+
+输出文件名为 `asns_{YYYYMMDDTHH}.csv`，六个栏位分别是 `no`、`location`、`org_id`、`registrar`、`reserved`、`name`。
+
+!!! warning "两边的 ASN 格式不同，比对前要先统一"
+
+    `ripe.py` 输出的 `no` 栏位是纯数字（`3462`），OONI 资料的 `probe_asn` 带 `AS` 前缀（`AS3462`）。直接用 VLOOKUP 比对会全部落空，比对前要先替其中一边补上或去掉 `AS`。
+
+两份数字备齐后即可计算：
+
+```text title="覆盖率算式"
+覆盖率 = 观测资料中出现的不重复 ASN 数 ÷ 该区域登记的 ASN 总数
+```
+
+以 [ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md) 引用的 2023-12 报告为例，台湾当时约有 437 组 ASN，观测资料涵盖的不重复 ASN 占 7.32%。你可以用同样的算式重算近期区间，对照覆盖率是否改善。
+
 ## 下一步
+
+抓到资料之后，接着看每一行的栏位怎么读。
 
 <div class="grid cards" markdown>
 
+- [:material-code-json: OONI 测量资料结构导览](./ooni-data-format.md)
+- [:material-shield-search: OONI 怎么判定一个网站被封锁](./ooni-blocking-determination.md)
+- [:material-table-search: OONI 测项速查表](./ooni-nettests-map.md)
 - [:material-access-point-network: ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md)
 - [:octicons-mark-github-24: 项目研究预先准备](./setup-repo.md)
 - [:material-hand-heart: 如何参与与认领主题](./how-to-contribute.md)

--- a/docs/zh-CN/community/ooni-blocking-determination.md
+++ b/docs/zh-CN/community/ooni-blocking-determination.md
@@ -1,0 +1,159 @@
+---
+title: OONI 怎么判定一个网站被封锁
+description: 网络连线测试（Web Connectivity）的 blocking 栏位怎么算出来，四种判定各自对应什么证据，以及为什么 blocking 有值不等于确认封锁。用五笔真实测量说明判读方法与常见误判来源。
+icon: material/shield-search
+---
+
+# :material-shield-search: OONI 怎么判定一个网站被封锁
+
+[OONI 测量资料结构导览](./ooni-data-format.md) 说明了栏位放在哪里，接下来的问题是栏位值怎么算出来。看到 `blocking: "dns"` 时，多数情况还不足以断定某个网站在台湾被封锁。
+
+`blocking` 只纪录单次测量与对照组不一致，距离「确认封锁」还有几步。以下拆解判定机制、四种类型各自对应的证据，以及把单笔测量推到可信结论需要补上什么。
+
+## 判定的基础：双边对照
+
+Probe 单独测一个网站，无法区分「网站遭到干预」与「网站本身无法连线」。`web_connectivity` 的作法是同一个网址测两次，一次从 Probe 所在的网络，一次请 OONI 的 test helper 从外部网络测，再比对两边结果。
+
+test helper 是 OONI 架设在外部网络的测量服务器，观测结果收在 `test_keys.control` 底下，包含 DNS 解析结果、TCP 连线状态与 HTTP 回应。判定栏位全部建立在双边差异上：
+
+| 差异出现的位置 | 判定 |
+|---|---|
+| DNS 解析结果不一致 | `blocking: "dns"` |
+| DNS 一致，Probe 连不上但 test helper 连得上 | `blocking: "tcp_ip"` |
+| TCP 连得上，HTTP 阶段失败 | `blocking: "http-failure"` |
+| HTTP 有回应，内容与 test helper 取得的不同 | `blocking: "http-diff"` |
+| 两边都正常且内容相符 | `blocking: false`、`accessible: true` |
+
+判定顺序由前往后，DNS 阶段就出问题时不会继续往下比对。四个 `*_match` 栏位在前三种情况下全是 `null`，原因正是比对在更早的阶段就中止。
+
+!!! tip "先看 `control` 再看 `blocking`"
+
+    `blocking` 是双边比对的结果，不是 Probe 单方面的观测。判读任何一笔异常测量时，先确认 `test_keys.control` 里 test helper 看到什么，再回头读 `blocking`。下一节的 `tcp_ip` 范例会示范，忽略 `control` 会把网站自身的问题误判成封锁。
+
+## 四种判定对应的证据
+
+后续章节引用的五笔测量都是 2026-08-04 的公开资料，可在 [OONI Explorer](https://explorer.ooni.org/){target="_blank"} 查到原始内容。
+
+### `dns`：解析结果不一致
+
+台湾 `https://ntc.party/` 的测量，Probe 对 A 与 AAAA 的查询都回报 `dns_nxdomain_error`（域名不存在），test helper 端查得到，因此 `dns_consistency` 标为 `inconsistent`。
+
+```json title="test_keys.queries"
+{"query_type": "A", "failure": "dns_nxdomain_error", "answers": []}
+{"query_type": "AAAA", "failure": "dns_nxdomain_error", "answers": []}
+```
+
+DNS 判定要留意解析器归属。该笔的 `resolver_asn` 是 `AS13335`（Cloudflare），`probe_asn` 则是 `AS3462`（中华电信）。测量者把 DNS 指向境外服务时，DNS 阶段的异常未必反映本地电信商的行为。
+
+### `tcp_ip`：连不到目标位址
+
+台湾 `http://www.tkec.com.tw/` 的测量判定为 `tcp_ip`，DNS 正常解析到 `210.64.193.1`，Probe 连 `80` 埠逾时。
+
+只看 Probe 端容易误读成封锁，对照 `control` 的结果就会得到不同结论：
+
+```json title="test_keys.control.tcp_connect"
+{"210.64.193.1:443": {"status": true,  "failure": null},
+ "210.64.193.1:80":  {"status": false, "failure": "generic_timeout_error"}}
+```
+
+test helper 从外部连 `80` 埠同样逾时，代表该网站的 `80` 埠从外部一样连不上，与台湾的网络环境无关。同一个 IP 的 `443` 埠两边都通，更说明问题出在该埠而非路径。
+
+### `http-failure`：连得上但取不到内容
+
+台湾 `https://bit.ly/` 的测量判定为 `http-failure`。DNS 正常，两个目标 IP 的 `443` 埠都连得上，`control` 显示 test helper 端也一样，差异出现在 HTTP 阶段的 `generic_timeout_error`。
+
+连线层没问题而应用层失败，常见于服务器端的速率限制、对特定来源的拒绝服务，以及 TLS 层的中断。要区分成因需要看 `tls_handshakes` 与 `network_events` 的时序。
+
+### `http-diff`：取得的内容不一致
+
+台湾目前的公开资料里查不到同类样态（见文末台湾现况），以下改用印尼的测量说明。
+
+四种类型里只有 `http-diff` 会让四个 `*_match` 栏位派上用场。印尼 `http://www.sportsinteraction.com/` 的测量是典型例子：
+
+| 观测方 | 状态码 | 标题 | 内容长度 |
+|---|---|---|---|
+| Probe | `200` | `Trustpositif` | 7,044 |
+| test helper | `403` | `Maintenance` | 7,067 |
+
+Probe 的请求被重导向到 `http://lamanlabuh.aduankonten.id/`，落在印尼官方的内容申诉域名，页面标题 `Trustpositif` 是当地网络内容过滤系统的名称。ISP 在连线途中把使用者导向告示页，是 `http-diff` 最典型的成因。
+
+该笔同时示范了单一栏位不可靠：
+
+```text title="四个 *_match 栏位与 body_proportion"
+title_match: false        status_code_match: false
+headers_match: true       body_length_match: true
+body_proportion: 0.9967
+```
+
+`body_length_match` 为 `true`、`body_proportion` 逼近 `1`，纯粹因为封锁告示页与对照组页面的长度刚好接近。只看长度会得到错误结论，四个栏位要一起读，其中 `title_match` 与 `status_code_match` 的鉴别力通常最高。
+
+## 误判从哪里来
+
+`blocking` 有值而实际上没有网络干预，是资料集里的常态。前面 `tkec.com.tw` 的 `80` 埠不通已经是一例，再看一笔更隐蔽的。
+
+埃及 `http://www.newipnow.com/` 的测量判定为 `http-diff`，四个 `*_match` 有三个不符，`body_proportion` 只有 `0.02`。看起来像被插入封锁页，实际内容是：
+
+| 观测方 | 状态码 | 标题 |
+|---|---|---|
+| Probe | `520` | `newipnow.com \| 520: Web server is returning an unknown error` |
+| test helper | `200` | `Buy Private Proxies: $0.88 per Dedicated Premium IP - NewIPNow` |
+
+`520` 是目标网站前方的 Cloudflare 在来源服务器异常时回应的错误页，代表该网站当下发生异常，与埃及的网络管制无关。另外值得留意的是，该笔的 `probe_asn` 是 `AS13335`（Cloudflare），测量端本身也走在 Cloudflare 的网络上，属于下面第二类的测量环境因素。
+
+常见的误判来源可以归成几类：
+
+- **来源网站自身状态**：服务器错误、维护页、CDN 错误页、地理限制。
+- **测量环境**：Probe 开着 VPN 或 Tor 时，测到的是出口所在地的网络。
+- **网站的动态内容**：轮播广告、个人化内容、A/B 测试会让两边的内容本来就不同。
+- **对照组本身失败**：`control_failure` 有值时，双边比对的前提不成立。
+
+OONI 在资料集层级也处理同一类问题，作法可参考 [OONI 如何分辨坏掉的量测资料](../blog/posts/2026-ooni-faulty-measurements.md)，该文整理了 OONI 用哪些启发式规则过滤异常投稿。
+
+## 从单笔测量到可信结论
+
+要把观测推进到「某个网站在某地被封锁」，单笔资料不够。实务上补上几个维度：
+
+1. **跨时间**：同一个网址在数天到数周内反覆出现同样的判定，才能排除偶发故障。
+2. **跨 ASN**：多家电信商都测到相同结果，指向网络层的普遍行为。只在单一 ASN 出现，较可能是该业者的个别设置。
+3. **跨解析器**：换不同 DNS 解析器仍然异常，才能排除解析器自身问题。
+4. **看 `confirmed` 栏位**：OONI 后端会用已知的封锁告示页指纹比对测量，命中时把 `confirmed` 标为 `true`。该栏位在 [measurements API](https://api.ooni.io/api/v1/measurements){target="_blank"} 的回应中，属于后端分析结果，不在 Probe 产生的原始资料里。
+
+想自己执行跨时间或跨 ASN 的比对，[ASN 观测资料撷取与分析](./asn-coverage-howto.md) 有批次取用的作法。
+
+!!! warning "`confirmed` 为 `true` 不等于 `http-diff`"
+
+    两者容易混淆。`confirmed` 标记的依据是封锁指纹比对，DNS 被导向已知的封锁用 IP 也会标记为 `confirmed`，判定类型仍是 `dns`。撰稿时抽查伊朗、俄罗斯、土耳其、中国各 5 笔 `confirmed` 测量，样本全部落在 `blocking: "dns"`。样本数少，仅能说明两者并非同一件事，不足以推论一般规律。
+
+## 台湾现况
+
+撰稿时抽样观察台湾的 `web_connectivity` 资料，纪录到两个现象：
+
+- **抽查 100 笔异常测量，`confirmed` 为 `true` 的有 0 笔**，与 [ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md) 长期以来的描述一致。
+- **抽查 40 笔异常测量的判定分布，`dns` 31 笔、`tcp_ip` 6 笔、`http-failure` 3 笔、`http-diff` 0 笔**。台湾目前的公开观测资料里没有出现重导向到封锁告示页的样态，前面的 `http-diff` 范例才需要引用印尼与埃及的资料。
+
+两组样本都取自 measurements API 的异常清单，查询条件如下，你可以自行重新执行确认结论是否仍成立：
+
+```bash title="列出台湾的异常测量"
+curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&anomaly=true&limit=100" \
+  | python3 -m json.tool | head -40
+```
+
+判定分布需要逐笔取 `raw_measurement` 后统计 `test_keys.blocking`，前述 40 笔即以此方式取得。
+
+以上是特定时间点的抽样，样本量小，仅供理解资料样态，不足以当作长期趋势的结论。要做有代表性的统计，需要涵盖更长时间与更多 ASN，而台湾的观测本身就存在 ASN 集中度过高的限制，细节见前面提到的 [ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md)。
+
+## 延伸阅读
+
+想自己执行跨时间、跨 ASN 的比对，从撷取指南开始。
+
+<div class="grid cards" markdown>
+
+- [:material-database-search: ASN 观测资料撷取与分析](./asn-coverage-howto.md)
+- [:material-code-json: OONI 测量资料结构导览](./ooni-data-format.md)
+- [:material-table-search: OONI 测项速查表](./ooni-nettests-map.md)
+- [:material-access-point-network: ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md)
+- [:material-list-status: OONI 网站检测清单](../taiwan/ooni-checklist.md)
+
+</div>
+
+判定演算法的完整定义在上游 [ts-017-web-connectivity](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}，失败字串的统一命名在 [df-007-errors](https://github.com/ooni/spec/blob/master/data-formats/df-007-errors.md){target="_blank"}。

--- a/docs/zh-CN/community/ooni-data-format.md
+++ b/docs/zh-CN/community/ooni-data-format.md
@@ -1,0 +1,178 @@
+---
+title: OONI 测量资料结构导览
+description: 一笔 OONI 测量资料由哪些栏位组成，怎么从中读出「谁在哪里测的」与「测出什么结果」。用两笔台湾的真实测量对照说明，并对应到上游 ooni/spec 的规格文件。
+icon: material/code-json
+---
+
+# :material-code-json: OONI 测量资料结构导览
+
+[ASN 观测资料撷取与分析](./asn-coverage-howto.md) 说明了如何撷取 OONI 公开资料，取得资料之后会遇到下一个问题：一笔测量有二十多个顶层栏位，`test_keys` 里还有二十几个，该看哪一个。
+
+以下用两笔台湾的真实测量对照，说明一笔网络连线测试（`web_connectivity`）的组成，以及每个栏位对应到上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的哪份规格。看懂之后，你可以自己判断一笔测量说了什么，也能决定分析程序该取哪些栏位。
+
+!!! info "范例资料来源"
+
+    两笔都是 2026-08-04 由台湾的 OONI Probe 产生的公开资料，可在 [OONI Explorer](https://explorer.ooni.org/){target="_blank"} 查到原始内容。
+
+    | | 正常通过 | 判定异常 |
+    |---|---|---|
+    | 测量对象 | `http://presidentlee.tw/` | `https://ntc.party/` |
+    | `measurement_uid` | `20260804085935.603513_TW_webconnectivity_4a5fd27dec0b32f6` | `20260804084548.416537_TW_webconnectivity_f4e7b0ab3d0251bf` |
+
+## 一笔测量的三层结构
+
+不用一开始就记住所有栏位。一笔测量可以拆成三层来读：
+
+1. **外壳**：谁在哪里、用什么软件、什么时候测的。所有测项共用同一套栏位，规格是 [df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"}。
+2. **判定**：测量得出的结论。栏位随测项而异，全部收在 `test_keys` 底下，`web_connectivity` 的定义在 [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}。
+3. **证据**：支撑结论的原始纪录，包含每一次 DNS 查询、TCP 连线、TLS 握手与 HTTP 请求，以及对照组的同类纪录。同样放在 `test_keys` 底下，各自对应一份 `df-` 开头的规格。
+
+判定层告诉你结论，证据层让你验证结论。两者分开读，各栏位的角色就清楚了。
+
+## 自己取一笔来看
+
+边读边对照手上的样本会快很多。不必先架好环境，用公开 API 就能取得单笔资料。先列出符合条件的测量：
+
+```bash title="列出台湾最近的网络连线测试"
+curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&limit=5" \
+  | python3 -m json.tool | head -40
+```
+
+回应中的 `measurement_uid` 可以换取完整内容：
+
+```bash title="取得单笔完整测量资料"
+curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement_uid>" \
+  | python3 -m json.tool | head -60
+```
+
+原始回应是未断行的长字串，直接输出到终端机不易阅读，上面两段都接了 `python3 -m json.tool` 排版。加上 `anomaly=true` 可以只列出被判定异常的测量，适合用来找对照范例。把 `probe_cc` 换成所在地区、`probe_asn` 换成自己的 ASN，就能看到本地网络上的观测纪录。
+
+需要批次处理大量资料时，改走 AWS S3 公开资料集会更有效率，作法见 [ASN 观测资料撷取与分析](./asn-coverage-howto.md)。
+
+## 外壳：谁在哪里测的
+
+外壳层的栏位在所有测项中都一样，实务上最常用到的如下：
+
+| 栏位 | 正常通过那笔 | 判定异常那笔 | 说明 |
+|---|---|---|---|
+| `probe_cc` | `TW` | `TW` | 测量发生的国家代码 |
+| `probe_asn` | `AS3462` | `AS3462` | 执行测量的网络所属 ASN |
+| `probe_network_name` | `Chunghwa Telecom Co., Ltd.` | `Chunghwa Telecom Co., Ltd.` | 该 ASN 的组织名称 |
+| `resolver_asn` | `AS3462` | `AS13335` | 测量时实际使用的 DNS 解析器所属 ASN |
+| `resolver_network_name` | `Chunghwa Telecom Co., Ltd.` | `Cloudflare Inc` | 解析器的组织名称 |
+| `input` | `http://presidentlee.tw/` | `https://ntc.party/` | 测量对象的网址 |
+| `test_name` | `web_connectivity` | `web_connectivity` | 测项名称 |
+| `software_name` | `ooniprobe-cli` | `ooniprobe-desktop-unattended` | 产生资料的 Probe 种类 |
+| `software_version` | `3.29.1` | `3.26.0` | Probe 版本 |
+| `measurement_start_time` | `2026-08-04 08:59:30` | `2026-08-04 08:45:45` | 测量开始时间（UTC）|
+| `report_id` | `20260804T062033Z_webconnectivity_TW_3462_n4_uEH5rGoD07cN2oYQ` | `20260804T084446Z_webconnectivity_TW_3462_n4_dFfWCDrwouM0TsT2` | 同一次执行产生的多笔测量共用此值 |
+
+`probe_asn` 与 `resolver_asn` 可能不同，上表就是实例。两笔都在中华电信的网络上执行，但其中一笔的使用者把 DNS 指向 Cloudflare。做 ASN 分析时两者要分开看，混用会让「哪家电信商的网络上看到什么」失准。
+
+!!! note "`probe_ip` 永远是 `127.0.0.1`"
+
+    OONI 刻意不收集测量者的真实 IP，`probe_ip` 固定写入本机位址。想追测量来源只能仰赖 `probe_asn` 加时间，同一条隐私边界在 [OONI Run v2 操作说明](../tools/ooni-run-v2.md) 也提醒协助者留意。
+
+## 判定：测量得出的结论
+
+判定栏位全部收在 `test_keys` 底下。读之前要先知道一件事：`web_connectivity` 的判定建立在双边对照上。Probe 测完之后，OONI 架设在外部网络的测量服务器（test helper）会对同一个网址再测一次，两边结果的差异才是判定的依据。test helper 那一侧的纪录收在 `test_keys.control`，下表的「对照组」指的就是它。
+
+判定结果与内容比对共八个栏位。把两笔并排，差异一眼可见：
+
+| 栏位 | 正常通过 | 判定异常 | 说明 |
+|---|---|---|---|
+| `blocking` | `false` | `"dns"` | 判定的干预类型，可能值为 `dns`、`tcp_ip`、`http-failure`、`http-diff`，未观测到干预时为布尔值 `false` |
+| `accessible` | `true` | `false` | 是否取得了合理的回应 |
+| `dns_consistency` | `"consistent"` | `"inconsistent"` | Probe 的 DNS 结果与对照组是否一致 |
+| `title_match` | `true` | `null` | 网页标题是否与对照组相符 |
+| `headers_match` | `true` | `null` | 回应标头是否相符 |
+| `status_code_match` | `true` | `null` | HTTP 状态码是否相符 |
+| `body_length_match` | `true` | `null` | 回应内容长度是否相近 |
+| `body_proportion` | `1` | `0` | 内容长度与对照组的比值 |
+
+各阶段的失败原因另有三个栏位，判读时要一起看：
+
+| 栏位 | 纪录什么 |
+|---|---|
+| `dns_experiment_failure` | DNS 阶段的失败原因，判定异常那笔为 `"dns_nxdomain_error"` |
+| `http_experiment_failure` | HTTP 阶段的失败原因，例如 `"generic_timeout_error"` |
+| `control_failure` | 对照组本身是否失败。有值时双边比对的前提不成立，判定结果不可信 |
+
+`blocking` 的四种值分别对应不同阶段的异常：`dns` 是解析结果与对照组不一致、`tcp_ip` 是封包送不到目标位址、`http-failure` 是连线建立后 HTTP 阶段失败、`http-diff` 是取得的内容与对照组不同（常见于封锁告示页）。四种手法在 [什么是 OONI](../tools/what-is-ooni.md) 有概念层的介绍。
+
+!!! tip "两个容易误判的类型问题"
+
+    `blocking` 未观测到干预时是布尔值 `false`，有干预时是字串。拿它做统计前要先统一处理，否则 `false` 与 `"dns"` 会被算成两类不同的东西。
+
+    四种值的命名本身不一致，`tcp_ip` 用下划线，`http-failure` 与 `http-diff` 用连字号。上游如此定义，照抄即可，不要自行统一。
+
+四个 `*_match` 栏位在异常那笔全是 `null`，原因是 DNS 阶段就失败，连线没有建立，后续没有东西可以比对。看到一整排 `null` 时，回头找测量流程中第一个有值的 failure 栏位，那里才是问题发生的地方。
+
+!!! warning "异常不等于封锁"
+
+    `blocking` 有值只代表该笔测量的结果与对照组不一致，判断是否真的存在网络干预需要更多佐证。以判定异常那笔为例，Probe 对 `ntc.party` 的 A 与 AAAA 查询都回报 `dns_nxdomain_error`（域名不存在），但撰稿时从多个公开 DNS 解析器查询，该域名可解析到 IPv6 位址。单笔测量无法区分网络干预、解析器当下的暂时状态，以及域名本身的设置变动。
+
+    要下封锁结论，需要跨时间、跨 ASN、跨解析器的多笔测量交叉比对。判定机制的完整拆解与常见误判来源见 [OONI 怎么判定一个网站被封锁](./ooni-blocking-determination.md)，资料集层级的品质控制则可参考 [OONI 如何分辨坏掉的量测资料](../blog/posts/2026-ooni-faulty-measurements.md)。
+
+## 证据：支撑结论的原始纪录
+
+`test_keys` 底下另有几个栏位，纪录测量过程中每一次网络操作。每个栏位各有一份规格：
+
+| 栏位 | 内容 | 规格 |
+|---|---|---|
+| `queries` | 每一次 DNS 查询的问题、回应与失败原因 | [df-002-dnst](https://github.com/ooni/spec/blob/master/data-formats/df-002-dnst.md){target="_blank"} |
+| `tcp_connect` | 每一次 TCP 连线尝试的目标与结果 | [df-005-tcpconnect](https://github.com/ooni/spec/blob/master/data-formats/df-005-tcpconnect.md){target="_blank"} |
+| `tls_handshakes` | 每一次 TLS 握手的参数、凭证与结果 | [df-006-tlshandshake](https://github.com/ooni/spec/blob/master/data-formats/df-006-tlshandshake.md){target="_blank"} |
+| `requests` | 每一次 HTTP 请求与回应的完整内容 | [df-001-httpt](https://github.com/ooni/spec/blob/master/data-formats/df-001-httpt.md){target="_blank"} |
+| `network_events` | 连线过程的时序事件，用于分析延迟与中断点 | [df-008-netevents](https://github.com/ooni/spec/blob/master/data-formats/df-008-netevents.md){target="_blank"} |
+| `control` | 对照组的同类纪录，结构与 Probe 侧对应，判定栏位全部由它与 Probe 端的差异算出 | [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} |
+| 各栏位的 `failure` 字串 | 所有失败原因的统一命名，例如 `dns_nxdomain_error`、`generic_timeout_error`、`ssl_unknown_authority` | [df-007-errors](https://github.com/ooni/spec/blob/master/data-formats/df-007-errors.md){target="_blank"} |
+
+把两笔的 `queries` 摊开对照，就能看到判定的依据：
+
+```json title="正常通过：查到位址"
+{
+  "hostname": "presidentlee.tw",
+  "query_type": "A",
+  "failure": null,
+  "answers": [{"answer_type": "A", "ipv4": "43.254.17.201"}]
+}
+```
+
+```json title="判定异常：查询落空"
+{
+  "hostname": "ntc.party",
+  "query_type": "A",
+  "failure": "dns_nxdomain_error",
+  "answers": []
+}
+```
+
+判定层的 `dns_consistency` 是结论，`queries` 与 `control` 是它的依据。想确认一笔测量的判定是否合理，往证据层查验即可。
+
+## 版本与相容性
+
+读 spec 之前先确认版本，能避免不少困惑：
+
+- **`data_format_version` 目前是 `0.2.0`**。外壳层的栏位定义稳定，[df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"} 可以直接对照。
+- **`web_connectivity` 实际流通的 `test_version` 是 `0.4.3`**。[ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} 的规格内容已更新为描述 v0.5 演算法，但生产环境仍以 v0.4 为主。spec 明订新版演算法必须使用不同的 test_keys 栏位，v0.4 的栏位定义保持相容，因此上表的栏位读法对两个版本都适用。
+- **`x_` 开头的栏位不在 spec 内**。实际资料中会看到 `x_dns_runtime`、`x_status`、`x_th_runtime` 等栏位，属于实作端的实验性扩充，随版本增减，分析程序不应依赖它们。
+
+上游 spec 的 master 分支自 2025-06 起没有新的合并，但 issue 与 PR 讨论持续进行（进行中的提案包含 ICMP 资料格式与 DPI 分片测项）。spec 现阶段适合当作稳定参考，引用时建议连回上游原文，避免自行复制规格内容而在上游更新后失准。
+
+## 延伸阅读
+
+看懂栏位之后，接着看判定栏位怎么算出来，以及为什么有值不等于封锁。
+
+<div class="grid cards" markdown>
+
+- [:material-shield-search: OONI 怎么判定一个网站被封锁](./ooni-blocking-determination.md)
+- [:material-table-search: OONI 测项速查表](./ooni-nettests-map.md)
+- [:material-access-point-network: 什么是 OONI](../tools/what-is-ooni.md)
+- [:material-database-search: ASN 观测资料撷取与分析](./asn-coverage-howto.md)
+- [:material-access-point-network: ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md)
+- [:material-list-status: OONI 网站检测清单](../taiwan/ooni-checklist.md)
+
+</div>
+
+上游规格的完整目录在 [ooni/spec](https://github.com/ooni/spec){target="_blank"}，其中 [data-formats](https://github.com/ooni/spec/tree/master/data-formats){target="_blank"} 收录资料格式、[nettests](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 收录各测项的演算法定义。

--- a/docs/zh-CN/community/ooni-nettests-map.md
+++ b/docs/zh-CN/community/ooni-nettests-map.md
@@ -1,0 +1,142 @@
+---
+title: OONI 测项速查表
+description: ooni/spec 收录的 41 个网络测项各自测什么、哪些还在产出资料、台湾实际测到哪几个。附上游规格连结，供挑选测项或解读资料时对照。
+icon: material/table-search
+---
+
+# :material-table-search: OONI 测项速查表
+
+[ooni/spec](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 的 `nettests` 目录收录 41 份测项规格，其中有相当比例已经停止使用。要挑测项或解读手上的资料时，先知道哪些还在产出资料，比逐份读规格有效率。
+
+本页把 41 份规格整理成一张对照表，标注上游规格的状态、实际是否还有公开资料，以及台湾观测到哪几个。
+
+!!! info "状态栏位怎么读"
+
+    **spec 状态**取自各份规格开头的 `_status_` 标记，分为 `current`、`experimental`、`obsolete` 三种，反映上游对该测项的定位。
+
+    **资料流通**是实测结果，以撰稿当日（2026-08-04）为快照，透过 [OONI API](https://api.ooni.io/api/v1/measurements){target="_blank"} 盘点各测项最近的公开测量。
+
+    **台湾**栏位来自 S3 公开资料集，抽查 2026-08-03 五个时段台湾底下出现过的测项目录。
+
+## 先看一件事：状态标记不等于实际有资料
+
+规格标记与实际资料不一致的情况存在，看下面的表格前先知道两个方向的落差：
+
+- **标为 `current` 却查不到资料**：`tlsmiddlebox`、`portfiltering`、`captiveportal` 三个。
+- **标为 `experimental` 却每日都有资料**：`dnscheck`、`echcheck`、`openvpn`、`stunreachability`、`vanilla_tor` 等，资料量与部分 `current` 测项相当。
+
+`experimental` 只反映规格本身的成熟度，与资料量多寡没有必然关系。要判断某个测项是否适合用于分析，直接查 API 是否有资料，比看状态标记可靠。
+
+## 依用途分群
+
+带着「我想观测什么」进来的话，先从下面挑方向，再到表格查细节：
+
+- **网站封锁侦测**：`web_connectivity`
+- **中间设备与干扰手法**：`http_header_field_manipulation`、`http_invalid_request_line`、`sni_blocking`、`echcheck`
+- **通讯软件可达性**：`telegram`、`whatsapp`、`signal`、`facebook_messenger`
+- **规避工具可用性**：`tor`、`vanilla_tor`、`torsf`、`psiphon`、`riseupvpn`、`openvpn`
+- **DNS 行为**：`dnscheck`、`dnsping`
+- **连线效能**：`ndt`、`dash`、`stunreachability`、`quicping`
+
+## 仍在产出资料的测项
+
+以下测项在撰稿当日都查得到公开测量，是解读 OONI 资料时最常遇到的一批。
+
+| 测项 | 测什么 | spec 状态 | 台湾 |
+|---|---|---|---|
+| [`web_connectivity`](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} | 网站可达性与封锁判定，资料量最大的测项 | current | 有 |
+| [`tor`](https://github.com/ooni/spec/blob/master/nettests/ts-023-tor.md){target="_blank"} | Tor 目录权威节点与桥接的可达性 | current | 有 |
+| [`vanilla_tor`](https://github.com/ooni/spec/blob/master/nettests/ts-016-vanilla-tor.md){target="_blank"} | 未经伪装的 Tor 能否顺利启动连线 | experimental | 有 |
+| [`torsf`](https://github.com/ooni/spec/blob/master/nettests/ts-030-torsf.md){target="_blank"} | 透过 Snowflake 传输层的 Tor 连线 | experimental | 无 |
+| [`telegram`](https://github.com/ooni/spec/blob/master/nettests/ts-020-telegram.md){target="_blank"} | Telegram 网页版与资料中心端点可达性 | current | 有 |
+| [`whatsapp`](https://github.com/ooni/spec/blob/master/nettests/ts-018-whatsapp.md){target="_blank"} | WhatsApp 端点与注册服务可达性 | current | 有 |
+| [`signal`](https://github.com/ooni/spec/blob/master/nettests/ts-029-signal.md){target="_blank"} | Signal 服务端点可达性 | current | 有 |
+| [`facebook_messenger`](https://github.com/ooni/spec/blob/master/nettests/ts-019-facebook-messenger.md){target="_blank"} | Facebook Messenger 端点可达性 | current | 有 |
+| [`dnscheck`](https://github.com/ooni/spec/blob/master/nettests/ts-028-dnscheck.md){target="_blank"} | 指定 DNS 解析器的行为，涵盖加密查询（DoH、DoT） | experimental | 有 |
+| [`dnsping`](https://github.com/ooni/spec/blob/master/nettests/ts-035-dnsping.md){target="_blank"} | DNS 查询的延迟与回应行为 | experimental | 无 |
+| [`echcheck`](https://github.com/ooni/spec/blob/master/nettests/ts-039-echcheck.md){target="_blank"} | 加密客户端问候（ECH）的支援与干扰状况 | experimental | 有 |
+| [`http_header_field_manipulation`](https://github.com/ooni/spec/blob/master/nettests/ts-006-header-field-manipulation.md){target="_blank"} | 中间设备是否窜改 HTTP 标头 | current | 有 |
+| [`http_invalid_request_line`](https://github.com/ooni/spec/blob/master/nettests/ts-007-http-invalid-request-line.md){target="_blank"} | 中间设备对异常请求行的反应，用于侦测透明代理 | current | 有 |
+| [`openvpn`](https://github.com/ooni/spec/blob/master/nettests/ts-040-openvpn.md){target="_blank"} | OpenVPN 握手能否完成 | experimental | 有 |
+| [`psiphon`](https://github.com/ooni/spec/blob/master/nettests/ts-015-psiphon.md){target="_blank"} | Psiphon 规避工具能否建立连线 | current | 有 |
+| [`riseupvpn`](https://github.com/ooni/spec/blob/master/nettests/ts-026-riseupvpn.md){target="_blank"} | RiseupVPN 服务可达性 | current | 有 |
+| [`stunreachability`](https://github.com/ooni/spec/blob/master/nettests/ts-025-stun-reachability.md){target="_blank"} | STUN 服务器可达性，牵动 WebRTC 通话 | experimental | 有 |
+| [`ndt`](https://github.com/ooni/spec/blob/master/nettests/ts-022-ndt.md){target="_blank"} | 连线速度与效能诊断 | current | 有 |
+| [`dash`](https://github.com/ooni/spec/blob/master/nettests/ts-021-dash.md){target="_blank"} | 影音串流播放品质 | current | 有 |
+| [`browser_web`](https://github.com/ooni/spec/blob/master/nettests/ts-036-browser_web.md){target="_blank"} | 以真实浏览器引擎载入网页 | experimental | 无 |
+
+!!! note "表中出现的缩写"
+
+    - **DoH、DoT**：把 DNS 查询包在 HTTPS 或 TLS 里传送，避免查询内容以明文经过网络。详见 [加密 DNS](../tools/encrypted-dns.md)。
+    - **ECH（Encrypted Client Hello）**：TLS 握手的第一个讯息原本会以明文带出要连的域名，ECH 把该栏位加密。
+    - **SNI（Server Name Indication）**：TLS 握手时以明文送出的目标域名，常被当成封锁判断的依据。
+    - **STUN**：协助装置找出自己对外 IP 与埠号的协定，WebRTC 通话建立连线时会用到。
+    - **QUIC**：以 UDP 为基础的传输协定，HTTP/3 建立在其上。
+
+## 偶尔才有资料的测项
+
+| 测项 | 测什么 | spec 状态 | 最近一笔 |
+|---|---|---|---|
+| [`quicping`](https://github.com/ooni/spec/blob/master/nettests/ts-031-quicping.md){target="_blank"} | QUIC 协定的可达性 | experimental | 2026-07-30 |
+| [`sni_blocking`](https://github.com/ooni/spec/blob/master/nettests/ts-024-sni-blocking.md){target="_blank"} | 针对 TLS SNI 栏位的封锁侦测 | experimental | 2026-07-20 |
+
+## 查不到公开资料的测项
+
+以下七个测项在 API 查不到公开测量。规格仍在上游仓库里，设计新测项或研究方法时可以参考。
+
+| 测项 | 测什么 | spec 状态 |
+|---|---|---|
+| [`tlsmiddlebox`](https://github.com/ooni/spec/blob/master/nettests/ts-037-tlsmiddlebox.md){target="_blank"} | TLS 连线路径上的中间设备行为 | current |
+| [`portfiltering`](https://github.com/ooni/spec/blob/master/nettests/ts-038-port-filtering.md){target="_blank"} | 特定连接埠是否被过滤 | current |
+| [`captiveportal`](https://github.com/ooni/spec/blob/master/nettests/ts-010-captive-portal.md){target="_blank"} | 是否处于需要登入的受控网络 | current |
+| [`urlgetter`](https://github.com/ooni/spec/blob/master/nettests/ts-027-urlgetter.md){target="_blank"} | 供其他测项复用的通用抓取元件 | experimental |
+| [`tcpping`](https://github.com/ooni/spec/blob/master/nettests/ts-032-tcpping.md){target="_blank"} | TCP 层的往返延迟 | experimental |
+| [`tlsping`](https://github.com/ooni/spec/blob/master/nettests/ts-033-tlsping.md){target="_blank"} | TLS 握手的往返延迟 | experimental |
+| [`simplequicping`](https://github.com/ooni/spec/blob/master/nettests/ts-034-simplequicping.md){target="_blank"} | QUIC 的简化延迟量测 | experimental |
+
+## 标记为 obsolete 的历史测项
+
+上游标为 `obsolete` 的有 12 份，多数功能已被 `web_connectivity` 吸收，或随着测量方法演进而退场。处理历史资料时可能会遇到它们的纪录，规划新的观测时没有理由采用它们。
+
+| 测项 | 规格 |
+|---|---|
+| bridgeT | [ts-001](https://github.com/ooni/spec/blob/master/nettests/ts-001-bridget.md){target="_blank"} |
+| DNS Consistency | [ts-002](https://github.com/ooni/spec/blob/master/nettests/ts-002-dns-consistency.md){target="_blank"} |
+| HTTP Requests | [ts-003](https://github.com/ooni/spec/blob/master/nettests/ts-003-http-requests.md){target="_blank"} |
+| HTTP Host | [ts-004](https://github.com/ooni/spec/blob/master/nettests/ts-004-http-host.md){target="_blank"} |
+| DNS Spoof | [ts-005](https://github.com/ooni/spec/blob/master/nettests/ts-005-dns-spoof.md){target="_blank"} |
+| TCP Connect | [ts-008](https://github.com/ooni/spec/blob/master/nettests/ts-008-tcp-connect.md){target="_blank"} |
+| Multi Protocol Traceroute | [ts-009](https://github.com/ooni/spec/blob/master/nettests/ts-009-multi-protocol-traceroute.md){target="_blank"} |
+| Bridge Reachability | [ts-011](https://github.com/ooni/spec/blob/master/nettests/ts-011-bridge-reachability.md){target="_blank"} |
+| DNS Injection | [ts-012](https://github.com/ooni/spec/blob/master/nettests/ts-012-dns-injection.md){target="_blank"} |
+| Lantern | [ts-013](https://github.com/ooni/spec/blob/master/nettests/ts-013-lantern.md){target="_blank"} |
+| Meek Fronted Requests | [ts-014](https://github.com/ooni/spec/blob/master/nettests/ts-014-meek-fronted-requests.md){target="_blank"} |
+| OpenVPN Client Test（旧版） | [ts-016](https://github.com/ooni/spec/blob/master/nettests/ts-016-openvpn.md){target="_blank"} |
+
+!!! note "编号重复的两份 OpenVPN 规格"
+
+    上游有两份规格都编为 `ts-016`，分别是上表标为 `obsolete` 的 `ts-016-openvpn.md` 与标为 `experimental` 的 `ts-016-vanilla-tor.md`。现行的 OpenVPN 测项规格是 `ts-040-openvpn.md`，引用时留意不要取到旧的那份。
+
+## 台湾观测到哪些测项
+
+抽查 2026-08-03 五个时段，台湾底下出现过 17 个测项（以下用 API 的下划线写法）：`web_connectivity`、`tor`、`vanilla_tor`、`telegram`、`whatsapp`、`signal`、`facebook_messenger`、`dnscheck`、`echcheck`、`http_header_field_manipulation`、`http_invalid_request_line`、`openvpn`、`psiphon`、`riseupvpn`、`stunreachability`、`ndt`、`dash`。
+
+S3 上的目录名与 `test_name` 写法不同，目录名没有下划线（`webconnectivity`、`vanillator`、`facebookmessenger`），API 查询要用下划线形式（`web_connectivity`、`vanilla_tor`、`facebook_messenger`）。取用路径的细节见 [ASN 观测资料撷取与分析](./asn-coverage-howto.md)。
+
+台湾目前的观测集中在 `web_connectivity`，其他测项的样本量偏小。想扩充在地观测的涵盖面，`tor` 与 `dnscheck` 是与社群既有主题最接近的两个方向。
+
+实际执行特定测项有两条路径。用 [OONI Probe](https://ooni.org/install/){target="_blank"} 桌面或行动版，在设置里挑选要启用的测项。想邀请其他人一起测固定的网址清单，改用 [OONI Run v2](../tools/ooni-run-v2.md) 建立连结分享，社群目前维运的连结 ID 是 `10328`。
+
+## 延伸阅读
+
+<div class="grid cards" markdown>
+
+- [:material-code-json: OONI 测量资料结构导览](./ooni-data-format.md)
+- [:material-shield-search: OONI 怎么判定一个网站被封锁](./ooni-blocking-determination.md)
+- [:material-database-search: ASN 观测资料撷取与分析](./asn-coverage-howto.md)
+- [:material-help-network: OONI Run v2 操作说明](../tools/ooni-run-v2.md)
+- [:material-access-point-network: 什么是 OONI](../tools/what-is-ooni.md)
+
+</div>
+
+各测项的完整演算法定义在上游 [nettests](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 目录。测项输出的共通栏位定义在 [data-formats](https://github.com/ooni/spec/tree/master/data-formats){target="_blank"}。

--- a/docs/zh-CN/taiwan/ooni-asn-coverage.md
+++ b/docs/zh-CN/taiwan/ooni-asn-coverage.md
@@ -117,59 +117,32 @@ AS 可以被理解为一个单一的管理实体（例如：一家公司、一�
 
 !!! question "检测发现 AS 与 DNS 的差异"
 
-    在这个示例说明过程中，可以发现 OONI Probe 会将检测过程记录下来。例如，我们可以发现即使通过中华电信的网络上网，但是在查询 DNS 服务时使用的是 Cloudflare 的 DNS 查询。
+    在上面的示例说明过程中，可以发现 OONI Probe 会将检测过程记录下来。例如即使通过中华电信的网络上网，查询 DNS 服务时使用的却是 Cloudflare 的 DNS 查询。对应到原始资料，`probe_asn` 与 `resolver_asn` 分属两个不同的 ASN。
 
     - 问题：网站受到阻挡无法连接访问，是 AS 问题还是 DNS 问题呢？
 
-### 数据获取
+每个栏位分别代表什么、判定结果又是怎么算出来的，另有三篇技术文件接续说明：
 
-通过 OONI Probe 的检测，观测数据会上传到 OONI 的 [AWS S3 Open Data](https://registry.opendata.aws/ooni/){target="_blank"} 中储存。在 [OONI Docs](https://docs.ooni.org/data){target="_blank"} 中有简单的数据获取教程，或者可以使用我们已经完成的[获取程序](https://github.com/anoni-net/docs/blob/main/asn_coverage/ooni.py){target="_blank"}，数据的字段结构可以参考 [ooni/spec](https://github.com/ooni/spec){target="_blank"}。
+<div class="grid cards" markdown>
 
-以下将通过[获取程序](https://github.com/anoni-net/docs/blob/main/asn_coverage/ooni.py){target="_blank"}来演示如何获取检测观测数据。
+- [:material-code-json: OONI 测量资料结构导览](../community/ooni-data-format.md)
+- [:material-shield-search: OONI 怎么判定一个网站被封锁](../community/ooni-blocking-determination.md)
+- [:material-table-search: OONI 测项速查表](../community/ooni-nettests-map.md)
 
-??? question "如何设置项目环境？"
+</div>
 
-    如何设置项目环境与安装所需的套件，请参考「项目研究预先准备」章节，接下来的说明将会省略前置准备过程。
+### 想着手分析？
 
-```bash title="回看观测资料"
+如果你想自己撷取与分析 OONI 公开资料，计算特定区域的 ASN 覆盖率，相关工具设置与指令见：
 
-python3 ./ooni.py lookback [--unit=36] [--loc=TW] [--frame=hours]
-```
-
-区间单位为 `小时`，默认设定为 `36` 个单位（36 小时），区域为台湾（`TW`）。执行后将以单位储存以下格式的文件。
-
-- `lookback_{loc}_{YYYYMMDD}_{units}_{frame}.csv`
-
-```bash title="取得区间数据"
-python3 ./ooni.py span --start=YYYY/MM/DD --end=YYYY/MM/DD [--loc=TW]
-```
-
-区间单位为 `小时`，带入开始时间（`start`）与结束时间（`end`），获取台湾（`TW`）在这一期间的各小时区间的数据。
-
-```bash title="转换为试算表数据"
-python3 ./ooni.py sheetrow --path={数据路径}
-```
-
-将已获取的数据展开后，为方便在试算表中进行计算操作，另存一份以 `rows_` 开头的数据文件。
-
-建议使用「取得区间数据」加上「转换为试算表数据」后，就可以统计各 ASNs 出现的次数与进行不重复统计计算。再获取目前台湾所有的 ASNs 数据，即可进行占比等统计分析。
-
-```bash title="计算统计 ASNs"
-python3 ./ripe.py save --loc=TW
-```
-
-详细的计算统计可以参考以下资料：
-
-[:material-google-spreadsheet: 20230901-20231204-TW](https://docs.google.com/spreadsheets/d/1lMDsqX8Oa3GKW68y8TuFeKQW2nKM7X0u4z-RopfJIaA/){ .md-button .md-button--primary target="_blank" }
+[:material-database-search: ASN 观测资料撷取与分析](../community/asn-coverage-howto.md){ .md-button .md-button--primary }
 
 ## :fontawesome-solid-diagram-project: 下一步
 
 <div class="grid cards" markdown>
 
-- [:material-database-search: ASN 观测资料撷取与分析](../community/asn-coverage-howto.md)
-- [:material-code-json: OONI 测量资料结构导览](../community/ooni-data-format.md)
-- [:material-shield-search: OONI 怎么判定一个网站被封锁](../community/ooni-blocking-determination.md)
-- [:material-table-search: OONI 测项速查表](../community/ooni-nettests-map.md)
+- [:material-list-status: OONI 网站检测清单](./ooni-checklist.md)
+- [:material-chart-bar: Tor Relay 观测点](./tor-relay-watcher.md)
 - [:octicons-mark-github-24: 项目研究预先准备](../community/setup-repo.md)
 - [:material-chat-question: 什么是 OONI？](../tools/what-is-ooni.md)
 

--- a/docs/zh-CN/taiwan/ooni-asn-coverage.md
+++ b/docs/zh-CN/taiwan/ooni-asn-coverage.md
@@ -166,6 +166,10 @@ python3 ./ripe.py save --loc=TW
 
 <div class="grid cards" markdown>
 
+- [:material-database-search: ASN 观测资料撷取与分析](../community/asn-coverage-howto.md)
+- [:material-code-json: OONI 测量资料结构导览](../community/ooni-data-format.md)
+- [:material-shield-search: OONI 怎么判定一个网站被封锁](../community/ooni-blocking-determination.md)
+- [:material-table-search: OONI 测项速查表](../community/ooni-nettests-map.md)
 - [:octicons-mark-github-24: 项目研究预先准备](../community/setup-repo.md)
 - [:material-chat-question: 什么是 OONI？](../tools/what-is-ooni.md)
 

--- a/docs/zh-CN/taiwan/ooni-checklist.md
+++ b/docs/zh-CN/taiwan/ooni-checklist.md
@@ -52,6 +52,8 @@ OONI Probe 每次检测都依据一份事先列举的网站清单，逐一检查
 <div class="grid cards" markdown>
 
 - [:material-chat-question: 什么是 OONI？](../tools/what-is-ooni.md)
+- [:material-code-json: OONI 测量资料结构导览](../community/ooni-data-format.md)
+- [:material-table-search: OONI 测项速查表](../community/ooni-nettests-map.md)
 - [:material-chat-question: 网络自由为什么重要](../basics/internet-freedom.md)
 - [:octicons-mark-github-24: 项目研究预先准备](../community/setup-repo.md)
 

--- a/docs/zh-CN/tools/ooni-run-v2.md
+++ b/docs/zh-CN/tools/ooni-run-v2.md
@@ -200,6 +200,8 @@ miniooni oonirun -i https://api.ooni.org/api/v2/oonirun/links/10328
 
 - [:material-list-status: OONI 网站检测清单](../taiwan/ooni-checklist.md)
 - [:material-access-point-network: ASNs 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md)
+- [:material-table-search: OONI 测项速查表](../community/ooni-nettests-map.md)
+- [:material-code-json: OONI 测量资料结构导览](../community/ooni-data-format.md)
 - [:material-server-network: 如何搭建 Tor Relay](../community/setup-tor-relay.md)
 
 </div>

--- a/docs/zh-CN/tools/what-is-ooni.md
+++ b/docs/zh-CN/tools/what-is-ooni.md
@@ -27,14 +27,14 @@ OONI 的工作可以拆成四块。核心是 [OONI Probe](https://ooni.org/insta
     </a>
 </figure>
 
-- **Probe：**OONI 检测观察程序。
+- **Probe：**OONI 检测观察程序，检测对象包含网站、通讯软件连线、VPN 连线、连线效能等。
 - **Censor：**资料传输过程中的监控者，可能是公司 IT 网络、电信公司、国家级网络架构。网路干预可透过以下方式进行，结果与目的都是阻止检视网站内容：
     1. DNS 篡改（DNS tampering、DNS 异常）
     2. IP 封锁（DNS tampering、TCP/IP 异常）
     3. HTTP 封锁（HTTP blocking，例如：封锁页面）
     4. 基于 TLS 的干扰（例如 TLS 握手期间 ClientHello 信息后出现连线重置或连线逾时（timeout））
 - **Tor：**[洋葱路由网络](https://zh.wikipedia.org/zh-cn/%E6%B4%8B%E8%91%B1%E8%B7%AF%E7%94%B1){target="_blank"}，将连线请求透过三层节点的转介传送取得资讯。
-- **Helper：**检测目标对象，可能是网站、通讯软件连线、VPN 连线、连线效能等。
+- **Helper：**OONI 架设在外部网络的测量服务器（test helper）。Probe 测完一个网址后，helper 会从未受干预的网络对同一个网址再测一次，两边结果的差异才是判定依据。完整判定机制见 [OONI 怎么判定一个网站被封锁](../community/ooni-blocking-determination.md)。
 
 !!! info "anoni.net 是台湾的社群"
 
@@ -151,5 +151,16 @@ OONI Probe 观测程序提供[移动装置版本](https://ooni.org/install/){tar
 - [:material-list-status: OONI 网站检测清单](../taiwan/ooni-checklist.md)
 - [:material-access-point-network: ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md)
 - [:material-server-network: Tor Relay 观测点](../taiwan/tor-relay-watcher.md)
+
+</div>
+
+## :material-code-json: 想读懂测量资料
+
+<div class="grid cards" markdown>
+
+- [:material-code-json: OONI 测量资料结构导览](../community/ooni-data-format.md)
+- [:material-shield-search: OONI 怎么判定一个网站被封锁](../community/ooni-blocking-determination.md)
+- [:material-table-search: OONI 测项速查表](../community/ooni-nettests-map.md)
+- [:material-database-search: ASN 观测资料撷取与分析](../community/asn-coverage-howto.md)
 
 </div>

--- a/docs/zh-TW/community/asn-coverage-howto.md
+++ b/docs/zh-TW/community/asn-coverage-howto.md
@@ -1,6 +1,6 @@
 ---
 title: ASN 觀測資料擷取與分析
-description: anoni-net/docs 提供的 OONI 資料擷取程式如何設定與使用，是 ASN 觀測分析的延伸操作指南。
+description: anoni-net/docs 提供的 OONI 資料擷取程式如何設定與使用，包含 S3 公開資料集的路徑結構、三種取用路徑的取捨，以及程式輸出的 CSV 欄位格式。
 icon: material/database-search
 ---
 
@@ -14,14 +14,37 @@ icon: material/database-search
 
     下面的指令都在 `anoni-net-docs/asn_coverage/` 目錄下執行。第一次使用先 `cd` 進該目錄、執行 `uv sync` 裝好依賴，接著用 `uv run python ooni.py ...`（或先 `source .venv/bin/activate` 再依下方範例執行）。
 
-## 資料來源
+## 三種取用路徑
 
-OONI Probe 的觀測資料會回傳到 OONI 的 [AWS S3 Open Data](https://registry.opendata.aws/ooni/){target="_blank"} 中儲存。你可以：
+OONI 的觀測資料有三個入口，用途差很多，先選對再動手：
 
-- 直接讀 [OONI Docs](https://docs.ooni.org/data){target="_blank"} 介紹的擷取方式
-- 或透過 [anoni-net/docs 的 asn_coverage 程式](https://github.com/anoni-net/docs/tree/main/asn_coverage){target="_blank"} 來操作
+| 入口 | 適合的情境 | 限制 |
+|---|---|---|
+| [AWS S3 公開資料集](https://registry.opendata.aws/ooni/){target="_blank"} | 批次分析、全量統計、跨時間比對 | 需自行解析，下載量以 GB 計 |
+| [OONI API](https://api.ooni.io/api/v1/measurements){target="_blank"} | 依條件篩選、取單筆完整測量 | 單次回傳筆數有上限 |
+| [OONI Explorer](https://explorer.ooni.org/zh-Hant){target="_blank"} | 人工查閱、確認個別測量 | 不適合程式化取用 |
 
-抓下來的資料每一行是一筆測量，欄位怎麼讀見 [OONI 測量資料結構導覽](./ooni-data-format.md)，該頁用兩筆台灣的真實測量對照說明各欄位含義，並對應到上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的規格文件。
+`asn_coverage` 走的是 S3 路徑，目的是統計覆蓋率而非查單筆。想查單筆或做小量篩選，[OONI 測量資料結構導覽](./ooni-data-format.md) 有 API 的用法。
+
+## S3 資料集的擺放方式
+
+Bucket 名稱是 `ooni-data-eu-fra`，位於 `eu-central-1`，公開讀取不需認證憑證。路徑依「日期、小時、國碼、測項」四層分下去：
+
+```text title="路徑結構"
+raw/{YYYYMMDD}/{HH}/{國碼}/{測項}/{YYYYMMDDHH}_{國碼}_{測項}.n{編號}.{序號}.jsonl.gz
+```
+
+不裝任何工具也能先看一眼裡面有什麼：
+
+```bash title="列出台灣某小時的所有測項"
+curl -s "https://ooni-data-eu-fra.s3.eu-central-1.amazonaws.com/?list-type=2&prefix=raw/20260804/00/TW/&delimiter=/"
+```
+
+台灣在單一小時內通常會有十幾個測項目錄，`webconnectivity` 只是其中之一，同層還有 `tor`、`telegram`、`signal`、`whatsapp`、`dnscheck`、`echcheck`、`openvpn`、`psiphon`、`ndt`、`dash` 等。
+
+每個測項目錄底下同一批資料有兩種封裝，`.jsonl.gz` 與 `.tar.gz`。`.jsonl.gz` 解開後一行一筆測量，適合逐行解析，程式取的是它。單一檔案的量體以 2026-08-04 台灣的 `webconnectivity` 為例約 10 MB，換算成整月全國資料會相當可觀，實際跑之前先估好磁碟與頻寬。
+
+每一行的欄位怎麼讀，見 [OONI 測量資料結構導覽](./ooni-data-format.md)。判定欄位代表什麼，見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)。
 
 ## 擷取與分析指令
 
@@ -38,10 +61,10 @@ python3 ./ooni.py lookback [--units=36] [--loc=TW] [--frame=hours]
 ### 取得區間資料
 
 ```bash title="取得區間資料"
-python3 ./ooni.py span --start=YYYY/MM/DD --end=YYYY/MM/DD [--loc=TW]
+python3 ./ooni.py span --start=YYYY/MM/DD --end=YYYY/MM/DD [--loc=TW] [--chunk=40]
 ```
 
-帶入開始時間（`start`）與結束時間（`end`），取得台灣這期間各小時區間的資料。
+帶入開始時間（`start`）與結束時間（`end`），取得台灣該期間各小時區間的資料。`--chunk` 控制同時處理幾個小時，預設 `40`，網路或記憶體吃緊時調小。
 
 ### 轉換為試算表資料
 
@@ -61,6 +84,45 @@ python3 ./ripe.py save --loc=TW
 
 即可計算占比等統計資料。
 
+## 輸出的 CSV 長什麼樣
+
+`lookback` 與 `span` 產出的檔案有四個欄位，一列代表一個小時：
+
+| 欄位 | 內容 |
+|---|---|
+| `loc` | 國碼，例如 `TW` |
+| `date` | 日期，格式 `YYYY/MM/DD` |
+| `hour` | 小時，格式 `HH` |
+| `statistics` | 該小時的統計結果，內容是一段 JSON |
+
+`statistics` 內含兩份計數，`counts` 依 ASN 統計測量筆數，`network_type` 依連線類型統計。以 2026-08-04 台灣 `00` 時的實際資料為例，該小時共 551 筆測量：
+
+```json title="statistics 欄位展開"
+{"counts": {"AS3462": 300, "AS17716": 100, "AS18419": 100, "AS24158": 51},
+ "network_type": {"mobile": 44, "no_internet": 7}}
+```
+
+兩份計數的總和對不起來屬於正常現象。`network_type` 由 Probe 自行標記，該小時只有 51 筆帶了標記，程式會跳過沒有標記的測量。
+
+巢狀 JSON 不好在試算表裡計算，`sheetrow` 的作用就是把它攤平成一列一個 ASN：
+
+| `loc` | `date` | `hour` | `asn` | `count` |
+|---|---|---|---|---|
+| `TW` | `2026/08/04` | `00` | `AS3462` | `300` |
+| `TW` | `2026/08/04` | `00` | `AS17716` | `100` |
+
+攤平後即可用樞紐分析計算各 ASN 占比、不重複 ASN 數量，再與 `ripe.py` 取得的全量 ASN 清單比對，算出覆蓋率。
+
+## 程式目前的取用範圍
+
+`ooni.py` 現階段只做覆蓋率統計，取用範圍有三個邊界值得知道：
+
+- **只讀 `webconnectivity` 目錄**。同一小時底下其他十幾個測項沒有納入，`tor`、`telegram`、`signal` 等測項的觀測不會出現在統計裡。
+- **每筆測量只取兩個欄位**，`probe_asn` 與 `annotations.network_type`。判定結果所在的 `test_keys` 完全沒有讀取，因此輸出能回答「哪些 ASN 有人在測、測了幾次」，無法回答「測量看到了什麼」。
+- **只取 `.jsonl.gz`**，同目錄的 `.tar.gz` 會跳過。
+
+想擴充的話，最小的一步是在逐行解析時多取 `test_keys.blocking`，統計就能從「測量筆數」延伸到「各 ASN 的異常分布」。要注意 `blocking` 有值不等於封鎖，判讀前提見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)。
+
 ## 範例試算表
 
 實際分析輸出的試算表範例（2023-09 至 2023-12）：
@@ -71,6 +133,8 @@ python3 ./ripe.py save --loc=TW
 
 <div class="grid cards" markdown>
 
+- [:material-code-json: OONI 測量資料結構導覽](./ooni-data-format.md)
+- [:material-shield-search: OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)
 - [:material-access-point-network: ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)
 - [:octicons-mark-github-24: 專案研究預先準備](./setup-repo.md)
 - [:material-hand-heart: 如何參與與認領主題](./how-to-contribute.md)

--- a/docs/zh-TW/community/asn-coverage-howto.md
+++ b/docs/zh-TW/community/asn-coverage-howto.md
@@ -1,22 +1,22 @@
 ---
 title: ASN 觀測資料擷取與分析
-description: anoni-net/docs 提供的 OONI 資料擷取程式如何設定與使用，包含 S3 公開資料集的路徑結構、三種取用路徑的取捨，以及程式輸出的 CSV 欄位格式。
+description: anoni-net/docs 提供的 OONI 資料擷取程式如何設定與使用，包含 S3 公開資料集的路徑結構、三種取用路徑的取捨、程式輸出的 CSV 欄位格式，以及覆蓋率的計算方式。
 icon: material/database-search
 ---
 
 # :material-database-search: ASN 觀測資料擷取與分析
 
-本頁是 [在地脈絡 → ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md) 的技術延伸：當你想自己實際操作抓 OONI 公開資料、計算特定區域 ASN 的觀測覆蓋率時，以下介紹 [anoni-net/docs](https://github.com/anoni-net/docs){target="_blank"} 提供的擷取程式如何設定與使用。
+本頁是 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md) 的技術延伸：當你想自己擷取 OONI 公開資料、計算特定區域 ASN 的觀測覆蓋率時，以下介紹 [anoni-net/docs](https://github.com/anoni-net/docs){target="_blank"} 提供的擷取程式如何設定與使用。
 
 開始前建議先讀 [專案研究預先準備](./setup-repo.md) 把開發環境建好。
 
 !!! tip "執行位置"
 
-    下面的指令都在 `anoni-net-docs/asn_coverage/` 目錄下執行。第一次使用先 `cd` 進該目錄、執行 `uv sync` 裝好依賴，接著用 `uv run python ooni.py ...`（或先 `source .venv/bin/activate` 再依下方範例執行）。
+    下面的指令都在 `anoni-net-docs/asn_coverage/` 目錄下執行。第一次使用先 `cd` 進該目錄，執行 `uv sync` 安裝依賴，接著依下方範例以 `uv run python ooni.py ...` 執行。
 
 ## 三種取用路徑
 
-OONI 的觀測資料有三個入口，用途差很多，先選對再動手：
+OONI 的觀測資料有三個入口，用途差異很大，先選對再著手：
 
 | 入口 | 適合的情境 | 限制 |
 |---|---|---|
@@ -24,25 +24,42 @@ OONI 的觀測資料有三個入口，用途差很多，先選對再動手：
 | [OONI API](https://api.ooni.io/api/v1/measurements){target="_blank"} | 依條件篩選、取單筆完整測量 | 單次回傳筆數有上限 |
 | [OONI Explorer](https://explorer.ooni.org/zh-Hant){target="_blank"} | 人工查閱、確認個別測量 | 不適合程式化取用 |
 
-`asn_coverage` 走的是 S3 路徑，目的是統計覆蓋率而非查單筆。想查單筆或做小量篩選，[OONI 測量資料結構導覽](./ooni-data-format.md) 有 API 的用法。
+`asn_coverage` 採用 S3 路徑，目的是統計覆蓋率而非查單筆。想查單筆或做小量篩選，[OONI 測量資料結構導覽](./ooni-data-format.md) 有 API 的用法。
+
+## 程式能回答什麼
+
+著手之前先確認工具的邊界，`ooni.py` 現階段只做覆蓋率統計，取用範圍有三個限制：
+
+- **只讀 `webconnectivity` 目錄**。同一小時底下其他十幾個測項沒有納入，`tor`、`telegram`、`signal` 等測項的觀測不會出現在統計裡。各測項分別測什麼見 [OONI 測項速查表](./ooni-nettests-map.md)。
+- **每筆測量只取兩個欄位**，`probe_asn` 與 `annotations.network_type`。判定結果所在的 `test_keys` 沒有讀取，因此輸出能回答「哪些 ASN 有人在測、測了幾次」，無法回答「測量看到了什麼」。
+- **只取 `.jsonl.gz`**，同目錄的 `.tar.gz` 會跳過。
+
+若要擴充，最小的一步是在逐行解析時多取 `test_keys.blocking`，統計就能從「測量筆數」延伸到「各 ASN 的異常分布」。`blocking` 未觀測到干預時是布林值 `false`、有干預時是字串，統計前要先統一型別。判讀前提見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)。
 
 ## S3 資料集的擺放方式
 
-Bucket 名稱是 `ooni-data-eu-fra`，位於 `eu-central-1`，公開讀取不需認證憑證。路徑依「日期、小時、國碼、測項」四層分下去：
+Bucket 名稱是 `ooni-data-eu-fra`，位於 `eu-central-1`，公開讀取不需認證憑證。路徑依「日期、小時、國碼、測項」分成四層：
 
 ```text title="路徑結構"
 raw/{YYYYMMDD}/{HH}/{國碼}/{測項}/{YYYYMMDDHH}_{國碼}_{測項}.n{編號}.{序號}.jsonl.gz
 ```
 
-不裝任何工具也能先看一眼裡面有什麼：
+!!! warning "日期與小時都是 UTC"
+
+    路徑中的 `{YYYYMMDD}` 與 `{HH}`、以及後面 CSV 輸出的 `date` 與 `hour` 欄位，全部使用 UTC。程式內部一律以 `arrow.Arrow.utcnow()` 取時間。要分析「台灣某個時段的觀測分布」時記得加 8 小時換算，否則圖表會整體偏移。
+
+檔名尾端的 `.n{編號}.{序號}` 是 OONI 內部的批次編號，解析時可以忽略。
+
+不必安裝任何工具，也能先確認裡面有什麼：
 
 ```bash title="列出台灣某小時的所有測項"
-curl -s "https://ooni-data-eu-fra.s3.eu-central-1.amazonaws.com/?list-type=2&prefix=raw/20260804/00/TW/&delimiter=/"
+curl -s "https://ooni-data-eu-fra.s3.eu-central-1.amazonaws.com/?list-type=2&prefix=raw/20260804/00/TW/&delimiter=/" \
+  | grep -oE '<Prefix>raw/[^<]+</Prefix>'
 ```
 
-台灣在單一小時內通常會有十幾個測項目錄，`webconnectivity` 只是其中之一，同層還有 `tor`、`telegram`、`signal`、`whatsapp`、`dnscheck`、`echcheck`、`openvpn`、`psiphon`、`ndt`、`dash` 等。
+回應是未斷行的 XML，上面接了 `grep` 只取出目錄名稱。台灣在單一小時內通常會有十幾個測項目錄，`webconnectivity` 只是其中之一，同層還有 `tor`、`telegram`、`signal`、`whatsapp`、`dnscheck`、`echcheck`、`openvpn`、`psiphon`、`ndt`、`dash` 等。
 
-每個測項目錄底下同一批資料有兩種封裝，`.jsonl.gz` 與 `.tar.gz`。`.jsonl.gz` 解開後一行一筆測量，適合逐行解析，程式取的是它。單一檔案的量體以 2026-08-04 台灣的 `webconnectivity` 為例約 10 MB，換算成整月全國資料會相當可觀，實際跑之前先估好磁碟與頻寬。
+每個測項目錄底下同一批資料有兩種封裝，`.jsonl.gz` 與 `.tar.gz`。`.jsonl.gz` 解開後一行一筆測量，適合逐行解析，程式取用的正是 `.jsonl.gz`。以 2026-08-04 台灣的 `webconnectivity` 為例，單一檔案約 10 MB，換算成整月全國資料會相當可觀，實際執行前先估算頻寬與執行時間。程式採串流處理，原始檔不會落地保存，最後只輸出 CSV。
 
 每一行的欄位怎麼讀，見 [OONI 測量資料結構導覽](./ooni-data-format.md)。判定欄位代表什麼，見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)。
 
@@ -50,49 +67,43 @@ curl -s "https://ooni-data-eu-fra.s3.eu-central-1.amazonaws.com/?list-type=2&pre
 
 ### 回看觀察資料
 
-```bash title="回看觀察資料"
-python3 ./ooni.py lookback [--units=36] [--loc=TW] [--frame=hours]
+```bash title="回看最近 36 小時"
+uv run python ooni.py lookback --units=36 --loc=TW --frame=hours
 ```
 
-區間單位為小時，預設為 36 個單位（36 小時），區域為台灣（`TW`）。執行後會依單位儲存以下格式的檔案：
+三個參數都可省略，預設值即為上例。`--frame` 決定回溯總長度的單位，可填 `hours`、`days`、`weeks` 等，無論填什麼，資料一律按小時切分。輸出檔名格式：
 
 - `lookback_{loc}_{YYYYMMDD}_{units}_{frame}.csv`
 
+檔名中的 `{YYYYMMDD}` 是執行當日的 UTC 日期，並非資料涵蓋的區間，資料範圍要看檔案內容。檔案寫在目前的工作目錄。
+
 ### 取得區間資料
 
-```bash title="取得區間資料"
-python3 ./ooni.py span --start=YYYY/MM/DD --end=YYYY/MM/DD [--loc=TW] [--chunk=40]
+```bash title="取得指定區間"
+uv run python ooni.py span --start=2026/08/01 --end=2026/08/03 --loc=TW --chunk=40
 ```
 
-帶入開始時間（`start`）與結束時間（`end`），取得台灣該期間各小時區間的資料。`--chunk` 控制同時處理幾個小時，預設 `40`，網路或記憶體吃緊時調小。
+帶入開始時間（`start`）與結束時間（`end`），取得該期間各小時區間的資料。`--chunk` 控制同時處理的小時數，預設 `40`，網路或記憶體不足時調小。輸出檔名格式：
+
+- `span_{loc}_{開始YYYYMMDD}_{結束YYYYMMDD}.csv`
 
 ### 轉換為試算表資料
 
-```bash title="轉換為試算表資料"
-python3 ./ooni.py sheetrow --path={資料路徑}
+```bash title="展開為試算表格式"
+uv run python ooni.py sheetrow --path=./span_TW_20260801_20260803.csv
 ```
 
-將已擷取的資料展開，方便在試算表中計算，會另存一份開頭為 `rows_` 的資料檔案。
+將已擷取的資料展開，方便在試算表中計算。輸出檔名是原檔名前面加上 `rows_`，以上例而言是 `rows_span_TW_20260801_20260803.csv`。
 
-### 計算 ASN 統計
-
-建議使用「取得區間資料」加「轉換為試算表資料」後，可以統計各 ASN 出現的次數與不重複統計計算。再取得目前台灣所有的 ASN 資料：
-
-```bash title="計算統計 ASNs"
-python3 ./ripe.py save --loc=TW
-```
-
-即可計算占比等統計資料。
-
-## 輸出的 CSV 長什麼樣
+## 輸出的 CSV 欄位格式
 
 `lookback` 與 `span` 產出的檔案有四個欄位，一列代表一個小時：
 
 | 欄位 | 內容 |
 |---|---|
 | `loc` | 國碼，例如 `TW` |
-| `date` | 日期，格式 `YYYY/MM/DD` |
-| `hour` | 小時，格式 `HH` |
+| `date` | 日期，格式 `YYYY/MM/DD`，UTC |
+| `hour` | 小時，格式 `HH`，UTC |
 | `statistics` | 該小時的統計結果，內容是一段 JSON |
 
 `statistics` 內含兩份計數，`counts` 依 ASN 統計測量筆數，`network_type` 依連線類型統計。以 2026-08-04 台灣 `00` 時的實際資料為例，該小時共 551 筆測量：
@@ -102,34 +113,44 @@ python3 ./ripe.py save --loc=TW
  "network_type": {"mobile": 44, "no_internet": 7}}
 ```
 
-兩份計數的總和對不起來屬於正常現象。`network_type` 由 Probe 自行標記，該小時只有 51 筆帶了標記，程式會跳過沒有標記的測量。
+兩份計數的總和不一致屬於正常現象。`network_type` 由 Probe 自行標記，行動版 App 通常會寫入，CLI 與桌面版多半不會，上例 551 筆中只有 51 筆帶標記，程式會跳過沒有標記的測量。其中 `no_internet` 代表 Probe 在測量當下判定自身沒有連線。標記涵蓋率不到一成，適合看趨勢，不適合當作行動與固網的比例依據。
 
-巢狀 JSON 不好在試算表裡計算，`sheetrow` 的作用就是把它攤平成一列一個 ASN：
+巢狀 JSON 不易在試算表裡計算，`sheetrow` 的作用就是把它攤平成一列一個 ASN：
 
 | `loc` | `date` | `hour` | `asn` | `count` |
 |---|---|---|---|---|
 | `TW` | `2026/08/04` | `00` | `AS3462` | `300` |
 | `TW` | `2026/08/04` | `00` | `AS17716` | `100` |
 
-攤平後即可用樞紐分析計算各 ASN 占比、不重複 ASN 數量，再與 `ripe.py` 取得的全量 ASN 清單比對，算出覆蓋率。
-
-## 程式目前的取用範圍
-
-`ooni.py` 現階段只做覆蓋率統計，取用範圍有三個邊界值得知道：
-
-- **只讀 `webconnectivity` 目錄**。同一小時底下其他十幾個測項沒有納入，`tor`、`telegram`、`signal` 等測項的觀測不會出現在統計裡。各測項分別測什麼見 [OONI 測項速查表](./ooni-nettests-map.md)。
-- **每筆測量只取兩個欄位**，`probe_asn` 與 `annotations.network_type`。判定結果所在的 `test_keys` 完全沒有讀取，因此輸出能回答「哪些 ASN 有人在測、測了幾次」，無法回答「測量看到了什麼」。
-- **只取 `.jsonl.gz`**，同目錄的 `.tar.gz` 會跳過。
-
-想擴充的話，最小的一步是在逐行解析時多取 `test_keys.blocking`，統計就能從「測量筆數」延伸到「各 ASN 的異常分布」。要注意 `blocking` 有值不等於封鎖，判讀前提見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)。
-
-## 範例試算表
-
 實際分析輸出的試算表範例（2023-09 至 2023-12）：
 
 [:material-google-spreadsheet: 20230901-20231204-TW](https://docs.google.com/spreadsheets/d/1lMDsqX8Oa3GKW68y8TuFeKQW2nKM7X0u4z-RopfJIaA/){ .md-button .md-button--primary target="_blank" }
 
+## 計算 ASN 覆蓋率
+
+覆蓋率需要兩份數字，觀測資料中出現過的不重複 ASN 數，以及該區域登記在案的 ASN 總數。前者從上一節攤平後的 CSV 用樞紐分析取得，後者用 `ripe.py` 向 RIPE NCC 索取：
+
+```bash title="取得該區域的全量 ASN 清單"
+uv run python ripe.py save --loc=TW
+```
+
+輸出檔名為 `asns_{YYYYMMDDTHH}.csv`，六個欄位分別是 `no`、`location`、`org_id`、`registrar`、`reserved`、`name`。
+
+!!! warning "兩邊的 ASN 格式不同，比對前要先統一"
+
+    `ripe.py` 輸出的 `no` 欄位是純數字（`3462`），OONI 資料的 `probe_asn` 帶 `AS` 前綴（`AS3462`）。直接用 VLOOKUP 比對會全部落空，比對前要先替其中一邊補上或去掉 `AS`。
+
+兩份數字備齊後即可計算：
+
+```text title="覆蓋率算式"
+覆蓋率 = 觀測資料中出現的不重複 ASN 數 ÷ 該區域登記的 ASN 總數
+```
+
+以 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md) 引用的 2023-12 報告為例，台灣當時約有 437 組 ASN，觀測資料涵蓋的不重複 ASN 佔 7.32%。你可以用同樣的算式重算近期區間，對照覆蓋率是否改善。
+
 ## 下一步
+
+抓到資料之後，接著看每一行的欄位怎麼讀。
 
 <div class="grid cards" markdown>
 

--- a/docs/zh-TW/community/asn-coverage-howto.md
+++ b/docs/zh-TW/community/asn-coverage-howto.md
@@ -117,7 +117,7 @@ python3 ./ripe.py save --loc=TW
 
 `ooni.py` 現階段只做覆蓋率統計，取用範圍有三個邊界值得知道：
 
-- **只讀 `webconnectivity` 目錄**。同一小時底下其他十幾個測項沒有納入，`tor`、`telegram`、`signal` 等測項的觀測不會出現在統計裡。
+- **只讀 `webconnectivity` 目錄**。同一小時底下其他十幾個測項沒有納入，`tor`、`telegram`、`signal` 等測項的觀測不會出現在統計裡。各測項分別測什麼見 [OONI 測項速查表](./ooni-nettests-map.md)。
 - **每筆測量只取兩個欄位**，`probe_asn` 與 `annotations.network_type`。判定結果所在的 `test_keys` 完全沒有讀取，因此輸出能回答「哪些 ASN 有人在測、測了幾次」，無法回答「測量看到了什麼」。
 - **只取 `.jsonl.gz`**，同目錄的 `.tar.gz` 會跳過。
 
@@ -135,6 +135,7 @@ python3 ./ripe.py save --loc=TW
 
 - [:material-code-json: OONI 測量資料結構導覽](./ooni-data-format.md)
 - [:material-shield-search: OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)
+- [:material-table-search: OONI 測項速查表](./ooni-nettests-map.md)
 - [:material-access-point-network: ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)
 - [:octicons-mark-github-24: 專案研究預先準備](./setup-repo.md)
 - [:material-hand-heart: 如何參與與認領主題](./how-to-contribute.md)

--- a/docs/zh-TW/community/asn-coverage-howto.md
+++ b/docs/zh-TW/community/asn-coverage-howto.md
@@ -21,7 +21,7 @@ OONI Probe 的觀測資料會回傳到 OONI 的 [AWS S3 Open Data](https://regis
 - 直接讀 [OONI Docs](https://docs.ooni.org/data){target="_blank"} 介紹的擷取方式
 - 或透過 [anoni-net/docs 的 asn_coverage 程式](https://github.com/anoni-net/docs/tree/main/asn_coverage){target="_blank"} 來操作
 
-資料欄位結構參考 [ooni/spec](https://github.com/ooni/spec){target="_blank"}。
+抓下來的資料每一行是一筆測量，欄位怎麼讀見 [OONI 測量資料結構導覽](./ooni-data-format.md)，該頁用兩筆台灣的真實測量對照說明各欄位含義，並對應到上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的規格文件。
 
 ## 擷取與分析指令
 

--- a/docs/zh-TW/community/ooni-blocking-determination.md
+++ b/docs/zh-TW/community/ooni-blocking-determination.md
@@ -1,68 +1,74 @@
 ---
 title: OONI 怎麼判定一個網站被封鎖
-description: web_connectivity 的 blocking 欄位怎麼算出來，四種判定各自的證據長什麼樣，以及為什麼 blocking 有值不等於確認封鎖。用六筆真實測量說明判讀方法與常見誤判來源。
+description: 網路連線測試（Web Connectivity）的 blocking 欄位怎麼算出來，四種判定各自對應什麼證據，以及為什麼 blocking 有值不等於確認封鎖。用五筆真實測量說明判讀方法與常見誤判來源。
 icon: material/shield-search
 ---
 
 # :material-shield-search: OONI 怎麼判定一個網站被封鎖
 
-[OONI 測量資料結構導覽](./ooni-data-format.md) 說明了欄位放在哪裡，接下來的問題是欄位值怎麼算出來。看到 `blocking: "dns"` 時，能不能說某個網站在台灣被封鎖了？
+[OONI 測量資料結構導覽](./ooni-data-format.md) 說明了欄位放在哪裡，接下來的問題是欄位值怎麼算出來。看到 `blocking: "dns"` 時，多數情況還不足以斷定某個網站在台灣被封鎖。
 
-答案多半是不能。`blocking` 記錄的是單次測量與對照組不一致，距離「確認封鎖」還有幾步。以下拆解判定機制、四種類型各自的證據形狀，以及把單筆測量推到可信結論需要補上什麼。
+`blocking` 只記錄單次測量與對照組不一致，距離「確認封鎖」還有幾步。以下拆解判定機制、四種類型各自對應的證據，以及把單筆測量推到可信結論需要補上什麼。
 
 ## 判定的基礎：雙邊對照
 
-Probe 單獨測一個網站，無法區分「網站被擋」與「網站本來就掛了」。web_connectivity 的作法是同一個網址測兩次，一次從 Probe 所在的網路，一次請 OONI 的 test helper 從外部網路測，再比對兩邊結果。
+Probe 單獨測一個網站，無法區分「網站遭到干預」與「網站本身無法連線」。`web_connectivity` 的作法是同一個網址測兩次，一次從 Probe 所在的網路，一次請 OONI 的 test helper 從外部網路測，再比對兩邊結果。
 
-test helper 的觀測結果收在 `test_keys.control` 底下，包含它的 DNS 解析結果、TCP 連線狀態與 HTTP 回應。判定欄位全部建立在雙邊差異上：
+test helper 是 OONI 架設在外部網路的測量伺服器，觀測結果收在 `test_keys.control` 底下，包含 DNS 解析結果、TCP 連線狀態與 HTTP 回應。判定欄位全部建立在雙邊差異上：
 
 | 差異出現的位置 | 判定 |
 |---|---|
-| DNS 解析結果對不上 | `blocking: "dns"` |
+| DNS 解析結果不一致 | `blocking: "dns"` |
 | DNS 一致，Probe 連不上但 test helper 連得上 | `blocking: "tcp_ip"` |
 | TCP 連得上，HTTP 階段失敗 | `blocking: "http-failure"` |
-| HTTP 有回應，內容與 test helper 拿到的不同 | `blocking: "http-diff"` |
+| HTTP 有回應，內容與 test helper 取得的不同 | `blocking: "http-diff"` |
 | 兩邊都正常且內容相符 | `blocking: false`、`accessible: true` |
 
-判定順序由前往後，DNS 階段就出問題時不會繼續往下比對。四個 `*_match` 欄位在前三種情況下全是 `null`，原因正是比對在更早的階段就停住了。
+判定順序由前往後，DNS 階段就出問題時不會繼續往下比對。四個 `*_match` 欄位在前三種情況下全是 `null`，原因正是比對在更早的階段就中止。
 
-## 四種判定的證據形狀
+!!! tip "先看 `control` 再看 `blocking`"
 
-以下六筆都是 2026-08-04 的公開測量，可在 [OONI Explorer](https://explorer.ooni.org/zh-Hant){target="_blank"} 查到原始內容。
+    `blocking` 是雙邊比對的結果，不是 Probe 單方面的觀測。判讀任何一筆異常測量時，先確認 `test_keys.control` 裡 test helper 看到什麼，再回頭讀 `blocking`。下一節的 `tcp_ip` 範例會示範，忽略 `control` 會把網站自身的問題誤判成封鎖。
 
-### `dns`：解析結果對不上
+## 四種判定對應的證據
 
-台灣 `https://ntc.party/` 的測量，Probe 對 A 與 AAAA 的查詢都回報 `dns_nxdomain_error`（網域不存在），test helper 那邊查得到，因此 `dns_consistency` 標為 `inconsistent`。
+後續章節引用的五筆測量都是 2026-08-04 的公開資料，可在 [OONI Explorer](https://explorer.ooni.org/zh-Hant){target="_blank"} 查到原始內容。
+
+### `dns`：解析結果不一致
+
+台灣 `https://ntc.party/` 的測量，Probe 對 A 與 AAAA 的查詢都回報 `dns_nxdomain_error`（網域不存在），test helper 端查得到，因此 `dns_consistency` 標為 `inconsistent`。
 
 ```json title="test_keys.queries"
 {"query_type": "A", "failure": "dns_nxdomain_error", "answers": []}
 {"query_type": "AAAA", "failure": "dns_nxdomain_error", "answers": []}
 ```
 
-DNS 判定要留意解析器歸屬。該筆的 `resolver_asn` 是 `AS13335`（Cloudflare），`probe_asn` 才是 `AS3462`（中華電信）。測量者把 DNS 指向境外服務時，DNS 階段的異常未必反映本地電信商的行為。
+DNS 判定要留意解析器歸屬。該筆的 `resolver_asn` 是 `AS13335`（Cloudflare），`probe_asn` 則是 `AS3462`（中華電信）。測量者把 DNS 指向境外服務時，DNS 階段的異常未必反映本地電信商的行為。
 
 ### `tcp_ip`：連不到目標位址
 
 台灣 `http://www.tkec.com.tw/` 的測量判定為 `tcp_ip`，DNS 正常解析到 `210.64.193.1`，Probe 連 `80` 埠逾時。
 
-只看 Probe 端容易誤讀成封鎖，往 `control` 看就會改變結論：
+只看 Probe 端容易誤讀成封鎖，對照 `control` 的結果就會得到不同結論：
 
 ```json title="test_keys.control.tcp_connect"
 {"210.64.193.1:443": {"status": true,  "failure": null},
  "210.64.193.1:80":  {"status": false, "failure": "generic_timeout_error"}}
 ```
 
-test helper 從外部連 `80` 埠同樣逾時，代表該網站的 `80` 埠對全世界都不通，與台灣的網路環境無關。看 `blocking` 之前先看 `control`，是判讀 web_connectivity 最省事的一個習慣。
+test helper 從外部連 `80` 埠同樣逾時，代表該網站的 `80` 埠從外部一樣連不上，與台灣的網路環境無關。同一個 IP 的 `443` 埠兩邊都通，更說明問題出在該埠而非路徑。
 
-### `http-failure`：連得上但要不到內容
+### `http-failure`：連得上但取不到內容
 
-台灣 `https://bit.ly/` 的測量判定為 `http-failure`。DNS 正常，兩個目標 IP 的 `443` 埠都連得上，`control` 顯示 test helper 也連得上，差異出現在 HTTP 階段的 `generic_timeout_error`。
+台灣 `https://bit.ly/` 的測量判定為 `http-failure`。DNS 正常，兩個目標 IP 的 `443` 埠都連得上，`control` 顯示 test helper 端也一樣，差異出現在 HTTP 階段的 `generic_timeout_error`。
 
 連線層沒問題而應用層失敗，常見於伺服器端的速率限制、對特定來源的拒絕服務，以及 TLS 層的中斷。要區分成因需要看 `tls_handshakes` 與 `network_events` 的時序。
 
-### `http-diff`：拿到的內容不一樣
+### `http-diff`：取得的內容不一致
 
-四種類型裡只有 `http-diff` 會讓四個 `*_match` 欄位真的派上用場。印尼 `http://www.sportsinteraction.com/` 的測量是典型例子：
+台灣目前的公開資料裡查不到同類樣態（見文末台灣現況），以下改用印尼的測量說明。
+
+四種類型裡只有 `http-diff` 會讓四個 `*_match` 欄位派上用場。印尼 `http://www.sportsinteraction.com/` 的測量是典型例子：
 
 | 觀測方 | 狀態碼 | 標題 | 內容長度 |
 |---|---|---|---|
@@ -73,7 +79,7 @@ Probe 的請求被重導向到 `http://lamanlabuh.aduankonten.id/`，落在印�
 
 該筆同時示範了單一欄位不可靠：
 
-```
+```text title="四個 *_match 欄位與 body_proportion"
 title_match: false        status_code_match: false
 headers_match: true       body_length_match: true
 body_proportion: 0.9967
@@ -85,55 +91,66 @@ body_proportion: 0.9967
 
 `blocking` 有值而實際上沒有網路干預，是資料集裡的常態。前面 `tkec.com.tw` 的 `80` 埠不通已經是一例，再看一筆更隱蔽的。
 
-埃及 `http://www.newipnow.com/` 的測量判定為 `http-diff`，四個 `*_match` 有三個不符，`body_proportion` 只有 `0.02`。看起來像被塞了封鎖頁，實際內容是：
+埃及 `http://www.newipnow.com/` 的測量判定為 `http-diff`，四個 `*_match` 有三個不符，`body_proportion` 只有 `0.02`。看起來像被插入封鎖頁，實際內容是：
 
 | 觀測方 | 狀態碼 | 標題 |
 |---|---|---|
 | Probe | `520` | `newipnow.com \| 520: Web server is returning an unknown error` |
 | test helper | `200` | `Buy Private Proxies: $0.88 per Dedicated Premium IP - NewIPNow` |
 
-`520` 是 Cloudflare 在來源伺服器異常時回的錯誤頁，該筆的 `probe_asn` 正是 `AS13335`（Cloudflare）。來源網站當下出狀況，與埃及的網路管制無關。
+`520` 是目標網站前方的 Cloudflare 在來源伺服器異常時回應的錯誤頁，代表該網站當下發生異常，與埃及的網路管制無關。另外值得留意的是，該筆的 `probe_asn` 是 `AS13335`（Cloudflare），測量端本身也走在 Cloudflare 的網路上，屬於下面第二類的測量環境因素。
 
 常見的誤判來源可以歸成幾類：
 
 - **來源網站自身狀態**：伺服器錯誤、維護頁、CDN 錯誤頁、地理限制。
 - **測量環境**：Probe 開著 VPN 或 Tor 時，測到的是出口所在地的網路。
-- **網站的動態內容**：輪播廣告、個人化內容、A/B 測試會讓兩邊的內容天然不同。
-- **對照組本身失敗**：`control_failure` 有值時，雙邊比對的前提就不成立。
+- **網站的動態內容**：輪播廣告、個人化內容、A/B 測試會讓兩邊的內容本來就不同。
+- **對照組本身失敗**：`control_failure` 有值時，雙邊比對的前提不成立。
 
-OONI 在資料集層級也處理同一類問題，作法可參考 [OONI 如何分辨壞掉的量測資料](../blog/posts/2026-ooni-faulty-measurements.md)，該文整理了他們用哪些啟發式規則過濾異常投稿。
+OONI 在資料集層級也處理同一類問題，作法可參考 [OONI 如何分辨壞掉的量測資料](../blog/posts/2026-ooni-faulty-measurements.md)，該文整理了 OONI 用哪些啟發式規則過濾異常投稿。
 
 ## 從單筆測量到可信結論
 
 要把觀測推進到「某個網站在某地被封鎖」，單筆資料不夠。實務上補上幾個維度：
 
 1. **跨時間**：同一個網址在數天到數週內反覆出現同樣的判定，才能排除偶發故障。
-2. **跨 ASN**：多家電信商都測到相同結果，指向網路層的普遍行為。只在單一 ASN 出現，比較像該業者的個別設定。
+2. **跨 ASN**：多家電信商都測到相同結果，指向網路層的普遍行為。只在單一 ASN 出現，較可能是該業者的個別設定。
 3. **跨解析器**：換不同 DNS 解析器仍然異常，才能排除解析器自身問題。
 4. **看 `confirmed` 欄位**：OONI 後端會用已知的封鎖告示頁指紋比對測量，命中時把 `confirmed` 標為 `true`。該欄位在 [measurements API](https://api.ooni.io/api/v1/measurements){target="_blank"} 的回應中，屬於後端分析結果，不在 Probe 產生的原始資料裡。
 
-想自己跑跨時間或跨 ASN 的比對，[ASN 觀測資料擷取與分析](./asn-coverage-howto.md) 有批次取用的作法。
+想自己執行跨時間或跨 ASN 的比對，[ASN 觀測資料擷取與分析](./asn-coverage-howto.md) 有批次取用的作法。
 
 !!! warning "`confirmed` 為 `true` 不等於 `http-diff`"
 
-    兩者容易混淆。`confirmed` 標記的依據是封鎖指紋比對，DNS 被導向已知的封鎖用 IP 也會標記為 `confirmed`，判定類型仍是 `dns`。撰稿時抽查伊朗、俄羅斯、土耳其、中國各五筆 `confirmed` 測量，四地的樣本全部落在 `blocking: "dns"`。
+    兩者容易混淆。`confirmed` 標記的依據是封鎖指紋比對，DNS 被導向已知的封鎖用 IP 也會標記為 `confirmed`，判定類型仍是 `dns`。撰稿時抽查伊朗、俄羅斯、土耳其、中國各 5 筆 `confirmed` 測量，樣本全部落在 `blocking: "dns"`。樣本數少，僅能說明兩者並非同一件事，不足以推論一般規律。
 
 ## 台灣現況
 
-撰稿時抽樣觀察台灣的 web_connectivity 資料，有兩個現象值得記錄：
+撰稿時抽樣觀察台灣的 `web_connectivity` 資料，記錄到兩個現象：
 
 - **抽查 100 筆異常測量，`confirmed` 為 `true` 的有 0 筆**，與 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md) 長期以來的描述一致。
-- **抽查 40 筆異常測量的判定分布，`dns` 31 筆、`tcp_ip` 6 筆、`http-failure` 3 筆，`http-diff` 0 筆**。台灣目前的公開觀測資料裡沒有出現重導向到封鎖告示頁的樣態，前面的 `http-diff` 範例才需要引用印尼與埃及的資料。
+- **抽查 40 筆異常測量的判定分布，`dns` 31 筆、`tcp_ip` 6 筆、`http-failure` 3 筆、`http-diff` 0 筆**。台灣目前的公開觀測資料裡沒有出現重導向到封鎖告示頁的樣態，前面的 `http-diff` 範例才需要引用印尼與埃及的資料。
 
-以上是特定時間點的抽樣，樣本量小，僅供理解資料樣態，不足以當作長期趨勢的結論。要做有代表性的統計，需要涵蓋更長時間與更多 ASN，而台灣的觀測本身就存在 [ASN 集中度過高](../taiwan/ooni-asn-coverage.md) 的限制。
+兩組樣本都取自 measurements API 的異常清單，查詢條件如下，你可以自行重新執行確認結論是否仍成立：
+
+```bash title="列出台灣的異常測量"
+curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&anomaly=true&limit=100" \
+  | python3 -m json.tool | head -40
+```
+
+判定分布需要逐筆取 `raw_measurement` 後統計 `test_keys.blocking`，前述 40 筆即以此方式取得。
+
+以上是特定時間點的抽樣，樣本量小，僅供理解資料樣態，不足以當作長期趨勢的結論。要做有代表性的統計，需要涵蓋更長時間與更多 ASN，而台灣的觀測本身就存在 ASN 集中度過高的限制，細節見前面提到的 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)。
 
 ## 延伸閱讀
 
+想自己執行跨時間、跨 ASN 的比對，從擷取指南開始。
+
 <div class="grid cards" markdown>
 
+- [:material-database-search: ASN 觀測資料擷取與分析](./asn-coverage-howto.md)
 - [:material-code-json: OONI 測量資料結構導覽](./ooni-data-format.md)
 - [:material-table-search: OONI 測項速查表](./ooni-nettests-map.md)
-- [:material-database-search: ASN 觀測資料擷取與分析](./asn-coverage-howto.md)
 - [:material-access-point-network: ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)
 - [:material-list-status: OONI 網站檢測清單](../taiwan/ooni-checklist.md)
 

--- a/docs/zh-TW/community/ooni-blocking-determination.md
+++ b/docs/zh-TW/community/ooni-blocking-determination.md
@@ -132,6 +132,7 @@ OONI 在資料集層級也處理同一類問題，作法可參考 [OONI 如何�
 <div class="grid cards" markdown>
 
 - [:material-code-json: OONI 測量資料結構導覽](./ooni-data-format.md)
+- [:material-table-search: OONI 測項速查表](./ooni-nettests-map.md)
 - [:material-database-search: ASN 觀測資料擷取與分析](./asn-coverage-howto.md)
 - [:material-access-point-network: ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)
 - [:material-list-status: OONI 網站檢測清單](../taiwan/ooni-checklist.md)

--- a/docs/zh-TW/community/ooni-blocking-determination.md
+++ b/docs/zh-TW/community/ooni-blocking-determination.md
@@ -1,0 +1,141 @@
+---
+title: OONI 怎麼判定一個網站被封鎖
+description: web_connectivity 的 blocking 欄位怎麼算出來，四種判定各自的證據長什麼樣，以及為什麼 blocking 有值不等於確認封鎖。用六筆真實測量說明判讀方法與常見誤判來源。
+icon: material/shield-search
+---
+
+# :material-shield-search: OONI 怎麼判定一個網站被封鎖
+
+[OONI 測量資料結構導覽](./ooni-data-format.md) 說明了欄位放在哪裡，接下來的問題是欄位值怎麼算出來。看到 `blocking: "dns"` 時，能不能說某個網站在台灣被封鎖了？
+
+答案多半是不能。`blocking` 記錄的是單次測量與對照組不一致，距離「確認封鎖」還有幾步。以下拆解判定機制、四種類型各自的證據形狀，以及把單筆測量推到可信結論需要補上什麼。
+
+## 判定的基礎：雙邊對照
+
+Probe 單獨測一個網站，無法區分「網站被擋」與「網站本來就掛了」。web_connectivity 的作法是同一個網址測兩次，一次從 Probe 所在的網路，一次請 OONI 的 test helper 從外部網路測，再比對兩邊結果。
+
+test helper 的觀測結果收在 `test_keys.control` 底下，包含它的 DNS 解析結果、TCP 連線狀態與 HTTP 回應。判定欄位全部建立在雙邊差異上：
+
+| 差異出現的位置 | 判定 |
+|---|---|
+| DNS 解析結果對不上 | `blocking: "dns"` |
+| DNS 一致，Probe 連不上但 test helper 連得上 | `blocking: "tcp_ip"` |
+| TCP 連得上，HTTP 階段失敗 | `blocking: "http-failure"` |
+| HTTP 有回應，內容與 test helper 拿到的不同 | `blocking: "http-diff"` |
+| 兩邊都正常且內容相符 | `blocking: false`、`accessible: true` |
+
+判定順序由前往後，DNS 階段就出問題時不會繼續往下比對。四個 `*_match` 欄位在前三種情況下全是 `null`，原因正是比對在更早的階段就停住了。
+
+## 四種判定的證據形狀
+
+以下六筆都是 2026-08-04 的公開測量，可在 [OONI Explorer](https://explorer.ooni.org/zh-Hant){target="_blank"} 查到原始內容。
+
+### `dns`：解析結果對不上
+
+台灣 `https://ntc.party/` 的測量，Probe 對 A 與 AAAA 的查詢都回報 `dns_nxdomain_error`（網域不存在），test helper 那邊查得到，因此 `dns_consistency` 標為 `inconsistent`。
+
+```json title="test_keys.queries"
+{"query_type": "A", "failure": "dns_nxdomain_error", "answers": []}
+{"query_type": "AAAA", "failure": "dns_nxdomain_error", "answers": []}
+```
+
+DNS 判定要留意解析器歸屬。該筆的 `resolver_asn` 是 `AS13335`（Cloudflare），`probe_asn` 才是 `AS3462`（中華電信）。測量者把 DNS 指向境外服務時，DNS 階段的異常未必反映本地電信商的行為。
+
+### `tcp_ip`：連不到目標位址
+
+台灣 `http://www.tkec.com.tw/` 的測量判定為 `tcp_ip`，DNS 正常解析到 `210.64.193.1`，Probe 連 `80` 埠逾時。
+
+只看 Probe 端容易誤讀成封鎖，往 `control` 看就會改變結論：
+
+```json title="test_keys.control.tcp_connect"
+{"210.64.193.1:443": {"status": true,  "failure": null},
+ "210.64.193.1:80":  {"status": false, "failure": "generic_timeout_error"}}
+```
+
+test helper 從外部連 `80` 埠同樣逾時，代表該網站的 `80` 埠對全世界都不通，與台灣的網路環境無關。看 `blocking` 之前先看 `control`，是判讀 web_connectivity 最省事的一個習慣。
+
+### `http-failure`：連得上但要不到內容
+
+台灣 `https://bit.ly/` 的測量判定為 `http-failure`。DNS 正常，兩個目標 IP 的 `443` 埠都連得上，`control` 顯示 test helper 也連得上，差異出現在 HTTP 階段的 `generic_timeout_error`。
+
+連線層沒問題而應用層失敗，常見於伺服器端的速率限制、對特定來源的拒絕服務，以及 TLS 層的中斷。要區分成因需要看 `tls_handshakes` 與 `network_events` 的時序。
+
+### `http-diff`：拿到的內容不一樣
+
+四種類型裡只有 `http-diff` 會讓四個 `*_match` 欄位真的派上用場。印尼 `http://www.sportsinteraction.com/` 的測量是典型例子：
+
+| 觀測方 | 狀態碼 | 標題 | 內容長度 |
+|---|---|---|---|
+| Probe | `200` | `Trustpositif` | 7,044 |
+| test helper | `403` | `Maintenance` | 7,067 |
+
+Probe 的請求被重導向到 `http://lamanlabuh.aduankonten.id/`，落在印尼官方的內容申訴網域，頁面標題 `Trustpositif` 是當地網路內容過濾系統的名稱。ISP 在連線途中把使用者導向告示頁，是 `http-diff` 最典型的成因。
+
+該筆同時示範了單一欄位不可靠：
+
+```
+title_match: false        status_code_match: false
+headers_match: true       body_length_match: true
+body_proportion: 0.9967
+```
+
+`body_length_match` 為 `true`、`body_proportion` 逼近 `1`，純粹因為封鎖告示頁與對照組頁面的長度剛好接近。只看長度會得到錯誤結論，四個欄位要一起讀，其中 `title_match` 與 `status_code_match` 的鑑別力通常最高。
+
+## 誤判從哪裡來
+
+`blocking` 有值而實際上沒有網路干預，是資料集裡的常態。前面 `tkec.com.tw` 的 `80` 埠不通已經是一例，再看一筆更隱蔽的。
+
+埃及 `http://www.newipnow.com/` 的測量判定為 `http-diff`，四個 `*_match` 有三個不符，`body_proportion` 只有 `0.02`。看起來像被塞了封鎖頁，實際內容是：
+
+| 觀測方 | 狀態碼 | 標題 |
+|---|---|---|
+| Probe | `520` | `newipnow.com \| 520: Web server is returning an unknown error` |
+| test helper | `200` | `Buy Private Proxies: $0.88 per Dedicated Premium IP - NewIPNow` |
+
+`520` 是 Cloudflare 在來源伺服器異常時回的錯誤頁，該筆的 `probe_asn` 正是 `AS13335`（Cloudflare）。來源網站當下出狀況，與埃及的網路管制無關。
+
+常見的誤判來源可以歸成幾類：
+
+- **來源網站自身狀態**：伺服器錯誤、維護頁、CDN 錯誤頁、地理限制。
+- **測量環境**：Probe 開著 VPN 或 Tor 時，測到的是出口所在地的網路。
+- **網站的動態內容**：輪播廣告、個人化內容、A/B 測試會讓兩邊的內容天然不同。
+- **對照組本身失敗**：`control_failure` 有值時，雙邊比對的前提就不成立。
+
+OONI 在資料集層級也處理同一類問題，作法可參考 [OONI 如何分辨壞掉的量測資料](../blog/posts/2026-ooni-faulty-measurements.md)，該文整理了他們用哪些啟發式規則過濾異常投稿。
+
+## 從單筆測量到可信結論
+
+要把觀測推進到「某個網站在某地被封鎖」，單筆資料不夠。實務上補上幾個維度：
+
+1. **跨時間**：同一個網址在數天到數週內反覆出現同樣的判定，才能排除偶發故障。
+2. **跨 ASN**：多家電信商都測到相同結果，指向網路層的普遍行為。只在單一 ASN 出現，比較像該業者的個別設定。
+3. **跨解析器**：換不同 DNS 解析器仍然異常，才能排除解析器自身問題。
+4. **看 `confirmed` 欄位**：OONI 後端會用已知的封鎖告示頁指紋比對測量，命中時把 `confirmed` 標為 `true`。該欄位在 [measurements API](https://api.ooni.io/api/v1/measurements){target="_blank"} 的回應中，屬於後端分析結果，不在 Probe 產生的原始資料裡。
+
+想自己跑跨時間或跨 ASN 的比對，[ASN 觀測資料擷取與分析](./asn-coverage-howto.md) 有批次取用的作法。
+
+!!! warning "`confirmed` 為 `true` 不等於 `http-diff`"
+
+    兩者容易混淆。`confirmed` 標記的依據是封鎖指紋比對，DNS 被導向已知的封鎖用 IP 也會標記為 `confirmed`，判定類型仍是 `dns`。撰稿時抽查伊朗、俄羅斯、土耳其、中國各五筆 `confirmed` 測量，四地的樣本全部落在 `blocking: "dns"`。
+
+## 台灣現況
+
+撰稿時抽樣觀察台灣的 web_connectivity 資料，有兩個現象值得記錄：
+
+- **抽查 100 筆異常測量，`confirmed` 為 `true` 的有 0 筆**，與 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md) 長期以來的描述一致。
+- **抽查 40 筆異常測量的判定分布，`dns` 31 筆、`tcp_ip` 6 筆、`http-failure` 3 筆，`http-diff` 0 筆**。台灣目前的公開觀測資料裡沒有出現重導向到封鎖告示頁的樣態，前面的 `http-diff` 範例才需要引用印尼與埃及的資料。
+
+以上是特定時間點的抽樣，樣本量小，僅供理解資料樣態，不足以當作長期趨勢的結論。要做有代表性的統計，需要涵蓋更長時間與更多 ASN，而台灣的觀測本身就存在 [ASN 集中度過高](../taiwan/ooni-asn-coverage.md) 的限制。
+
+## 延伸閱讀
+
+<div class="grid cards" markdown>
+
+- [:material-code-json: OONI 測量資料結構導覽](./ooni-data-format.md)
+- [:material-database-search: ASN 觀測資料擷取與分析](./asn-coverage-howto.md)
+- [:material-access-point-network: ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)
+- [:material-list-status: OONI 網站檢測清單](../taiwan/ooni-checklist.md)
+
+</div>
+
+判定演算法的完整定義在上游 [ts-017-web-connectivity](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}，失敗字串的統一命名在 [df-007-errors](https://github.com/ooni/spec/blob/master/data-formats/df-007-errors.md){target="_blank"}。

--- a/docs/zh-TW/community/ooni-data-format.md
+++ b/docs/zh-TW/community/ooni-data-format.md
@@ -6,9 +6,9 @@ icon: material/code-json
 
 # :material-code-json: OONI 測量資料結構導覽
 
-[ASN 觀測資料擷取與分析](./asn-coverage-howto.md) 說明了怎麼把 OONI 公開資料抓下來，抓下來之後會遇到下一個問題：一筆測量有二十多個頂層欄位，`test_keys` 裡還有二十幾個，該看哪一個。
+[ASN 觀測資料擷取與分析](./asn-coverage-howto.md) 說明了如何擷取 OONI 公開資料，取得資料之後會遇到下一個問題：一筆測量有二十多個頂層欄位，`test_keys` 裡還有二十幾個，該看哪一個。
 
-以下用兩筆台灣的真實測量對照，說明一筆 web_connectivity 測量的組成，以及每個欄位對應到上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的哪份規格。看懂之後，你可以自己判斷一筆測量說了什麼，也能決定分析程式該取哪些欄位。
+以下用兩筆台灣的真實測量對照，說明一筆網路連線測試（`web_connectivity`）的組成，以及每個欄位對應到上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的哪份規格。看懂之後，你可以自己判斷一筆測量說了什麼，也能決定分析程式該取哪些欄位。
 
 !!! info "範例資料來源"
 
@@ -24,14 +24,34 @@ icon: material/code-json
 不用一開始就記住所有欄位。一筆測量可以拆成三層來讀：
 
 1. **外殼**：誰在哪裡、用什麼軟體、什麼時候測的。所有測項共用同一套欄位，規格是 [df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"}。
-2. **判定**：測量得出的結論。欄位隨測項而異，全部收在 `test_keys` 底下，web_connectivity 的定義在 [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}。
-3. **證據**：支撐結論的原始紀錄，包含每一次 DNS 查詢、TCP 連線、TLS 握手與 HTTP 請求。同樣放在 `test_keys` 底下，各自對應一份 `df-` 開頭的規格。
+2. **判定**：測量得出的結論。欄位隨測項而異，全部收在 `test_keys` 底下，`web_connectivity` 的定義在 [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}。
+3. **證據**：支撐結論的原始紀錄，包含每一次 DNS 查詢、TCP 連線、TLS 握手與 HTTP 請求，以及對照組的同類紀錄。同樣放在 `test_keys` 底下，各自對應一份 `df-` 開頭的規格。
 
-判定層告訴你結論，證據層讓你驗證結論。兩者分開看，資料就不會亂。
+判定層告訴你結論，證據層讓你驗證結論。兩者分開讀，各欄位的角色就清楚了。
+
+## 自己取一筆來看
+
+邊讀邊對照手上的樣本會快很多。不必先架好環境，用公開 API 就能取得單筆資料。先列出符合條件的測量：
+
+```bash title="列出台灣最近的網路連線測試"
+curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&limit=5" \
+  | python3 -m json.tool | head -40
+```
+
+回應中的 `measurement_uid` 可以換取完整內容：
+
+```bash title="取得單筆完整測量資料"
+curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement_uid>" \
+  | python3 -m json.tool | head -60
+```
+
+原始回應是未斷行的長字串，直接輸出到終端機不易閱讀，上面兩段都接了 `python3 -m json.tool` 排版。加上 `anomaly=true` 可以只列出被判定異常的測量，適合用來找對照範例。把 `probe_cc` 換成所在地區、`probe_asn` 換成自己的 ASN，就能看到本地網路上的觀測紀錄。
+
+需要批次處理大量資料時，改走 AWS S3 公開資料集會更有效率，作法見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
 
 ## 外殼：誰在哪裡測的
 
-外殼層的欄位在所有測項中都一樣，實務上最常用到的欄位如下：
+外殼層的欄位在所有測項中都一樣，實務上最常用到的如下：
 
 | 欄位 | 正常通過那筆 | 判定異常那筆 | 說明 |
 |---|---|---|---|
@@ -47,41 +67,56 @@ icon: material/code-json
 | `measurement_start_time` | `2026-08-04 08:59:30` | `2026-08-04 08:45:45` | 測量開始時間（UTC）|
 | `report_id` | `20260804T062033Z_webconnectivity_TW_3462_n4_uEH5rGoD07cN2oYQ` | `20260804T084446Z_webconnectivity_TW_3462_n4_dFfWCDrwouM0TsT2` | 同一次執行產生的多筆測量共用此值 |
 
-`probe_asn` 與 `resolver_asn` 可能不同，上表就是實例。兩筆都在中華電信的網路上執行，但其中一筆的使用者把 DNS 指向了 Cloudflare。做 ASN 分析時兩個欄位要分開看，混用會讓「哪家電信商的網路上看到什麼」失準。
+`probe_asn` 與 `resolver_asn` 可能不同，上表就是實例。兩筆都在中華電信的網路上執行，但其中一筆的使用者把 DNS 指向 Cloudflare。做 ASN 分析時兩者要分開看，混用會讓「哪家電信商的網路上看到什麼」失準。
 
 !!! note "`probe_ip` 永遠是 `127.0.0.1`"
 
-    OONI 刻意不收集測量者的真實 IP，`probe_ip` 固定寫入本機位址。想追測量來源只能靠 `probe_asn` 加時間，[OONI Run v2 操作說明](../tools/ooni-run-v2.md) 也提醒協助者注意同樣的隱私邊界。
+    OONI 刻意不收集測量者的真實 IP，`probe_ip` 固定寫入本機位址。想追測量來源只能仰賴 `probe_asn` 加時間，同一條隱私邊界在 [OONI Run v2 操作說明](../tools/ooni-run-v2.md) 也提醒協助者留意。
 
 ## 判定：測量得出的結論
 
-`test_keys` 底下有八個欄位負責 web_connectivity 的判定。把兩筆並排，差異一眼可見：
+判定欄位全部收在 `test_keys` 底下。讀之前要先知道一件事：`web_connectivity` 的判定建立在雙邊對照上。Probe 測完之後，OONI 架設在外部網路的測量伺服器（test helper）會對同一個網址再測一次，兩邊結果的差異才是判定的依據。test helper 那一側的紀錄收在 `test_keys.control`，下表的「對照組」指的就是它。
+
+判定結果與內容比對共八個欄位。把兩筆並排，差異一眼可見：
 
 | 欄位 | 正常通過 | 判定異常 | 說明 |
 |---|---|---|---|
-| `blocking` | `false` | `"dns"` | 判定的干預類型，可能值為 `dns`、`tcp_ip`、`http-failure`、`http-diff`，未觀測到干預時為 `false` |
+| `blocking` | `false` | `"dns"` | 判定的干預類型，可能值為 `dns`、`tcp_ip`、`http-failure`、`http-diff`，未觀測到干預時為布林值 `false` |
 | `accessible` | `true` | `false` | 是否取得了合理的回應 |
-| `dns_consistency` | `"consistent"` | `"inconsistent"` | Probe 的 DNS 結果與 test helper 對照後是否一致 |
-| `dns_experiment_failure` | `null` | `"dns_nxdomain_error"` | DNS 階段的失敗原因 |
+| `dns_consistency` | `"consistent"` | `"inconsistent"` | Probe 的 DNS 結果與對照組是否一致 |
 | `title_match` | `true` | `null` | 網頁標題是否與對照組相符 |
 | `headers_match` | `true` | `null` | 回應標頭是否相符 |
 | `status_code_match` | `true` | `null` | HTTP 狀態碼是否相符 |
 | `body_length_match` | `true` | `null` | 回應內容長度是否相近 |
 | `body_proportion` | `1` | `0` | 內容長度與對照組的比值 |
 
-`blocking` 的四種值，對應 [什麼是 OONI](../tools/what-is-ooni.md) 介紹過的四種干預手法：`dns` 是解析被導向錯誤結果、`tcp_ip` 是封包送不到目標位址、`http-failure` 是連線層被中斷、`http-diff` 是拿到的內容與對照組不同（常見於封鎖告示頁）。
+各階段的失敗原因另有三個欄位，判讀時要一起看：
 
-四個 `*_match` 欄位在異常那筆全是 `null`，原因是 DNS 階段就失敗了，連線根本沒建立，後續沒有東西可以比對。看到一整排 `null` 時，往前找第一個非 `null` 的 failure 欄位，那裡才是問題發生的地方。
+| 欄位 | 記錄什麼 |
+|---|---|
+| `dns_experiment_failure` | DNS 階段的失敗原因，判定異常那筆為 `"dns_nxdomain_error"` |
+| `http_experiment_failure` | HTTP 階段的失敗原因，例如 `"generic_timeout_error"` |
+| `control_failure` | 對照組本身是否失敗。有值時雙邊比對的前提不成立，判定結果不可信 |
+
+`blocking` 的四種值分別對應不同階段的異常：`dns` 是解析結果與對照組不一致、`tcp_ip` 是封包送不到目標位址、`http-failure` 是連線建立後 HTTP 階段失敗、`http-diff` 是取得的內容與對照組不同（常見於封鎖告示頁）。四種手法在 [什麼是 OONI](../tools/what-is-ooni.md) 有概念層的介紹。
+
+!!! tip "兩個容易誤判的型別問題"
+
+    `blocking` 未觀測到干預時是布林值 `false`，有干預時是字串。拿它做統計前要先統一處理，否則 `false` 與 `"dns"` 會被算成兩類不同的東西。
+
+    四種值的命名本身不一致，`tcp_ip` 用底線，`http-failure` 與 `http-diff` 用連字號。上游如此定義，照抄即可，不要自行統一。
+
+四個 `*_match` 欄位在異常那筆全是 `null`，原因是 DNS 階段就失敗，連線沒有建立，後續沒有東西可以比對。看到一整排 `null` 時，回頭找測量流程中第一個有值的 failure 欄位，那裡才是問題發生的地方。
 
 !!! warning "異常不等於封鎖"
 
-    `blocking` 有值只代表該筆測量觀測到與對照組不一致，判斷是否真的存在網路干預需要更多佐證。以上表那筆為例，Probe 對 `ntc.party` 的 A 與 AAAA 查詢都回報 `dns_nxdomain_error`（網域不存在），但撰稿時從多個公開 DNS 解析器查詢，該網域可解析到 IPv6 位址。單筆測量無法區分網路干預、解析器當下的暫時狀態，以及網域本身的設定變動。
+    `blocking` 有值只代表該筆測量的結果與對照組不一致，判斷是否真的存在網路干預需要更多佐證。以判定異常那筆為例，Probe 對 `ntc.party` 的 A 與 AAAA 查詢都回報 `dns_nxdomain_error`（網域不存在），但撰稿時從多個公開 DNS 解析器查詢，該網域可解析到 IPv6 位址。單筆測量無法區分網路干預、解析器當下的暫時狀態，以及網域本身的設定變動。
 
-    要下封鎖結論，需要跨時間、跨 ASN、跨解析器的多筆測量交叉比對。判定機制的完整拆解與常見誤判來源見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)，資料集層級的品質控制則可參考 [OONI 談測量結果失準](../blog/posts/2026-ooni-faulty-measurements.md)。
+    要下封鎖結論，需要跨時間、跨 ASN、跨解析器的多筆測量交叉比對。判定機制的完整拆解與常見誤判來源見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)，資料集層級的品質控制則可參考 [OONI 如何分辨壞掉的量測資料](../blog/posts/2026-ooni-faulty-measurements.md)。
 
 ## 證據：支撐結論的原始紀錄
 
-`test_keys` 底下另有幾個陣列欄位，記錄測量過程中每一次網路操作。每個欄位各有一份規格：
+`test_keys` 底下另有幾個欄位，記錄測量過程中每一次網路操作。每個欄位各有一份規格：
 
 | 欄位 | 內容 | 規格 |
 |---|---|---|
@@ -90,6 +125,7 @@ icon: material/code-json
 | `tls_handshakes` | 每一次 TLS 握手的參數、憑證與結果 | [df-006-tlshandshake](https://github.com/ooni/spec/blob/master/data-formats/df-006-tlshandshake.md){target="_blank"} |
 | `requests` | 每一次 HTTP 請求與回應的完整內容 | [df-001-httpt](https://github.com/ooni/spec/blob/master/data-formats/df-001-httpt.md){target="_blank"} |
 | `network_events` | 連線過程的時序事件，用於分析延遲與中斷點 | [df-008-netevents](https://github.com/ooni/spec/blob/master/data-formats/df-008-netevents.md){target="_blank"} |
+| `control` | 對照組的同類紀錄，結構與 Probe 側對應，判定欄位全部由它與 Probe 端的差異算出 | [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} |
 | 各欄位的 `failure` 字串 | 所有失敗原因的統一命名，例如 `dns_nxdomain_error`、`generic_timeout_error`、`ssl_unknown_authority` | [df-007-errors](https://github.com/ooni/spec/blob/master/data-formats/df-007-errors.md){target="_blank"} |
 
 把兩筆的 `queries` 攤開對照，就能看到判定的依據：
@@ -112,37 +148,21 @@ icon: material/code-json
 }
 ```
 
-判定層的 `dns_consistency` 是結論，`queries` 是它的依據。想確認一筆測量的判定是否合理，往證據層看就對了。
+判定層的 `dns_consistency` 是結論，`queries` 與 `control` 是它的依據。想確認一筆測量的判定是否合理，往證據層查驗即可。
 
 ## 版本與相容性
 
-讀 spec 之前先確認版本，能省下不少困惑：
+讀 spec 之前先確認版本，能避免不少困惑：
 
 - **`data_format_version` 目前是 `0.2.0`**。外殼層的欄位定義穩定，[df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"} 可以直接對照。
-- **web_connectivity 實際流通的 `test_version` 是 `0.4.3`**。[ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} 的規格內容已更新為描述 v0.5 演算法，但生產環境仍以 v0.4 為主。spec 明訂新版演算法必須使用不同的 test_keys 欄位，v0.4 的欄位定義保持相容，因此上表的欄位讀法對兩個版本都適用。
+- **`web_connectivity` 實際流通的 `test_version` 是 `0.4.3`**。[ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} 的規格內容已更新為描述 v0.5 演算法，但生產環境仍以 v0.4 為主。spec 明訂新版演算法必須使用不同的 test_keys 欄位，v0.4 的欄位定義保持相容，因此上表的欄位讀法對兩個版本都適用。
 - **`x_` 開頭的欄位不在 spec 內**。實際資料中會看到 `x_dns_runtime`、`x_status`、`x_th_runtime` 等欄位，屬於實作端的實驗性擴充，隨版本增減，分析程式不應依賴它們。
 
-上游 spec 的 master 分支自 2025-06 起沒有新的合併，但 issue 與 PR 討論持續進行（進行中的提案包含 ICMP 資料格式與 DPI 分片測項）。目前的狀態適合當作穩定參考，引用時建議連回上游原文，避免自行複製規格內容而在上游更新後失準。
-
-## 自己取一筆來看
-
-不必先架好環境，用公開 API 就能取得單筆資料。先列出符合條件的測量：
-
-```bash title="列出台灣最近的 web_connectivity 測量"
-curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&limit=5"
-```
-
-回應中的 `measurement_uid` 可以換取完整內容：
-
-```bash title="取得單筆完整測量資料"
-curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement_uid>"
-```
-
-加上 `anomaly=true` 可以只列出被判定異常的測量，適合用來找對照範例。把 `probe_cc` 換成自己所在地區、`probe_asn` 換成自己的 ASN，就能看到自己網路上的觀測紀錄。
-
-需要批次處理大量資料時，改走 AWS S3 公開資料集會更有效率，作法見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
+上游 spec 的 master 分支自 2025-06 起沒有新的合併，但 issue 與 PR 討論持續進行（進行中的提案包含 ICMP 資料格式與 DPI 分片測項）。spec 現階段適合當作穩定參考，引用時建議連回上游原文，避免自行複製規格內容而在上游更新後失準。
 
 ## 延伸閱讀
+
+看懂欄位之後，接著看判定欄位怎麼算出來，以及為什麼有值不等於封鎖。
 
 <div class="grid cards" markdown>
 

--- a/docs/zh-TW/community/ooni-data-format.md
+++ b/docs/zh-TW/community/ooni-data-format.md
@@ -1,0 +1,156 @@
+---
+title: OONI 測量資料結構導覽
+description: 一筆 OONI 測量資料由哪些欄位組成，怎麼從中讀出「誰在哪裡測的」與「測出什麼結果」。用兩筆台灣的真實測量對照說明，並對應到上游 ooni/spec 的規格文件。
+icon: material/code-json
+---
+
+# :material-code-json: OONI 測量資料結構導覽
+
+[ASN 觀測資料擷取與分析](./asn-coverage-howto.md) 說明了怎麼把 OONI 公開資料抓下來，抓下來之後會遇到下一個問題：一筆測量有二十多個頂層欄位，`test_keys` 裡還有二十幾個，該看哪一個。
+
+這頁用兩筆台灣的真實測量對照，說明一筆 web_connectivity 測量的組成，以及每個欄位對應到上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的哪份規格。看懂之後，你可以自己判斷一筆測量說了什麼，也能決定分析程式該取哪些欄位。
+
+!!! info "這頁的範例資料"
+
+    兩筆都是 2026-08-04 由台灣的 OONI Probe 產生的公開資料，可在 [OONI Explorer](https://explorer.ooni.org/zh-Hant){target="_blank"} 查到原始內容。
+
+    | | 正常通過 | 判定異常 |
+    |---|---|---|
+    | 測量對象 | `http://presidentlee.tw/` | `https://ntc.party/` |
+    | `measurement_uid` | `20260804085935.603513_TW_webconnectivity_4a5fd27dec0b32f6` | `20260804084548.416537_TW_webconnectivity_f4e7b0ab3d0251bf` |
+
+## 一筆測量的三層結構
+
+不用一開始就記住所有欄位。一筆測量可以拆成三層來讀：
+
+1. **外殼**：誰在哪裡、用什麼軟體、什麼時候測的。所有測項共用同一套欄位，規格是 [df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"}。
+2. **判定**：這次測量的結論。欄位隨測項而異，全部收在 `test_keys` 底下，web_connectivity 的定義在 [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}。
+3. **證據**：支撐結論的原始紀錄，包含每一次 DNS 查詢、TCP 連線、TLS 握手與 HTTP 請求。同樣放在 `test_keys` 底下，各自對應一份 `df-` 開頭的規格。
+
+判定層告訴你結論，證據層讓你驗證結論。兩者分開看，資料就不會亂。
+
+## 外殼：誰在哪裡測的
+
+外殼層的欄位在所有測項中都一樣。實務上最常用到的是這幾個：
+
+| 欄位 | 正常通過那筆 | 判定異常那筆 | 說明 |
+|---|---|---|---|
+| `probe_cc` | `TW` | `TW` | 測量發生的國家代碼 |
+| `probe_asn` | `AS3462` | `AS3462` | 執行測量的網路所屬 ASN |
+| `probe_network_name` | `Chunghwa Telecom Co., Ltd.` | `Chunghwa Telecom Co., Ltd.` | 該 ASN 的組織名稱 |
+| `resolver_asn` | `AS3462` | `AS13335` | 測量時實際使用的 DNS 解析器所屬 ASN |
+| `resolver_network_name` | `Chunghwa Telecom Co., Ltd.` | `Cloudflare Inc` | 解析器的組織名稱 |
+| `input` | `http://presidentlee.tw/` | `https://ntc.party/` | 這次測量的對象 |
+| `test_name` | `web_connectivity` | `web_connectivity` | 測項名稱 |
+| `software_name` | `ooniprobe-cli` | `ooniprobe-desktop-unattended` | 產生這筆資料的 Probe 種類 |
+| `software_version` | `3.29.1` | `3.26.0` | Probe 版本 |
+| `measurement_start_time` | `2026-08-04 08:59:30` | `2026-08-04 08:45:45` | 測量開始時間（UTC）|
+| `report_id` | `20260804T062033Z_webconnectivity_TW_3462_n4_uEH5rGoD07cN2oYQ` | `20260804T084446Z_webconnectivity_TW_3462_n4_dFfWCDrwouM0TsT2` | 同一次執行產生的多筆測量共用此值 |
+
+`probe_asn` 與 `resolver_asn` 可能不同，上表就是實例。兩筆都在中華電信的網路上執行，但其中一筆的使用者把 DNS 指向了 Cloudflare。做 ASN 分析時這兩個欄位要分開看，混用會讓「哪家電信商的網路上看到什麼」失準。
+
+!!! note "`probe_ip` 永遠是 `127.0.0.1`"
+
+    OONI 刻意不收集測量者的真實 IP，這個欄位固定寫入本機位址。想追測量來源只能靠 `probe_asn` 加時間，這也是 [OONI Run v2 操作說明](../tools/ooni-run-v2.md) 提醒協助者注意的隱私邊界。
+
+## 判定：這次測量的結論
+
+`test_keys` 底下有八個欄位負責 web_connectivity 的判定。把兩筆並排，差異一眼可見：
+
+| 欄位 | 正常通過 | 判定異常 | 說明 |
+|---|---|---|---|
+| `blocking` | `false` | `"dns"` | 判定的干預類型，可能值為 `dns`、`tcp_ip`、`http-failure`、`http-diff`，未觀測到干預時為 `false` |
+| `accessible` | `true` | `false` | 是否取得了合理的回應 |
+| `dns_consistency` | `"consistent"` | `"inconsistent"` | Probe 的 DNS 結果與 test helper 對照後是否一致 |
+| `dns_experiment_failure` | `null` | `"dns_nxdomain_error"` | DNS 階段的失敗原因 |
+| `title_match` | `true` | `null` | 網頁標題是否與對照組相符 |
+| `headers_match` | `true` | `null` | 回應標頭是否相符 |
+| `status_code_match` | `true` | `null` | HTTP 狀態碼是否相符 |
+| `body_length_match` | `true` | `null` | 回應內容長度是否相近 |
+| `body_proportion` | `1` | `0` | 內容長度與對照組的比值 |
+
+`blocking` 的四種值，對應 [什麼是 OONI](../tools/what-is-ooni.md) 介紹過的四種干預手法：`dns` 是解析被導向錯誤結果、`tcp_ip` 是封包送不到目標位址、`http-failure` 是連線層被中斷、`http-diff` 是拿到的內容與對照組不同（常見於封鎖告示頁）。
+
+四個 `*_match` 欄位在異常那筆全是 `null`，原因是 DNS 階段就失敗了，連線根本沒建立，後續沒有東西可以比對。看到一整排 `null` 時，往前找第一個非 `null` 的 failure 欄位，那裡才是問題發生的地方。
+
+!!! warning "異常不等於封鎖"
+
+    `blocking` 有值只代表這次測量觀測到與對照組不一致，判斷是否真的存在網路干預需要更多佐證。以上表那筆為例，Probe 對 `ntc.party` 的 A 與 AAAA 查詢都回報 `dns_nxdomain_error`（網域不存在），但撰稿時從多個公開 DNS 解析器查詢，該網域可解析到 IPv6 位址。單筆測量無法區分網路干預、解析器當下的暫時狀態，以及網域本身的設定變動。
+
+    要下封鎖結論，需要跨時間、跨 ASN、跨解析器的多筆測量交叉比對。誤判的成因與辨識方式可參考 [OONI 談測量結果失準](../blog/posts/2026-ooni-faulty-measurements.md)。
+
+## 證據：支撐結論的原始紀錄
+
+`test_keys` 底下另有幾個陣列欄位，記錄測量過程中每一次網路操作。每個欄位各有一份規格：
+
+| 欄位 | 內容 | 規格 |
+|---|---|---|
+| `queries` | 每一次 DNS 查詢的問題、回應與失敗原因 | [df-002-dnst](https://github.com/ooni/spec/blob/master/data-formats/df-002-dnst.md){target="_blank"} |
+| `tcp_connect` | 每一次 TCP 連線嘗試的目標與結果 | [df-005-tcpconnect](https://github.com/ooni/spec/blob/master/data-formats/df-005-tcpconnect.md){target="_blank"} |
+| `tls_handshakes` | 每一次 TLS 握手的參數、憑證與結果 | [df-006-tlshandshake](https://github.com/ooni/spec/blob/master/data-formats/df-006-tlshandshake.md){target="_blank"} |
+| `requests` | 每一次 HTTP 請求與回應的完整內容 | [df-001-httpt](https://github.com/ooni/spec/blob/master/data-formats/df-001-httpt.md){target="_blank"} |
+| `network_events` | 連線過程的時序事件，用於分析延遲與中斷點 | [df-008-netevents](https://github.com/ooni/spec/blob/master/data-formats/df-008-netevents.md){target="_blank"} |
+| 各欄位的 `failure` 字串 | 所有失敗原因的統一命名，例如 `dns_nxdomain_error`、`generic_timeout_error`、`ssl_unknown_authority` | [df-007-errors](https://github.com/ooni/spec/blob/master/data-formats/df-007-errors.md){target="_blank"} |
+
+把兩筆的 `queries` 攤開對照，就能看到判定的依據：
+
+```json title="正常通過：查到位址"
+{
+  "hostname": "presidentlee.tw",
+  "query_type": "A",
+  "failure": null,
+  "answers": [{"answer_type": "A", "ipv4": "43.254.17.201"}]
+}
+```
+
+```json title="判定異常：查詢落空"
+{
+  "hostname": "ntc.party",
+  "query_type": "A",
+  "failure": "dns_nxdomain_error",
+  "answers": []
+}
+```
+
+判定層的 `dns_consistency` 是結論，`queries` 是它的依據。想確認一筆測量的判定是否合理，往證據層看就對了。
+
+## 版本與相容性
+
+讀 spec 之前先確認版本，這能省下不少困惑：
+
+- **`data_format_version` 目前是 `0.2.0`**。外殼層的欄位定義穩定，[df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"} 可以直接對照。
+- **web_connectivity 實際流通的 `test_version` 是 `0.4.3`**。[ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} 的規格內容已更新為描述 v0.5 演算法，但生產環境仍以 v0.4 為主。spec 明訂新版演算法必須使用不同的 test_keys 欄位，v0.4 的欄位定義保持相容，因此上表的欄位讀法對兩個版本都適用。
+- **`x_` 開頭的欄位不在 spec 內**。實際資料中會看到 `x_dns_runtime`、`x_status`、`x_th_runtime` 等欄位，屬於實作端的實驗性擴充，隨版本增減，分析程式不應依賴它們。
+
+上游 spec 的 master 分支自 2025-06 起沒有新的合併，但 issue 與 PR 討論持續進行（進行中的提案包含 ICMP 資料格式與 DPI 分片測項）。目前的狀態適合當作穩定參考，引用時建議連回上游原文，避免自行複製規格內容而在上游更新後失準。
+
+## 自己取一筆來看
+
+不必先架好環境，用公開 API 就能取得單筆資料。先列出符合條件的測量：
+
+```bash title="列出台灣最近的 web_connectivity 測量"
+curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&limit=5"
+```
+
+回應中的 `measurement_uid` 可以換取完整內容：
+
+```bash title="取得單筆完整測量資料"
+curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement_uid>"
+```
+
+加上 `anomaly=true` 可以只列出被判定異常的測量，適合用來找對照範例。把 `probe_cc` 換成自己所在地區、`probe_asn` 換成自己的 ASN，就能看到自己這條網路上的觀測紀錄。
+
+需要批次處理大量資料時，改走 AWS S3 公開資料集會更有效率，作法見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
+
+## 延伸閱讀
+
+<div class="grid cards" markdown>
+
+- [:material-access-point-network: 什麼是 OONI](../tools/what-is-ooni.md)
+- [:material-database-search: ASN 觀測資料擷取與分析](./asn-coverage-howto.md)
+- [:material-access-point-network: ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)
+- [:material-list-status: OONI 網站檢測清單](../taiwan/ooni-checklist.md)
+
+</div>
+
+上游規格的完整目錄在 [ooni/spec](https://github.com/ooni/spec){target="_blank"}，其中 [data-formats](https://github.com/ooni/spec/tree/master/data-formats){target="_blank"} 收錄資料格式、[nettests](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 收錄各測項的演算法定義。

--- a/docs/zh-TW/community/ooni-data-format.md
+++ b/docs/zh-TW/community/ooni-data-format.md
@@ -77,7 +77,7 @@ icon: material/code-json
 
     `blocking` 有值只代表該筆測量觀測到與對照組不一致，判斷是否真的存在網路干預需要更多佐證。以上表那筆為例，Probe 對 `ntc.party` 的 A 與 AAAA 查詢都回報 `dns_nxdomain_error`（網域不存在），但撰稿時從多個公開 DNS 解析器查詢，該網域可解析到 IPv6 位址。單筆測量無法區分網路干預、解析器當下的暫時狀態，以及網域本身的設定變動。
 
-    要下封鎖結論，需要跨時間、跨 ASN、跨解析器的多筆測量交叉比對。誤判的成因與辨識方式可參考 [OONI 談測量結果失準](../blog/posts/2026-ooni-faulty-measurements.md)。
+    要下封鎖結論，需要跨時間、跨 ASN、跨解析器的多筆測量交叉比對。判定機制的完整拆解與常見誤判來源見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)，資料集層級的品質控制則可參考 [OONI 談測量結果失準](../blog/posts/2026-ooni-faulty-measurements.md)。
 
 ## 證據：支撐結論的原始紀錄
 
@@ -146,6 +146,7 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 
 <div class="grid cards" markdown>
 
+- [:material-shield-search: OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)
 - [:material-access-point-network: 什麼是 OONI](../tools/what-is-ooni.md)
 - [:material-database-search: ASN 觀測資料擷取與分析](./asn-coverage-howto.md)
 - [:material-access-point-network: ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)

--- a/docs/zh-TW/community/ooni-data-format.md
+++ b/docs/zh-TW/community/ooni-data-format.md
@@ -147,6 +147,7 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 <div class="grid cards" markdown>
 
 - [:material-shield-search: OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)
+- [:material-table-search: OONI 測項速查表](./ooni-nettests-map.md)
 - [:material-access-point-network: 什麼是 OONI](../tools/what-is-ooni.md)
 - [:material-database-search: ASN 觀測資料擷取與分析](./asn-coverage-howto.md)
 - [:material-access-point-network: ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)

--- a/docs/zh-TW/community/ooni-data-format.md
+++ b/docs/zh-TW/community/ooni-data-format.md
@@ -8,9 +8,9 @@ icon: material/code-json
 
 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md) 說明了怎麼把 OONI 公開資料抓下來，抓下來之後會遇到下一個問題：一筆測量有二十多個頂層欄位，`test_keys` 裡還有二十幾個，該看哪一個。
 
-這頁用兩筆台灣的真實測量對照，說明一筆 web_connectivity 測量的組成，以及每個欄位對應到上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的哪份規格。看懂之後，你可以自己判斷一筆測量說了什麼，也能決定分析程式該取哪些欄位。
+以下用兩筆台灣的真實測量對照，說明一筆 web_connectivity 測量的組成，以及每個欄位對應到上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的哪份規格。看懂之後，你可以自己判斷一筆測量說了什麼，也能決定分析程式該取哪些欄位。
 
-!!! info "這頁的範例資料"
+!!! info "範例資料來源"
 
     兩筆都是 2026-08-04 由台灣的 OONI Probe 產生的公開資料，可在 [OONI Explorer](https://explorer.ooni.org/zh-Hant){target="_blank"} 查到原始內容。
 
@@ -24,14 +24,14 @@ icon: material/code-json
 不用一開始就記住所有欄位。一筆測量可以拆成三層來讀：
 
 1. **外殼**：誰在哪裡、用什麼軟體、什麼時候測的。所有測項共用同一套欄位，規格是 [df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"}。
-2. **判定**：這次測量的結論。欄位隨測項而異，全部收在 `test_keys` 底下，web_connectivity 的定義在 [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}。
+2. **判定**：測量得出的結論。欄位隨測項而異，全部收在 `test_keys` 底下，web_connectivity 的定義在 [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}。
 3. **證據**：支撐結論的原始紀錄，包含每一次 DNS 查詢、TCP 連線、TLS 握手與 HTTP 請求。同樣放在 `test_keys` 底下，各自對應一份 `df-` 開頭的規格。
 
 判定層告訴你結論，證據層讓你驗證結論。兩者分開看，資料就不會亂。
 
 ## 外殼：誰在哪裡測的
 
-外殼層的欄位在所有測項中都一樣。實務上最常用到的是這幾個：
+外殼層的欄位在所有測項中都一樣，實務上最常用到的欄位如下：
 
 | 欄位 | 正常通過那筆 | 判定異常那筆 | 說明 |
 |---|---|---|---|
@@ -40,20 +40,20 @@ icon: material/code-json
 | `probe_network_name` | `Chunghwa Telecom Co., Ltd.` | `Chunghwa Telecom Co., Ltd.` | 該 ASN 的組織名稱 |
 | `resolver_asn` | `AS3462` | `AS13335` | 測量時實際使用的 DNS 解析器所屬 ASN |
 | `resolver_network_name` | `Chunghwa Telecom Co., Ltd.` | `Cloudflare Inc` | 解析器的組織名稱 |
-| `input` | `http://presidentlee.tw/` | `https://ntc.party/` | 這次測量的對象 |
+| `input` | `http://presidentlee.tw/` | `https://ntc.party/` | 測量對象的網址 |
 | `test_name` | `web_connectivity` | `web_connectivity` | 測項名稱 |
-| `software_name` | `ooniprobe-cli` | `ooniprobe-desktop-unattended` | 產生這筆資料的 Probe 種類 |
+| `software_name` | `ooniprobe-cli` | `ooniprobe-desktop-unattended` | 產生資料的 Probe 種類 |
 | `software_version` | `3.29.1` | `3.26.0` | Probe 版本 |
 | `measurement_start_time` | `2026-08-04 08:59:30` | `2026-08-04 08:45:45` | 測量開始時間（UTC）|
 | `report_id` | `20260804T062033Z_webconnectivity_TW_3462_n4_uEH5rGoD07cN2oYQ` | `20260804T084446Z_webconnectivity_TW_3462_n4_dFfWCDrwouM0TsT2` | 同一次執行產生的多筆測量共用此值 |
 
-`probe_asn` 與 `resolver_asn` 可能不同，上表就是實例。兩筆都在中華電信的網路上執行，但其中一筆的使用者把 DNS 指向了 Cloudflare。做 ASN 分析時這兩個欄位要分開看，混用會讓「哪家電信商的網路上看到什麼」失準。
+`probe_asn` 與 `resolver_asn` 可能不同，上表就是實例。兩筆都在中華電信的網路上執行，但其中一筆的使用者把 DNS 指向了 Cloudflare。做 ASN 分析時兩個欄位要分開看，混用會讓「哪家電信商的網路上看到什麼」失準。
 
 !!! note "`probe_ip` 永遠是 `127.0.0.1`"
 
-    OONI 刻意不收集測量者的真實 IP，這個欄位固定寫入本機位址。想追測量來源只能靠 `probe_asn` 加時間，這也是 [OONI Run v2 操作說明](../tools/ooni-run-v2.md) 提醒協助者注意的隱私邊界。
+    OONI 刻意不收集測量者的真實 IP，`probe_ip` 固定寫入本機位址。想追測量來源只能靠 `probe_asn` 加時間，[OONI Run v2 操作說明](../tools/ooni-run-v2.md) 也提醒協助者注意同樣的隱私邊界。
 
-## 判定：這次測量的結論
+## 判定：測量得出的結論
 
 `test_keys` 底下有八個欄位負責 web_connectivity 的判定。把兩筆並排，差異一眼可見：
 
@@ -75,7 +75,7 @@ icon: material/code-json
 
 !!! warning "異常不等於封鎖"
 
-    `blocking` 有值只代表這次測量觀測到與對照組不一致，判斷是否真的存在網路干預需要更多佐證。以上表那筆為例，Probe 對 `ntc.party` 的 A 與 AAAA 查詢都回報 `dns_nxdomain_error`（網域不存在），但撰稿時從多個公開 DNS 解析器查詢，該網域可解析到 IPv6 位址。單筆測量無法區分網路干預、解析器當下的暫時狀態，以及網域本身的設定變動。
+    `blocking` 有值只代表該筆測量觀測到與對照組不一致，判斷是否真的存在網路干預需要更多佐證。以上表那筆為例，Probe 對 `ntc.party` 的 A 與 AAAA 查詢都回報 `dns_nxdomain_error`（網域不存在），但撰稿時從多個公開 DNS 解析器查詢，該網域可解析到 IPv6 位址。單筆測量無法區分網路干預、解析器當下的暫時狀態，以及網域本身的設定變動。
 
     要下封鎖結論，需要跨時間、跨 ASN、跨解析器的多筆測量交叉比對。誤判的成因與辨識方式可參考 [OONI 談測量結果失準](../blog/posts/2026-ooni-faulty-measurements.md)。
 
@@ -116,7 +116,7 @@ icon: material/code-json
 
 ## 版本與相容性
 
-讀 spec 之前先確認版本，這能省下不少困惑：
+讀 spec 之前先確認版本，能省下不少困惑：
 
 - **`data_format_version` 目前是 `0.2.0`**。外殼層的欄位定義穩定，[df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"} 可以直接對照。
 - **web_connectivity 實際流通的 `test_version` 是 `0.4.3`**。[ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} 的規格內容已更新為描述 v0.5 演算法，但生產環境仍以 v0.4 為主。spec 明訂新版演算法必須使用不同的 test_keys 欄位，v0.4 的欄位定義保持相容，因此上表的欄位讀法對兩個版本都適用。
@@ -138,7 +138,7 @@ curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_conne
 curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement_uid>"
 ```
 
-加上 `anomaly=true` 可以只列出被判定異常的測量，適合用來找對照範例。把 `probe_cc` 換成自己所在地區、`probe_asn` 換成自己的 ASN，就能看到自己這條網路上的觀測紀錄。
+加上 `anomaly=true` 可以只列出被判定異常的測量，適合用來找對照範例。把 `probe_cc` 換成自己所在地區、`probe_asn` 換成自己的 ASN，就能看到自己網路上的觀測紀錄。
 
 需要批次處理大量資料時，改走 AWS S3 公開資料集會更有效率，作法見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
 

--- a/docs/zh-TW/community/ooni-nettests-map.md
+++ b/docs/zh-TW/community/ooni-nettests-map.md
@@ -1,12 +1,12 @@
 ---
 title: OONI 測項速查表
-description: ooni/spec 收錄的 41 個網路測項各自測什麼、哪些還在產出資料、台灣實際跑到哪幾個。附上游規格連結，供挑選測項或解讀資料時對照。
+description: ooni/spec 收錄的 41 個網路測項各自測什麼、哪些還在產出資料、台灣實際測到哪幾個。附上游規格連結，供挑選測項或解讀資料時對照。
 icon: material/table-search
 ---
 
 # :material-table-search: OONI 測項速查表
 
-[ooni/spec](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 的 `nettests` 目錄收錄 41 份測項規格，其中有相當比例已經停止使用。要挑測項或解讀手上的資料時，先知道哪些還在跑，比逐份讀規格有效率。
+[ooni/spec](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 的 `nettests` 目錄收錄 41 份測項規格，其中有相當比例已經停止使用。要挑測項或解讀手上的資料時，先知道哪些還在產出資料，比逐份讀規格有效率。
 
 本頁把 41 份規格整理成一張對照表，標註上游規格的狀態、實際是否還有公開資料，以及台灣觀測到哪幾個。
 
@@ -14,9 +14,29 @@ icon: material/table-search
 
     **spec 狀態**取自各份規格開頭的 `_status_` 標記，分為 `current`、`experimental`、`obsolete` 三種，反映上游對該測項的定位。
 
-    **資料流通**是實測結果，撰稿時（2026-08-04）以 [OONI API](https://api.ooni.io/api/v1/measurements){target="_blank"} 逐一查詢各測項最近的公開測量。兩者可能不一致，後面有專節說明。
+    **資料流通**是實測結果，以撰稿當日（2026-08-04）為快照，透過 [OONI API](https://api.ooni.io/api/v1/measurements){target="_blank"} 盤點各測項最近的公開測量。
 
     **台灣**欄位來自 S3 公開資料集，抽查 2026-08-03 五個時段台灣底下出現過的測項目錄。
+
+## 先看一件事：狀態標記不等於實際有資料
+
+規格標記與實際資料不一致的情況存在，看下面的表格前先知道兩個方向的落差：
+
+- **標為 `current` 卻查不到資料**：`tlsmiddlebox`、`portfiltering`、`captiveportal` 三個。
+- **標為 `experimental` 卻每日都有資料**：`dnscheck`、`echcheck`、`openvpn`、`stunreachability`、`vanilla_tor` 等，資料量與部分 `current` 測項相當。
+
+`experimental` 只反映規格本身的成熟度，與資料量多寡沒有必然關係。要判斷某個測項是否適合用於分析，直接查 API 是否有資料，比看狀態標記可靠。
+
+## 依用途分群
+
+帶著「我想觀測什麼」進來的話，先從下面挑方向，再到表格查細節：
+
+- **網站封鎖偵測**：`web_connectivity`
+- **中間設備與干擾手法**：`http_header_field_manipulation`、`http_invalid_request_line`、`sni_blocking`、`echcheck`
+- **通訊軟體可達性**：`telegram`、`whatsapp`、`signal`、`facebook_messenger`
+- **規避工具可用性**：`tor`、`vanilla_tor`、`torsf`、`psiphon`、`riseupvpn`、`openvpn`
+- **DNS 行為**：`dnscheck`、`dnsping`
+- **連線效能**：`ndt`、`dash`、`stunreachability`、`quicping`
 
 ## 仍在產出資料的測項
 
@@ -32,9 +52,9 @@ icon: material/table-search
 | [`whatsapp`](https://github.com/ooni/spec/blob/master/nettests/ts-018-whatsapp.md){target="_blank"} | WhatsApp 端點與註冊服務可達性 | current | 有 |
 | [`signal`](https://github.com/ooni/spec/blob/master/nettests/ts-029-signal.md){target="_blank"} | Signal 服務端點可達性 | current | 有 |
 | [`facebook_messenger`](https://github.com/ooni/spec/blob/master/nettests/ts-019-facebook-messenger.md){target="_blank"} | Facebook Messenger 端點可達性 | current | 有 |
-| [`dnscheck`](https://github.com/ooni/spec/blob/master/nettests/ts-028-dnscheck.md){target="_blank"} | 指定 DNS 解析器的行為，涵蓋 DoH 與 DoT | experimental | 有 |
+| [`dnscheck`](https://github.com/ooni/spec/blob/master/nettests/ts-028-dnscheck.md){target="_blank"} | 指定 DNS 解析器的行為，涵蓋加密查詢（DoH、DoT） | experimental | 有 |
 | [`dnsping`](https://github.com/ooni/spec/blob/master/nettests/ts-035-dnsping.md){target="_blank"} | DNS 查詢的延遲與回應行為 | experimental | 無 |
-| [`echcheck`](https://github.com/ooni/spec/blob/master/nettests/ts-039-echcheck.md){target="_blank"} | TLS Encrypted Client Hello 的支援與干擾狀況 | experimental | 有 |
+| [`echcheck`](https://github.com/ooni/spec/blob/master/nettests/ts-039-echcheck.md){target="_blank"} | 加密用戶端問候（ECH）的支援與干擾狀況 | experimental | 有 |
 | [`http_header_field_manipulation`](https://github.com/ooni/spec/blob/master/nettests/ts-006-header-field-manipulation.md){target="_blank"} | 中間設備是否竄改 HTTP 標頭 | current | 有 |
 | [`http_invalid_request_line`](https://github.com/ooni/spec/blob/master/nettests/ts-007-http-invalid-request-line.md){target="_blank"} | 中間設備對異常請求行的反應，用於偵測透明代理 | current | 有 |
 | [`openvpn`](https://github.com/ooni/spec/blob/master/nettests/ts-040-openvpn.md){target="_blank"} | OpenVPN 握手能否完成 | experimental | 有 |
@@ -44,6 +64,14 @@ icon: material/table-search
 | [`ndt`](https://github.com/ooni/spec/blob/master/nettests/ts-022-ndt.md){target="_blank"} | 連線速度與效能診斷 | current | 有 |
 | [`dash`](https://github.com/ooni/spec/blob/master/nettests/ts-021-dash.md){target="_blank"} | 影音串流播放品質 | current | 有 |
 | [`browser_web`](https://github.com/ooni/spec/blob/master/nettests/ts-036-browser_web.md){target="_blank"} | 以真實瀏覽器引擎載入網頁 | experimental | 無 |
+
+!!! note "表中出現的縮寫"
+
+    - **DoH、DoT**：把 DNS 查詢包在 HTTPS 或 TLS 裡傳送，避免查詢內容以明文經過網路。詳見 [加密 DNS](../tools/encrypted-dns.md)。
+    - **ECH（Encrypted Client Hello）**：TLS 握手的第一個訊息原本會以明文帶出要連的網域名稱，ECH 把該欄位加密。
+    - **SNI（Server Name Indication）**：TLS 握手時以明文送出的目標網域名稱，常被當成封鎖判斷的依據。
+    - **STUN**：協助裝置找出自己對外 IP 與埠號的協定，WebRTC 通話建立連線時會用到。
+    - **QUIC**：以 UDP 為基礎的傳輸協定，HTTP/3 建立在其上。
 
 ## 偶爾才有資料的測項
 
@@ -66,32 +94,38 @@ icon: material/table-search
 | [`tlsping`](https://github.com/ooni/spec/blob/master/nettests/ts-033-tlsping.md){target="_blank"} | TLS 握手的往返延遲 | experimental |
 | [`simplequicping`](https://github.com/ooni/spec/blob/master/nettests/ts-034-simplequicping.md){target="_blank"} | QUIC 的簡化延遲量測 | experimental |
 
-## 已標記為 obsolete 的歷史測項
+## 標記為 obsolete 的歷史測項
 
-上游標為 `obsolete` 的有 12 份，多數功能已被 `web_connectivity` 吸收，或隨著測量方法演進而退場：`bridget`、DNS Consistency、HTTP Requests、HTTP Host、DNS Spoof、TCP Connect、Multi Protocol Traceroute、Bridge Reachability、DNS Injection、Lantern、Meek Fronted Requests，以及舊版的 OpenVPN Client Test。
+上游標為 `obsolete` 的有 12 份，多數功能已被 `web_connectivity` 吸收，或隨著測量方法演進而退場。處理歷史資料時可能會遇到它們的紀錄，規劃新的觀測時沒有理由採用它們。
 
-處理歷史資料時可能會遇到它們的紀錄，規格留在上游倉庫可供查閱。目前規劃新的觀測時沒有採用的理由。
+| 測項 | 規格 |
+|---|---|
+| bridgeT | [ts-001](https://github.com/ooni/spec/blob/master/nettests/ts-001-bridget.md){target="_blank"} |
+| DNS Consistency | [ts-002](https://github.com/ooni/spec/blob/master/nettests/ts-002-dns-consistency.md){target="_blank"} |
+| HTTP Requests | [ts-003](https://github.com/ooni/spec/blob/master/nettests/ts-003-http-requests.md){target="_blank"} |
+| HTTP Host | [ts-004](https://github.com/ooni/spec/blob/master/nettests/ts-004-http-host.md){target="_blank"} |
+| DNS Spoof | [ts-005](https://github.com/ooni/spec/blob/master/nettests/ts-005-dns-spoof.md){target="_blank"} |
+| TCP Connect | [ts-008](https://github.com/ooni/spec/blob/master/nettests/ts-008-tcp-connect.md){target="_blank"} |
+| Multi Protocol Traceroute | [ts-009](https://github.com/ooni/spec/blob/master/nettests/ts-009-multi-protocol-traceroute.md){target="_blank"} |
+| Bridge Reachability | [ts-011](https://github.com/ooni/spec/blob/master/nettests/ts-011-bridge-reachability.md){target="_blank"} |
+| DNS Injection | [ts-012](https://github.com/ooni/spec/blob/master/nettests/ts-012-dns-injection.md){target="_blank"} |
+| Lantern | [ts-013](https://github.com/ooni/spec/blob/master/nettests/ts-013-lantern.md){target="_blank"} |
+| Meek Fronted Requests | [ts-014](https://github.com/ooni/spec/blob/master/nettests/ts-014-meek-fronted-requests.md){target="_blank"} |
+| OpenVPN Client Test（舊版） | [ts-016](https://github.com/ooni/spec/blob/master/nettests/ts-016-openvpn.md){target="_blank"} |
 
 !!! note "編號重複的兩份 OpenVPN 規格"
 
-    上游有兩份規格都編為 `ts-016`，分別是標為 `obsolete` 的 `ts-016-openvpn.md` 與標為 `experimental` 的 `ts-016-vanilla-tor.md`。現行的 OpenVPN 測項規格是 `ts-040-openvpn.md`，引用時留意不要取到舊的那份。
-
-## spec 狀態與實際流通的落差
-
-規格標記與實際資料兩邊對不上的情況確實存在，挑測項時值得先確認：
-
-- **標為 `current` 卻查不到資料**：`tlsmiddlebox`、`portfiltering`、`captiveportal` 三個。
-- **標為 `experimental` 卻天天有資料**：`dnscheck`、`echcheck`、`openvpn`、`stunreachability`、`vanilla_tor` 等，資料量與部分 `current` 測項相當。
-
-`experimental` 反映的是規格本身的成熟度，與資料量多寡沒有必然關係。要判斷某個測項適不適合拿來分析，直接查 API 有沒有資料比看狀態標記可靠。
+    上游有兩份規格都編為 `ts-016`，分別是上表標為 `obsolete` 的 `ts-016-openvpn.md` 與標為 `experimental` 的 `ts-016-vanilla-tor.md`。現行的 OpenVPN 測項規格是 `ts-040-openvpn.md`，引用時留意不要取到舊的那份。
 
 ## 台灣觀測到哪些測項
 
-抽查 2026-08-03 五個時段，台灣底下出現過 17 個測項目錄：`web_connectivity`、`tor`、`vanilla_tor`、`telegram`、`whatsapp`、`signal`、`facebook_messenger`、`dnscheck`、`echcheck`、`http_header_field_manipulation`、`http_invalid_request_line`、`openvpn`、`psiphon`、`riseupvpn`、`stunreachability`、`ndt`、`dash`。
+抽查 2026-08-03 五個時段，台灣底下出現過 17 個測項（以下用 API 的底線寫法）：`web_connectivity`、`tor`、`vanilla_tor`、`telegram`、`whatsapp`、`signal`、`facebook_messenger`、`dnscheck`、`echcheck`、`http_header_field_manipulation`、`http_invalid_request_line`、`openvpn`、`psiphon`、`riseupvpn`、`stunreachability`、`ndt`、`dash`。
 
 S3 上的目錄名與 `test_name` 寫法不同，目錄名沒有底線（`webconnectivity`、`vanillator`、`facebookmessenger`），API 查詢要用底線形式（`web_connectivity`、`vanilla_tor`、`facebook_messenger`）。取用路徑的細節見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
 
 台灣目前的觀測集中在 `web_connectivity`，其他測項的樣本量偏小。想擴充在地觀測的涵蓋面，`tor` 與 `dnscheck` 是與社群既有主題最接近的兩個方向。
+
+實際執行特定測項有兩條路徑。用 [OONI Probe](https://ooni.org/install/){target="_blank"} 桌面或行動版，在設定裡挑選要啟用的測項。想邀請其他人一起測固定的網址清單，改用 [OONI Run v2](../tools/ooni-run-v2.md) 建立連結分享，社群目前維運的連結 ID 是 `10328`。
 
 ## 延伸閱讀
 
@@ -100,6 +134,7 @@ S3 上的目錄名與 `test_name` 寫法不同，目錄名沒有底線（`webcon
 - [:material-code-json: OONI 測量資料結構導覽](./ooni-data-format.md)
 - [:material-shield-search: OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)
 - [:material-database-search: ASN 觀測資料擷取與分析](./asn-coverage-howto.md)
+- [:material-help-network: OONI Run v2 操作說明](../tools/ooni-run-v2.md)
 - [:material-access-point-network: 什麼是 OONI](../tools/what-is-ooni.md)
 
 </div>

--- a/docs/zh-TW/community/ooni-nettests-map.md
+++ b/docs/zh-TW/community/ooni-nettests-map.md
@@ -1,0 +1,107 @@
+---
+title: OONI 測項速查表
+description: ooni/spec 收錄的 41 個網路測項各自測什麼、哪些還在產出資料、台灣實際跑到哪幾個。附上游規格連結，供挑選測項或解讀資料時對照。
+icon: material/table-search
+---
+
+# :material-table-search: OONI 測項速查表
+
+[ooni/spec](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 的 `nettests` 目錄收錄 41 份測項規格，其中有相當比例已經停止使用。要挑測項或解讀手上的資料時，先知道哪些還在跑，比逐份讀規格有效率。
+
+本頁把 41 份規格整理成一張對照表，標註上游規格的狀態、實際是否還有公開資料，以及台灣觀測到哪幾個。
+
+!!! info "狀態欄位怎麼讀"
+
+    **spec 狀態**取自各份規格開頭的 `_status_` 標記，分為 `current`、`experimental`、`obsolete` 三種，反映上游對該測項的定位。
+
+    **資料流通**是實測結果，撰稿時（2026-08-04）以 [OONI API](https://api.ooni.io/api/v1/measurements){target="_blank"} 逐一查詢各測項最近的公開測量。兩者可能不一致，後面有專節說明。
+
+    **台灣**欄位來自 S3 公開資料集，抽查 2026-08-03 五個時段台灣底下出現過的測項目錄。
+
+## 仍在產出資料的測項
+
+以下測項在撰稿當日都查得到公開測量，是解讀 OONI 資料時最常遇到的一批。
+
+| 測項 | 測什麼 | spec 狀態 | 台灣 |
+|---|---|---|---|
+| [`web_connectivity`](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} | 網站可達性與封鎖判定，資料量最大的測項 | current | 有 |
+| [`tor`](https://github.com/ooni/spec/blob/master/nettests/ts-023-tor.md){target="_blank"} | Tor 目錄權威節點與橋接的可達性 | current | 有 |
+| [`vanilla_tor`](https://github.com/ooni/spec/blob/master/nettests/ts-016-vanilla-tor.md){target="_blank"} | 未經偽裝的 Tor 能否順利啟動連線 | experimental | 有 |
+| [`torsf`](https://github.com/ooni/spec/blob/master/nettests/ts-030-torsf.md){target="_blank"} | 透過 Snowflake 傳輸層的 Tor 連線 | experimental | 無 |
+| [`telegram`](https://github.com/ooni/spec/blob/master/nettests/ts-020-telegram.md){target="_blank"} | Telegram 網頁版與資料中心端點可達性 | current | 有 |
+| [`whatsapp`](https://github.com/ooni/spec/blob/master/nettests/ts-018-whatsapp.md){target="_blank"} | WhatsApp 端點與註冊服務可達性 | current | 有 |
+| [`signal`](https://github.com/ooni/spec/blob/master/nettests/ts-029-signal.md){target="_blank"} | Signal 服務端點可達性 | current | 有 |
+| [`facebook_messenger`](https://github.com/ooni/spec/blob/master/nettests/ts-019-facebook-messenger.md){target="_blank"} | Facebook Messenger 端點可達性 | current | 有 |
+| [`dnscheck`](https://github.com/ooni/spec/blob/master/nettests/ts-028-dnscheck.md){target="_blank"} | 指定 DNS 解析器的行為，涵蓋 DoH 與 DoT | experimental | 有 |
+| [`dnsping`](https://github.com/ooni/spec/blob/master/nettests/ts-035-dnsping.md){target="_blank"} | DNS 查詢的延遲與回應行為 | experimental | 無 |
+| [`echcheck`](https://github.com/ooni/spec/blob/master/nettests/ts-039-echcheck.md){target="_blank"} | TLS Encrypted Client Hello 的支援與干擾狀況 | experimental | 有 |
+| [`http_header_field_manipulation`](https://github.com/ooni/spec/blob/master/nettests/ts-006-header-field-manipulation.md){target="_blank"} | 中間設備是否竄改 HTTP 標頭 | current | 有 |
+| [`http_invalid_request_line`](https://github.com/ooni/spec/blob/master/nettests/ts-007-http-invalid-request-line.md){target="_blank"} | 中間設備對異常請求行的反應，用於偵測透明代理 | current | 有 |
+| [`openvpn`](https://github.com/ooni/spec/blob/master/nettests/ts-040-openvpn.md){target="_blank"} | OpenVPN 握手能否完成 | experimental | 有 |
+| [`psiphon`](https://github.com/ooni/spec/blob/master/nettests/ts-015-psiphon.md){target="_blank"} | Psiphon 規避工具能否建立連線 | current | 有 |
+| [`riseupvpn`](https://github.com/ooni/spec/blob/master/nettests/ts-026-riseupvpn.md){target="_blank"} | RiseupVPN 服務可達性 | current | 有 |
+| [`stunreachability`](https://github.com/ooni/spec/blob/master/nettests/ts-025-stun-reachability.md){target="_blank"} | STUN 伺服器可達性，牽動 WebRTC 通話 | experimental | 有 |
+| [`ndt`](https://github.com/ooni/spec/blob/master/nettests/ts-022-ndt.md){target="_blank"} | 連線速度與效能診斷 | current | 有 |
+| [`dash`](https://github.com/ooni/spec/blob/master/nettests/ts-021-dash.md){target="_blank"} | 影音串流播放品質 | current | 有 |
+| [`browser_web`](https://github.com/ooni/spec/blob/master/nettests/ts-036-browser_web.md){target="_blank"} | 以真實瀏覽器引擎載入網頁 | experimental | 無 |
+
+## 偶爾才有資料的測項
+
+| 測項 | 測什麼 | spec 狀態 | 最近一筆 |
+|---|---|---|---|
+| [`quicping`](https://github.com/ooni/spec/blob/master/nettests/ts-031-quicping.md){target="_blank"} | QUIC 協定的可達性 | experimental | 2026-07-30 |
+| [`sni_blocking`](https://github.com/ooni/spec/blob/master/nettests/ts-024-sni-blocking.md){target="_blank"} | 針對 TLS SNI 欄位的封鎖偵測 | experimental | 2026-07-20 |
+
+## 查不到公開資料的測項
+
+以下七個測項在 API 查不到公開測量。規格仍在上游倉庫裡，設計新測項或研究方法時可以參考。
+
+| 測項 | 測什麼 | spec 狀態 |
+|---|---|---|
+| [`tlsmiddlebox`](https://github.com/ooni/spec/blob/master/nettests/ts-037-tlsmiddlebox.md){target="_blank"} | TLS 連線路徑上的中間設備行為 | current |
+| [`portfiltering`](https://github.com/ooni/spec/blob/master/nettests/ts-038-port-filtering.md){target="_blank"} | 特定連接埠是否被過濾 | current |
+| [`captiveportal`](https://github.com/ooni/spec/blob/master/nettests/ts-010-captive-portal.md){target="_blank"} | 是否處於需要登入的受控網路 | current |
+| [`urlgetter`](https://github.com/ooni/spec/blob/master/nettests/ts-027-urlgetter.md){target="_blank"} | 供其他測項複用的通用抓取元件 | experimental |
+| [`tcpping`](https://github.com/ooni/spec/blob/master/nettests/ts-032-tcpping.md){target="_blank"} | TCP 層的往返延遲 | experimental |
+| [`tlsping`](https://github.com/ooni/spec/blob/master/nettests/ts-033-tlsping.md){target="_blank"} | TLS 握手的往返延遲 | experimental |
+| [`simplequicping`](https://github.com/ooni/spec/blob/master/nettests/ts-034-simplequicping.md){target="_blank"} | QUIC 的簡化延遲量測 | experimental |
+
+## 已標記為 obsolete 的歷史測項
+
+上游標為 `obsolete` 的有 12 份，多數功能已被 `web_connectivity` 吸收，或隨著測量方法演進而退場：`bridget`、DNS Consistency、HTTP Requests、HTTP Host、DNS Spoof、TCP Connect、Multi Protocol Traceroute、Bridge Reachability、DNS Injection、Lantern、Meek Fronted Requests，以及舊版的 OpenVPN Client Test。
+
+處理歷史資料時可能會遇到它們的紀錄，規格留在上游倉庫可供查閱。目前規劃新的觀測時沒有採用的理由。
+
+!!! note "編號重複的兩份 OpenVPN 規格"
+
+    上游有兩份規格都編為 `ts-016`，分別是標為 `obsolete` 的 `ts-016-openvpn.md` 與標為 `experimental` 的 `ts-016-vanilla-tor.md`。現行的 OpenVPN 測項規格是 `ts-040-openvpn.md`，引用時留意不要取到舊的那份。
+
+## spec 狀態與實際流通的落差
+
+規格標記與實際資料兩邊對不上的情況確實存在，挑測項時值得先確認：
+
+- **標為 `current` 卻查不到資料**：`tlsmiddlebox`、`portfiltering`、`captiveportal` 三個。
+- **標為 `experimental` 卻天天有資料**：`dnscheck`、`echcheck`、`openvpn`、`stunreachability`、`vanilla_tor` 等，資料量與部分 `current` 測項相當。
+
+`experimental` 反映的是規格本身的成熟度，與資料量多寡沒有必然關係。要判斷某個測項適不適合拿來分析，直接查 API 有沒有資料比看狀態標記可靠。
+
+## 台灣觀測到哪些測項
+
+抽查 2026-08-03 五個時段，台灣底下出現過 17 個測項目錄：`web_connectivity`、`tor`、`vanilla_tor`、`telegram`、`whatsapp`、`signal`、`facebook_messenger`、`dnscheck`、`echcheck`、`http_header_field_manipulation`、`http_invalid_request_line`、`openvpn`、`psiphon`、`riseupvpn`、`stunreachability`、`ndt`、`dash`。
+
+S3 上的目錄名與 `test_name` 寫法不同，目錄名沒有底線（`webconnectivity`、`vanillator`、`facebookmessenger`），API 查詢要用底線形式（`web_connectivity`、`vanilla_tor`、`facebook_messenger`）。取用路徑的細節見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
+
+台灣目前的觀測集中在 `web_connectivity`，其他測項的樣本量偏小。想擴充在地觀測的涵蓋面，`tor` 與 `dnscheck` 是與社群既有主題最接近的兩個方向。
+
+## 延伸閱讀
+
+<div class="grid cards" markdown>
+
+- [:material-code-json: OONI 測量資料結構導覽](./ooni-data-format.md)
+- [:material-shield-search: OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)
+- [:material-database-search: ASN 觀測資料擷取與分析](./asn-coverage-howto.md)
+- [:material-access-point-network: 什麼是 OONI](../tools/what-is-ooni.md)
+
+</div>
+
+各測項的完整演算法定義在上游 [nettests](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 目錄。測項輸出的共通欄位定義在 [data-formats](https://github.com/ooni/spec/tree/master/data-formats){target="_blank"}。

--- a/docs/zh-TW/taiwan/ooni-asn-coverage.md
+++ b/docs/zh-TW/taiwan/ooni-asn-coverage.md
@@ -50,7 +50,7 @@ icon: material/access-point-network
 
 ## 如何解讀單筆測量資料（進階）
 
-這一節示範如何讀懂一筆原始測量紀錄，適合想自己著手分析的人，一般讀者可以直接跳到下一節。想了解單筆 OONI 測量的內容如何判讀，從 OONI Probe 操作開始：
+以下示範如何讀懂一筆原始測量紀錄，適合想自己著手分析的人，一般讀者可以直接跳到下一節。最快的入門路徑是先產生一筆屬於自己的資料，從 OONI Probe 操作開始：
 
 1. 下載 [OONI Probe](https://ooni.org/install/){target="_blank"}（行動裝置或桌面版本）
 2. 開啟 OONI Probe、選擇「網站」項目並執行檢測
@@ -62,7 +62,7 @@ icon: material/access-point-network
 
 此筆結果為「在 AS3462 上執行檢測失敗」，失敗訊息 `unknown_failure: dial tcp [scrubbed]: connect: host is down`，可斷定為網站已不提供服務。在「DNS 查詢」段落可看到 `www.asap.com.tw` 設定 DNS `A` 指向 `60.250.151.72 (AS3462 (Chunghwa Telecom Co., Ltd.)`，其來自 Cloudflare DNS 的查詢結果。
 
-「原始測量資料」會列出所有檢測項目的細節，有些不會完整顯示在結果頁面，但可從這裡找到更多分析素材。
+「原始測量資料」會列出所有檢測項目的細節，有些不會完整顯示在結果頁面，可從該處找到更多分析素材。
 
 <figure markdown="span">
     <a target="_blank"
@@ -77,9 +77,19 @@ icon: material/access-point-network
 
 !!! question "AS 與 DNS 的差異"
 
-    OONI Probe 會將檢測過程都記錄下來。這個範例顯示：即使透過中華電信網路上網，DNS 查詢服務卻是用 Cloudflare 的。
+    OONI Probe 會將檢測過程都記錄下來。上面的範例顯示，即使透過中華電信網路上網，DNS 查詢服務卻是用 Cloudflare 的。對應到原始資料，`probe_asn` 與 `resolver_asn` 分屬兩個不同的 ASN。
 
     - 問題：網站受到阻擋無法連線存取，是 AS 還是 DNS 的問題呢？
+
+每個欄位分別代表什麼、判定結果又是怎麼算出來的，另有三篇技術文件接續說明：
+
+<div class="grid cards" markdown>
+
+- [:material-code-json: OONI 測量資料結構導覽](../community/ooni-data-format.md)
+- [:material-shield-search: OONI 怎麼判定一個網站被封鎖](../community/ooni-blocking-determination.md)
+- [:material-table-search: OONI 測項速查表](../community/ooni-nettests-map.md)
+
+</div>
 
 ## 想著手分析？
 

--- a/docs/zh-TW/taiwan/ooni-checklist.md
+++ b/docs/zh-TW/taiwan/ooni-checklist.md
@@ -61,6 +61,8 @@ icon: material/list-status
 
 - 想參與名單維護：到 Matrix 的 anoni-net 公開空間表達意願，會有夥伴協助分配對象
 - 想參與技術擷取分析：見 [ASN 自治網路觀測資料分析](./ooni-asn-coverage.md) 與 [ASN 觀測資料擷取與分析](../community/asn-coverage-howto.md)
+- 想讀懂測量資料本身：見 [OONI 測量資料結構導覽](../community/ooni-data-format.md) 與 [OONI 怎麼判定一個網站被封鎖](../community/ooni-blocking-determination.md)
+- 想知道清單以外還有哪些測項：見 [OONI 測項速查表](../community/ooni-nettests-map.md)
 - 想了解整體社群運作：見 [如何參與與認領主題](../community/how-to-contribute.md)
 
 ## 下一步

--- a/docs/zh-TW/tools/ooni-run-v2.md
+++ b/docs/zh-TW/tools/ooni-run-v2.md
@@ -200,6 +200,8 @@ miniooni oonirun -i https://api.ooni.org/api/v2/oonirun/links/10328
 
 - [:material-list-status: OONI 網站檢測清單](../taiwan/ooni-checklist.md)
 - [:material-access-point-network: ASNs 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)
+- [:material-table-search: OONI 測項速查表](../community/ooni-nettests-map.md)
+- [:material-code-json: OONI 測量資料結構導覽](../community/ooni-data-format.md)
 - [:material-server-network: 如何搭建 Tor Relay](../community/setup-tor-relay.md)
 
 </div>

--- a/docs/zh-TW/tools/what-is-ooni.md
+++ b/docs/zh-TW/tools/what-is-ooni.md
@@ -27,14 +27,14 @@ OONI 的工作可以拆成四塊。核心是 [OONI Probe](https://ooni.org/insta
     </a>
 </figure>
 
-- **Probe：**為 OONI 檢測觀察程式。
+- **Probe：**為 OONI 檢測觀察程式，檢測對象包含網站、通訊軟體連線、VPN 連線、連線效能等。
 - **Censor：**為資訊傳輸過程中的監控者，可能為公司 IT 網路、電信公司、國家等級的網路架構。網路干預可透過以下方式進行，但其結果與目的都是阻止檢視網站內容。
     1. DNS 篡改（DNS tampering、DNS 異常）：把網址解析導到錯誤位址，讓你連到假網站或直接連不上。
     2. IP 封鎖（TCP/IP 異常）：直接擋掉目標伺服器的 IP，封包送不到。
     3. HTTP 封鎖（HTTP blocking）：在網頁連線層攔截，常見是跳出一頁封鎖告示。
     4. 基於 TLS 的干擾：在加密連線剛要建立（TLS 握手）時把它切斷，例如 ClientHello 訊息後出現連線重置或連線逾時（timeout）。
 - **Tor：**[洋蔥路由網路](https://zh.wikipedia.org/zh-tw/%E6%B4%8B%E8%91%B1%E8%B7%AF%E7%94%B1 "前往 Wiki 了解更多！"){target="_blank"}，將連線請求透過三層節點的轉介傳送取得資訊。
-- **Helper：**檢測目標對象，可能為網站、通訊軟體連線、VPN 連線、連線效能等。
+- **Helper：**OONI 架設在外部網路的測量伺服器（test helper）。Probe 測完一個網址後，helper 會從未受干預的網路對同一個網址再測一次，兩邊結果的差異才是判定依據。完整判定機制見 [OONI 怎麼判定一個網站被封鎖](../community/ooni-blocking-determination.md)。
 
 在臺灣比較熟悉與類似的阻擋行為與技術如中華電信提供的「[色情守門員](https://hicare.hinet.net/CHT/hicare/){target="_blank"}」、透過 DNS 阻擋廣告、惡意網站的 [AdGuard](https://adguard.com/zh_tw/welcome.html){target="_blank"}、[Pi-Hole](https://pi-hole.net/){target="_blank"}。 或是數位發展部與財團法人臺灣網路資訊中心（TWNIC）進行網域阻擋的[打擊詐騙方式](https://moda.gov.tw/press/press-releases/6303){target="_blank"}，都可算是阻擋網頁瀏覽。
 
@@ -147,5 +147,16 @@ OONI Probe 觀測程式提供[行動裝置版本](https://ooni.org/install/){tar
 - [:material-list-status: OONI 網站檢測清單](../taiwan/ooni-checklist.md)
 - [:material-access-point-network: ASNs 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)
 - [:material-server-network: Tor Relay 觀測點](../taiwan/tor-relay-watcher.md)
+
+</div>
+
+## :material-code-json: 想讀懂測量資料
+
+<div class="grid cards" markdown>
+
+- [:material-code-json: OONI 測量資料結構導覽](../community/ooni-data-format.md)
+- [:material-shield-search: OONI 怎麼判定一個網站被封鎖](../community/ooni-blocking-determination.md)
+- [:material-table-search: OONI 測項速查表](../community/ooni-nettests-map.md)
+- [:material-database-search: ASN 觀測資料擷取與分析](../community/asn-coverage-howto.md)
 
 </div>


### PR DESCRIPTION
## 這批文件解決什麼

社群長期使用 OONI 資料，但文件端一直缺「抓到資料之後怎麼讀」的那一層。既有的 `asn-coverage-howto` 只說明如何擷取，欄位含義僅以一句「參考 ooni/spec」帶過。`asn_coverage/ooni.py` 也只讀 `probe_asn` 與 `annotations.network_type` 兩個欄位，完全沒碰判定結果所在的 `test_keys`。

本 PR 補上四篇技術文件，涵蓋從擷取、解讀欄位、判讀結果到挑選測項的完整路徑。

## 內容

| 檔案 | 說明 | 行數 |
|---|---|---|
| `zh-TW/community/ooni-data-format.md` | 新增。用三層結構（外殼、判定、證據）拆解一筆 web_connectivity 測量，各欄位對應到上游 df-000 至 df-008 規格 | 157 |
| `zh-TW/community/ooni-blocking-determination.md` | 新增。說明 blocking 欄位怎麼算出來，四種類型各配一筆真實測量，並解釋為什麼有值不等於封鎖 | 141 |
| `zh-TW/community/asn-coverage-howto.md` | 補強。新增三種取用路徑對照、S3 四層路徑結構、CSV 輸出格式與程式取用邊界 | 78 → 143 |
| `zh-TW/community/ooni-nettests-map.md` | 新增。41 份測項規格分四組整理，標註 spec 狀態、資料流通與台灣觀測狀況 | 107 |

`mkdocs.yml` 的「動手實作」依閱讀動線加入三個新頁面，排在 `asn-coverage-howto` 之後。

## 資料來源

全部取自實測，文件中沒有任何虛構數值：

- **對照範例**：2026-08-04 台灣 AS3462 的兩筆測量，`presidentlee.tw` 正常通過、`ntc.party` 判定異常
- **四種 blocking 類型**：`dns` 用台灣 `ntc.party`、`tcp_ip` 用台灣 `tkec.com.tw`、`http-failure` 用台灣 `bit.ly`、`http-diff` 用印尼 `sportsinteraction.com`
- **S3 結構**：實地列出 `ooni-data-eu-fra` 的目錄，並下載 2026-08-04 台灣 00 時的 `jsonl.gz`（10.8 MB、551 筆）統計 ASN 分布
- **測項清單**：逐份讀取 41 份規格的 `_status_` 標記，再以 OONI API 於 2026-08-04 逐一查詢各測項最近測量

## 幾個值得注意的發現

**spec 描述 v0.5，生產環境是 v0.4.3。** `ts-017` 的規格內容已更新為描述 web_connectivity v0.5 演算法，但實測資料與 probe-cli master 的 `webconnectivity.go` 都是 `0.4.3`。文件以 v0.4 為主軸並標註落差。

**異常多半不是封鎖。** 文件收錄三筆誤判實例，包含台灣 `tkec.com.tw`（test helper 連 80 埠同樣逾時，代表該站 80 埠對全世界都不通）與埃及 `newipnow.com`（判定 http-diff，實為 Cloudflare 520 錯誤頁）。台灣抽查 100 筆異常測量，`confirmed` 為 true 的有 0 筆。

**spec 狀態與實際流通有落差。** `tlsmiddlebox`、`portfiltering`、`captiveportal` 標為 current 卻查不到公開資料；`dnscheck`、`echcheck`、`openvpn` 等標為 experimental 卻天天有資料。

**上游有兩份規格同編為 `ts-016`。** 現行 OpenVPN 規格是 `ts-040`，文件加了註記避免引用到標為 obsolete 的舊版。

## 驗證

- `mkdocs build --strict` 通過，無壞連結
- 29 個上游 spec 連結逐一核對檔名存在於 ooni/spec，未失效
- 四篇的交叉連結全部可解析
- 依 `contributor-handbook` 的寫作風格規範檢查：無雙破折號、無「不是⋯而是⋯」句型、無全形分號、無全形斜線、無「這⋯」開頭與堆疊

## 後續補上（2026-08-05）

**三語系翻譯完成。** en 與 zh-CN 各補三篇新頁，`mkdocs_en.yml` 與 `mkdocs_cn.yml` 的 nav 同步。過程中發現既有翻譯的落差比預期大：en 與 zh-CN 的 `asn-coverage-howto` 還停在改寫前的版本，指令寫成 `python3 ./ooni.py`，與 zh-TW 已統一的 `uv run python ooni.py` 不一致，zh-CN 該頁的提示框與指令區塊本身也互相矛盾，一併補齊四個新章節。翻譯另外處理三處結構落差：en 的區域頁在 `regional/` 而非 `taiwan/`、en 沒有 `tools/what-is-ooni.md`（改連 OONI 官方 glossary）、OONI Explorer 連結統一為不帶語系區段的形式。

**#186 Helper 定義修正。** `what-is-ooni` 把 Helper 定義成「檢測目標對象」，與 OONI test helper 衝突。頁面配圖 `how-ooni-works.svg` 的四個角色標記正是 Probe、Censor、Helper、Tor，Helper 指的就是 test helper。改寫定義並連向判定判讀指南，原本的檢測對象清單移到 Probe 條目保留。en 沒有該頁，只影響 zh-TW 與 zh-CN。

**#187 入站連結與重複段落。** 三篇新頁先前只有側邊欄 nav 可達，全站沒有任何既有頁指向它們。在 `what-is-ooni`、`ooni-run-v2`、`ooni-checklist`、`ooni-asn-coverage` 四類頁面補上入站連結，三語系同步。同時壓縮 `zh-TW/taiwan/ooni-asn-coverage.md` 與新頁重複的段落，欄位層級的說明改為指向資料結構導覽，保留 OONI Probe 的實機操作步驟。

驗證：`docs_style_lint.py` 掃八個 zh-TW 檔案 0 error 0 warn，`run_zh-tw.sh`、`run_en.sh`、`run_zh-cn.sh` 三份建置腳本（均含 `-s` strict）全部通過，三語系的新頁皆有產出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDKynnUECxWh8c5xBL8Hjh
