### PR TITLE
content(changelog): 新增 Tor Browser 16.0a9 與 Arti 2.5.1

### DIFF
--- a/docs/en/changelog/arti.md
+++ b/docs/en/changelog/arti.md
@@ -31,6 +31,15 @@ Legend: ✅ Done　🟡 In development　⬜ Not implemented
 
 On the client side, Arti's capabilities are now largely on par with c-tor: it works as a SOCKS proxy, connects to and hosts onion services, and runs over bridges and pluggable transports. The project's current focus is the relay side. Relay and directory authority support are still under development, so you cannot yet run a Tor relay with Arti, which still requires c-tor. Arti replaces c-tor's control port with the RPC interface, a different design approach.
 
+## Arti 2.5.1
+
+> 2026-08-03 · [Official CHANGELOG](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/CHANGELOG.md){target="_blank"}
+
+- Fixed an important performance bug: `XON` messages were interpreting bytes-per-second as bits-per-second, causing Arti to send 8x less data than allowed. This is now corrected.
+- Onion services can now be configured to connect to `AF_UNIX` addresses.
+- Clients and onion services can negotiate congestion control and Counter Galois Onion (CGO) encryption with each other when the experimental `hsc-negotiate-extensions` and `hss-negotiate-extensions` features are enabled.
+- Continued progress toward "Arti as a Tor relay," adding infrastructure for validating and handling incoming relay messages.
+
 ## Arti 2.5.0
 
 > 2026-06-30 · [Upstream announcement](https://blog.torproject.org/arti_2_5_0_released/){target="_blank"}

--- a/docs/en/changelog/tor.md
+++ b/docs/en/changelog/tor.md
@@ -8,6 +8,17 @@ icon: simple/torbrowser
 
 Tor Browser, Tor daemon, and Onion service release summaries. Newest at the top. Each entry links back to the full translation.
 
+## Tor Browser 16.0a9 (alpha)
+
+> 2026-07-23 · [Upstream announcement](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}
+
+- The alpha channel is for testing only; regular users should stay on the stable channel (15.x).
+- Major rebase of the Firefox base onto 153.0esr (up from 140.0esr); Android GeckoView also moved to 153.0esr (tor-browser#45101).
+- The Tor Project announced the alpha channel will now track Firefox beta releases and rebase incrementally, instead of jumping a full year of Firefox versions at once, aiming to ship Tor Browser 16.0 stable a month early in September.
+- NoScript updated to 13.6.30.90201984, Go to 1.26.5, and libevent to 2.1.13 in the build toolchain.
+- Android's omni.ja now uses xz compression, saving about 3 MB; only one tracking-related dependency remains, Mozilla Telemetry (disabled by default).
+- Known issues: Firefox branding still appears in some places, and the Android address bar icon currently always shows "insecure" — tap it to verify the certificate manually.
+
 ## Tor Browser 15.0.19
 
 > 2026-07-21 · [Upstream announcement](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}

--- a/docs/zh-CN/changelog/arti.md
+++ b/docs/zh-CN/changelog/arti.md
@@ -31,6 +31,15 @@ Arti 是 Tor Project 从 2021 年开始的计划，把原本用 C 写成的 Tor�
 
 客户端这一侧的能力已大致对齐 c-tor，能当 SOCKS 代理、连接与架设 onion 服务、走桥接与 pluggable transports。计划现在的主力放在中继端，relay 与 directory authority 仍在开发，还无法用 Arti 架设 Tor 中继，这部分目前只能用 c-tor。c-tor 的 control port 在 Arti 改以 RPC 接口取代，设计取向不同。
 
+## Arti 2.5.1
+
+> 2026-08-03 · [官方 CHANGELOG](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/CHANGELOG.md){target="_blank"}
+
+- 修补一个影响性能的重要错误：`XON` 消息原本把「每秒字节」误判为「每秒位」，导致允许传输的数据量少了 8 倍，现已修正。
+- Onion 服务新增可配置连到 `AF_UNIX` 地址。
+- 客户端与 onion 服务之间，在启用实验性 feature（`hsc-negotiate-extensions`、`hss-negotiate-extensions`）时，可协商拥塞控制与 Counter Galois Onion（CGO）加密。
+- 持续往「Arti 作为 Tor 中继」开发，新增验证与处理传入中继消息的基础设施。
+
 ## Arti 2.5.0
 
 > 2026-06-30 · [上游公告](https://blog.torproject.org/arti_2_5_0_released/){target="_blank"}

--- a/docs/zh-CN/changelog/tor.md
+++ b/docs/zh-CN/changelog/tor.md
@@ -8,6 +8,17 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon 与 Onion 服务的版本更新整理。新版本永远在最上面，每个条目附「完整翻译文章」链接。
 
+## Tor Browser 16.0a9（Alpha 测试通道）
+
+> 2026-07-23 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}
+
+- Alpha 通道仅供测试，一般用户请继续用稳定版（15.x）。
+- Firefox 基底大幅 rebase 至 153.0esr（前一版为 140.0esr），Android 版 GeckoView 同步升至 153.0esr（tor-browser#45101）。
+- 官方宣布 Alpha 通道日后改为持续追踪 Firefox beta 版本、逐步小步 rebase，取代过去一次跳过整年版本的做法，目标让 16.0 稳定版于 9 月提前发布。
+- NoScript 升至 13.6.30.90201984，构建工具链的 Go 升至 1.26.5，libevent 升至 2.1.13。
+- Android 版 omni.ja 改用 xz 压缩省下约 3 MB，追踪用途的依赖仅剩 Mozilla Telemetry（默认停用）。
+- 已知问题：部分画面仍残留 Firefox 品牌图示。Android 版网址栏图示目前一律显示「不安全」，需手动点击查验证书。
+
 ## Tor Browser 15.0.19
 
 > 2026-07-21 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}

--- a/docs/zh-TW/changelog/arti.md
+++ b/docs/zh-TW/changelog/arti.md
@@ -31,6 +31,15 @@ Arti 是 Tor Project 從 2021 年開始的計畫，把原本用 C 寫成的 Tor�
 
 用戶端這一側的能力已大致對齊 c-tor，能當 SOCKS 代理、連線與架設 onion 服務、走橋接與 pluggable transports。計畫現在的主力放在中繼端，relay 與 directory authority 仍在開發，還無法用 Arti 架設 Tor 中繼，這部分目前只能用 c-tor。c-tor 的 control port 在 Arti 改以 RPC 介面取代，設計取向不同。
 
+## Arti 2.5.1
+
+> 2026-08-03 · [官方 CHANGELOG](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/CHANGELOG.md){target="_blank"}
+
+- 修補一個影響效能的重要錯誤：`XON` 訊息原本把「每秒位元組」誤判為「每秒位元」，導致允許傳輸的資料量少了 8 倍，現已修正。
+- Onion 服務新增可設定連到 `AF_UNIX` 位址。
+- 用戶端與 onion 服務之間，在啟用實驗性 feature（`hsc-negotiate-extensions`、`hss-negotiate-extensions`）時，可協商壅塞控制與 Counter Galois Onion（CGO）加密。
+- 持續往「Arti 作為 Tor 中繼」開發，新增驗證與處理傳入中繼訊息的基礎設施。
+
 ## Arti 2.5.0
 
 > 2026-06-30 · [上游公告](https://blog.torproject.org/arti_2_5_0_released/){target="_blank"}

--- a/docs/zh-TW/changelog/tor.md
+++ b/docs/zh-TW/changelog/tor.md
@@ -8,6 +8,17 @@ icon: simple/torbrowser
 
 [Tor Browser](../tools/what-is-tor.md)、Tor daemon、Onion 服務的版本發布整理，從上游 release notes 條列摘譯。新版本永遠在最上面。本頁同時收錄穩定版與 Alpha 測試通道，Alpha 條目會在標題標注。
 
+## Tor Browser 16.0a9（Alpha 測試通道）
+
+> 2026-07-23 · [上游公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/){target="_blank"}
+
+- Alpha 通道僅供測試，一般使用者請繼續用穩定版（15.x）。
+- Firefox 基底大幅 rebase 至 153.0esr（前一版為 140.0esr），Android 版 GeckoView 同步升至 153.0esr（tor-browser#45101）。
+- 官方宣布 Alpha 通道日後改為持續追蹤 Firefox beta 版本、逐步小步 rebase，取代過去一次跳過整年版本的做法，目標讓 16.0 穩定版於 9 月提前發布。
+- NoScript 升至 13.6.30.90201984，建置工具鏈的 Go 升至 1.26.5，libevent 升至 2.1.13。
+- Android 版 omni.ja 改用 xz 壓縮省下約 3 MB，追蹤用途的相依套件僅剩 Mozilla Telemetry（預設停用）。
+- 已知問題：部分畫面仍殘留 Firefox 品牌圖示。Android 版網址列圖示目前一律顯示「不安全」，需手動點擊查驗證書。
+
 ## Tor Browser 15.0.19
 
 > 2026-07-21 · [上游公告](https://blog.torproject.org/new-release-tor-browser-15019/){target="_blank"}


### PR DESCRIPTION
## 內容

檢查 `docs/*/changelog/` 追蹤的四個上游，跟頁面上記錄的最新版本比對：

| 專案 | 頁面記錄 | 上游現況 | 結果 |
|---|---|---|---|
| Tor Browser 穩定版 | 15.0.19（2026-07-21） | 15.0.19 | 無變化 |
| Tor Browser Alpha | 16.0a8（2026-07-02） | **16.0a9（2026-07-23）** | **新增** |
| Tails | 7.10（2026-07-23） | 7.10 | 無變化 |
| Arti | 2.5.0（2026-06-30） | **2.5.1（2026-08-03）** | **新增** |
| OONI Probe | 6.1.1（2026-07-07） | 6.1.1 | 無變化 |

新增兩筆條目，三語系（zh-TW、zh-CN、en）同步：

### Tor Browser 16.0a9（Alpha）

Firefox 基底從 140.0esr 大幅 rebase 到 153.0esr，官方同時宣布日後 Alpha 通道改為持續追蹤 Firefox beta、逐步小步 rebase，取代過去一次跳過整年版本的做法，目標讓 16.0 穩定版於 9 月提前發布。來源：[官方部落格公告](https://blog.torproject.org/new-alpha-release-tor-browser-160a9/)。

### Arti 2.5.1

純 patch release，修補 `XON` 訊息把「每秒位元組」誤判為「每秒位元」的效能錯誤（實際傳輸量少了 8 倍），並讓 onion 服務支援 `AF_UNIX` 位址設定與壅塞控制／CGO 加密協商。這次沒有對應的 blog.torproject.org 公告，改引官方 [GitLab CHANGELOG](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/CHANGELOG.md) 為來源（該網域對一般自動化請求回 403，這次改用 GitLab REST API 取得原始內容核對版本與日期）。

## 驗證

- [x] `python3 tools/docs_style_lint.py` 6 個變更檔案：0 error、0 warn
- [x] 三語系 `mkdocs build` 皆 exit 0（strict 模式的 abort 是既有 cairo 警告，過濾後無新增警告）
- [x] 六個檔案的渲染輸出逐一 grep 確認新條目正確顯示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzFgTGBpSpj7rNL1iQUsob