### PR TITLE
content(blog): 翻譯 Snowflake Volunteer Android App 上線公告

### DIFF
--- a/docs/en/blog/posts/snowflake-volunteer-android-app.md
+++ b/docs/en/blog/posts/snowflake-volunteer-android-app.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-04
+date: 2026-08-05
 authors:
     - anoni-net
 categories:

--- a/docs/en/blog/posts/snowflake-volunteer-android-app.md
+++ b/docs/en/blog/posts/snowflake-volunteer-android-app.md
@@ -1,0 +1,81 @@
+---
+date: 2026-08-04
+authors:
+    - anoni-net
+categories:
+    - Update
+    - Tor
+    - Translated Article
+slug: snowflake-volunteer-android-app
+image: "assets/images/tor.webp"
+summary: "Tor Project shipped Snowflake Volunteer, a standalone Android app for running a Snowflake bridge. In its first three months, daily volunteer proxies grew from about 1,300 to about 1,700, up 29% in a month."
+description: "Snowflake Volunteer turns being a Snowflake bridge into a single-purpose Android app. We cover what it does, the early growth numbers, and who in our region is actually well positioned to run it."
+---
+
+# Snowflake gets a dedicated app, and the volunteer pool grew 29% in a month
+
+!!! info ""
+
+    This post is based on the Tor Project announcement:
+
+    - [Snowflake Volunteer, an Android app to help people bypass censorship | August 3, 2026](https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/){target="_blank"}
+
+<figure markdown="span">
+    <a href="https://forum.torproject.org/uploads/default/original/2X/c/c9143874b416a1c6e0d676145c11846ad63bad39.jpeg" target="_blank">
+        <img src="https://forum.torproject.org/uploads/default/original/2X/c/c9143874b416a1c6e0d676145c11846ad63bad39.jpeg"
+            alt="Snowflake Volunteer promotional graphic showing several phone mockups of the app's enable toggle, settings screen, and statistics screen"
+            style="border-radius: 10px;">
+    </a>
+    <figcaption>Image source: <a target="_blank" href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/">Tor Project Blog</a>.</figcaption>
+</figure>
+
+We've [written before](iran-blackout-webtunnel.md) that [Snowflake](../../tools/tor-snowflake.md) is the lowest-barrier way to help people reach Tor: open a browser tab, leave it running, and you're relaying anonymous traffic. On 3 August, Tor Project lowered that barrier again with **Snowflake Volunteer**, a standalone Android app whose only job is being a Snowflake bridge.
+
+<!-- more -->
+
+## Why a dedicated app
+
+Snowflake works by disguising a user's traffic as a video call and routing it through volunteer-run proxies over short-lived connections, which makes it harder for censors to detect and block. That depends on a large, steady pool of volunteers. In the first half of 2026, the Snowflake broker saw an average of roughly 146,000 unique volunteer proxy IPs check in per day[^1], with about a third of that coming from [Orbot's Kindness Mode](https://orbot.app/en/kindness/){target="_blank"}.
+
+Portuguese app studio [Bloco](https://www.bloco.io/){target="_blank"} noticed how much Kindness Mode alone contributed and asked whether a single-purpose app could do even more. Building on the Guardian Project's [IPtProxy](https://github.com/tladesignz/IPtProxy){target="_blank"} library, Bloco focused on three things: keeping the app alive in the background without draining the battery, making the settings legible enough that anyone can configure it correctly, and showing volunteers a running tally of how much they've helped.
+
+<figure markdown="span">
+    <a href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/features-overview.png" target="_blank">
+        <img src="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/features-overview.png"
+            alt="Three screenshots of the Snowflake Volunteer app: the main screen showing people helped and traffic stats, the settings screen with background-run, Wi-Fi-only, and charging-only toggles, and a statistics screen listing daily connections and traffic"
+            style="border-radius: 10px;">
+    </a>
+    <figcaption>The app's main screen, settings, and statistics view. Image source: <a target="_blank" href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/">Tor Project Blog</a>.</figcaption>
+</figure>
+
+The result gives volunteers real control: run only in the background, restrict to unmetered Wi-Fi, run only while charging, or cap how many people it helps at once.
+
+## The number that matters: +29% in a month
+
+Snowflake Volunteer launched publicly in April after a round of community testing. Daily unique volunteer IPs went from about 1,300 in May to about 1,700 in June, a 29% increase in one month, with single-day peaks above 2,100. That's a meaningful jump for a channel that previously only existed as a browser extension, a website widget, a desktop CLI tool, or Orbot's Kindness Mode. It suggests a chunk of would-be volunteers were simply waiting for an option that fit how they actually use their devices, phone-first, not desktop-first.
+
+The app currently ships in 8 languages (Chinese, English, French, German, Japanese, Portuguese, Turkish, and Vietnamese), and the project is looking for more translators via [Weblate](https://hosted.weblate.org/projects/snowflake-volunteers/){target="_blank"}.
+
+## Who in our region should actually install this
+
+A phone that can run this app in the background needs unrestricted outbound connectivity, the same requirement as running Snowflake in a browser tab. That describes a lot of readers in Taiwan and across East and Southeast Asia, but not everyone: if your own network sits behind a national firewall, you may not be able to reach the Snowflake broker reliably in the first place, and running circumvention infrastructure from inside a heavily censored network carries risk that has nothing to do with the app's technical design.
+
+For readers in Hong Kong specifically, the same caveat we've flagged for browser-based Snowflake still applies here: installing this app means your device is relaying Tor traffic on behalf of people in censored regions, and that fact alone could draw scrutiny if your device were ever searched under national-security-related powers. Weigh that before installing.
+
+For everyone else with a spare Android phone and a connection that isn't itself under heavy censorship, this is about as close to zero-effort volunteering gets: install it, flip the toggle, and leave it charging overnight.
+
+## Getting the app
+
+Snowflake Volunteer is on [F-Droid](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"} and [Google Play](https://play.google.com/store/apps/details?id=io.bloco.snowflake){target="_blank"}, and the source is on [GitHub](https://github.com/blocoio/snowflake){target="_blank"} if you'd rather build it yourself or [file an issue](https://github.com/blocoio/snowflake/issues/new){target="_blank"}.
+
+## Related reading
+
+- [Tor Snowflake bridge](../../tools/tor-snowflake.md): how the browser-tab version works, and the Hong Kong risk note
+- [After Iran's 80-day blackout, traffic surged through our community's Tor WebTunnel bridge](iran-blackout-webtunnel.md): why we already recommend Snowflake as the low-effort option
+- [Set up a Tor relay](https://community.torproject.org/relay/){target="_blank"}: the next step up if you want to commit a server
+
+[^1]: Based on 180 daily Snowflake broker reports covering 1 January through 30 June 2026, aggregated from the `snowflake-stats` descriptors in Tor Metrics' [CollecTor archive](https://metrics.torproject.org/collector/archive/snowflakes/){target="_blank"}.
+
+!!! info "Source"
+
+    Based on the official Tor Project post [Snowflake Volunteer, an Android app to help people bypass censorship](https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/){target="_blank"}.

--- a/docs/zh-CN/blog/posts/snowflake-volunteer-android-app.md
+++ b/docs/zh-CN/blog/posts/snowflake-volunteer-android-app.md
@@ -8,11 +8,11 @@ categories:
     - 翻译文章
 slug: snowflake-volunteer-android-app
 image: "assets/images/tor.webp"
-summary: "Tor Project 8 月推出 Snowflake Volunteer，把当 Snowflake 志愿者桥接独立成一支 Android App，上线后三个月志愿者桥接数成长近 6 成。文末补充华语读者可以怎么看待这支 App。"
-description: "翻译 Tor Project 官方公告，介绍新上线的 Snowflake Volunteer Android App：背景由来、怎么运作、上线后的成长数字，以及华语读者可以怎么看待用手机贡献 Snowflake 桥接这件事。"
+summary: "Tor Project 8 月发文介绍 4 月上架的 Snowflake Volunteer，把贡献 Snowflake 志愿者桥接做成一支 Android App，志愿者桥接数单月成长 29%。文末说明什么情况下适合用这支 App。"
+description: "翻译 Tor Project 官方公告，介绍 Snowflake Volunteer 这支 Android App：开发背景、如何运作、上线后的成长数字，以及什么情况下适合用手机贡献 Snowflake 桥接。"
 ---
 
-# Snowflake Volunteer 上线：Tor Project 推出手机志愿者桥接 App
+# Snowflake Volunteer：Tor Project 推出手机志愿者桥接 App
 
 !!! info ""
 
@@ -29,21 +29,23 @@ description: "翻译 Tor Project 官方公告，介绍新上线的 Snowflake Vol
     <figcaption>图片来源：<a target="_blank" href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/">Tor Project Blog</a>。</figcaption>
 </figure>
 
-Tor Project 在 2026 年 8 月 3 日发布 [Snowflake Volunteer](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}，一支专门让人用 Android 手机当 [Snowflake](../../tools/tor-snowflake.md) 志愿者桥接的独立 App。过去要贡献 Snowflake 桥接，需通过浏览器扩展、网站内嵌 widget、桌面命令行工具，或 Android 上的 [Orbot Kindness Mode](https://orbot.app/en/kindness/){target="_blank"}。新 App 把「当志愿者桥接」独立成一个单一用途的应用程序，界面与流程都只为此设计。
+我们在[伊朗封网后的那篇](iran-blackout-webtunnel.md)提过，[Snowflake](../../tools/tor-snowflake.md) 是帮人连上 Tor 门槛最低的方式：开一个浏览器标签页放着不动，就是在帮忙转发流量。2026 年 8 月 3 日，Tor Project 发文介绍 4 月已经上架的 Snowflake Volunteer，把「贡献志愿者桥接」做成一支独立的 Android App，门槛又降了一阶。过去要贡献 Snowflake 桥接，需通过浏览器扩展、网站内嵌 widget、桌面版命令行工具，或 Android 上的 [Orbot Kindness Mode](https://orbot.app/en/kindness/){target="_blank"}。新 App 只做这一件事，界面与设置都只为此设计。
 
 <!-- more -->
 
-## 为什么要多做一支独立 App
+## 为什么需要一支独立的 App
 
-Snowflake 的原理是把用户的流量伪装成视频通话的样子，再通过志愿者提供的临时连接转发，让审查者更难侦测与封锁。这个机制要运作得好，需要一大群稳定在线的志愿者桥接。2026 年上半年，Snowflake broker 平均每天约有 14 万 6 千个不重复志愿者桥接 IP 地址回报[^1]，其中约三分之一来自 Orbot 的 Kindness Mode。Kindness Mode 会显示这个桥接帮过几个连接，让贡献变得具体可见。
+Snowflake 的运作原理，是把用户的流量伪装成视频通话，再通过志愿者提供的临时连接转发，让审查者更难侦测与封锁。机制要运作得好，需要大量稳定在线的志愿者桥接。2026 年上半年，Snowflake 的媒合服务器（broker）平均每天约有 146,000 个不重复志愿者桥接 IP 地址回报[^1]，其中约三分之一来自 Orbot 的 Kindness Mode，它会显示自己的设备协助过多少条连接，让贡献变得具体可见。
 
-葡萄牙的 Android App 工作室 [Bloco](https://www.bloco.io/){target="_blank"} 看到 Kindness Mode 贡献的比重后，好奇一支「只做志愿者桥接」的独立 App，能不能吸引到更多人参与。他们主动找上 Tor 的反审查团队，发现对方本来就有类似计划，只是尚无余力着手，于是接下了开发工作。背后的原因，是 Bloco 团队先前参与 [OONI](https://ooni.org/){target="_blank"}（Open Observatory of Network Interference，全球最大规模的网络封锁观测计划）合作时，看到 NGO 与行动者有多依赖反审查工具维持安全与连接，发现贡献 Snowflake 桥接的门槛不高后，就想拿自己的专业回馈这个开源项目。
+葡萄牙的 Android App 工作室 [Bloco](https://www.bloco.io/){target="_blank"} 先前参与 [OONI](https://ooni.org/){target="_blank"}（Open Observatory of Network Interference，网络干扰开放观测，拥有全球最大的网络审查开放数据集）的合作，看到 NGO 与行动者高度依赖反审查工具维持安全与连接。他们发现贡献 Snowflake 桥接的门槛不高，想以自身专业回馈这个开源项目，注意到 Kindness Mode 贡献的比重后，好奇一支「只做志愿者桥接」的独立 App 能不能吸引更多人参与，于是主动接洽 Tor 的反审查团队。对方本来就有类似计划，只是尚无余力着手，这个任务便交给了 Bloco。
 
-## App 做了什么
+## App 的功能
 
-Bloco 站在 [Guardian Project](https://guardianproject.info){target="_blank"} 既有的移动端 Tor 生态基础上开发，特别是 [IPtProxy](https://github.com/tladesignz/IPtProxy){target="_blank"} 这个函式库，把 Tor 整合进移动 App 所需的工具与 pluggable transport 整合在一起。有这层基础，Bloco 就能把心力集中在三件事。第一是让 App 能长时间在后台稳定运作、尽量省电。第二是把用户体验做对，让每个人都看得懂 App 在做什么、能照自己的网络状况正确设置。第三是用统计数字持续呈现志愿者帮上了多少忙，维持参与的动力。
+Bloco 站在 [Guardian Project](https://guardianproject.info){target="_blank"} 既有的移动端 Tor 生态基础上开发，特别是函式库 [IPtProxy](https://github.com/tladesignz/IPtProxy){target="_blank"}，它把移动 App 串接 Tor 所需的工具与 pluggable transport（可插拔传输，让流量伪装成其他外观以规避审查的技术模块）打包在一起。有了这些现成元件，Bloco 可以把心力放在后台稳定运作与省电、让用户看得懂并能照自己的网络状况正确设置，以及用统计数字持续呈现志愿者协助了多少连接。
 
-成果是 Snowflake Volunteer，一支把「什么时候贡献、贡献多少」的控制权交给志愿者自己的单一用途 App。用户可以让它在后台执行、限制只在 Wi-Fi（非计量网络）下运作、设置只在充电时执行，也可以设置同时能帮几个连接。启用后，App 会自动跟需要 Snowflake 桥接的用户配对，协助把对方的连接导向 Tor 网络。
+成果是 Snowflake Volunteer：用户可以设置让它在后台执行、只在 Wi-Fi 等非计量网络下运作、只在充电时运作，也可以设置同时协助的连接数上限。启用后，App 会自动与需要 Snowflake 桥接的用户配对，协助把对方的连接导向 Tor 网络，过程中双方互不知道彼此身份。
+
+浏览器标签页版本的 Snowflake 在手机上有已知限制：标签页进入后台后，Android 系统经常会直接中断 WebRTC 连接，长时间贡献一直都建议改用台式机或笔电。Snowflake Volunteer 是独立 App，用的是 Android 允许持续执行的后台服务，不受标签页被系统回收的限制，正是手机能长期贡献的关键差异。
 
 <figure markdown="span">
     <a href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/features-overview.png" target="_blank">
@@ -56,26 +58,26 @@ Bloco 站在 [Guardian Project](https://guardianproject.info){target="_blank"} �
 
 ## 上线后的成效
 
-Snowflake Volunteer 经过一轮社群测试与意见反馈后，于 4 月正式公开上线。5 月平均每天约 1,300 个不重复志愿者桥接 IP，6 月成长到约 1,700 个，单月成长 29%。这段期间单日峰值曾超过 2,100 个桥接。这个数字显示，一支专用 App 确实能把额外的志愿者带进 Snowflake 社群。
+Snowflake Volunteer 经过一段社群测试与意见反馈后，于 4 月正式在 [F-Droid](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"} 与 [Google Play](https://play.google.com/store/apps/details?id=io.bloco.snowflake){target="_blank"} 上架。5 月平均每天约 1,300 个不重复志愿者桥接 IP，6 月成长到约 1,700 个，单月成长 29%，单日峰值曾超过 2,100 个桥接。相对于整体约 146,000 个桥接的规模，这批新增志愿者还只是一小块，但原本并不在池子里，多半是过去被浏览器标签页版本挡在门外的手机用户。
 
-App 目前已支持 8 种语言（中文、英文、法文、德文、日文、葡萄牙文、土耳其文、越南文），要感谢社群本地化志愿者的贡献。想协助扩大语言覆盖，可以通过 [Weblate 项目页](https://hosted.weblate.org/projects/snowflake-volunteers/){target="_blank"} 或参考 [Tor 的本地化流程说明](https://community.torproject.org/localization/){target="_blank"} 加入。
-
-## 怎么安装
-
-Snowflake Volunteer 可以从 [F-Droid](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}、[Google Play](https://play.google.com/store/apps/details?id=io.bloco.snowflake){target="_blank"} 下载，源代码开源在 [GitHub](https://github.com/blocoio/snowflake){target="_blank"}，想自己编译或反馈问题都可以直接[开 issue](https://github.com/blocoio/snowflake/issues/new){target="_blank"}。
-
-[^1]: 统计依据 2026 年 1 月 1 日至 6 月 30 日、共 180 份 Snowflake broker 每日报告，数据来自 Tor Metrics 的 [CollecTor 存档](https://metrics.torproject.org/collector/archive/snowflakes/){target="_blank"} 汇整的 snowflake-stats descriptor。
+App 目前支持 8 种语言（英文、法文、德文、日文、葡萄牙文、土耳其文、越南文，以及简体中文），这些语言版本来自社群本地化志愿者的贡献。想协助支持更多语言，可以到 [Weblate 项目页](https://hosted.weblate.org/projects/snowflake-volunteers/){target="_blank"}，或先读 [Tor 的本地化流程说明](https://community.torproject.org/localization/){target="_blank"}。
 
 ## 什么情况下适合用这支 App
 
-[Tor Snowflake 桥接点](../../tools/tor-snowflake.md) 页面已经说明过用浏览器贡献 Snowflake 桥接的风险，这支 App 改变的只是安装方式，判断原则不变：安装它代表你的设备会替审查地区的用户转发 Tor 流量。
+[Tor Snowflake 桥接点](../../tools/tor-snowflake.md) 页面已经说明过用浏览器贡献 Snowflake 桥接的风险，这支 App 改变的只是安装方式，判断原则不变。安装它，表示设备会替审查地区的用户转发 Tor 流量，实际运作上有几件事值得先知道：对外网站看到的是 Tor 出口节点，不是你的 IP，你自己也看不到流量内容，因为流量在转发前已经被 Tor 加密。预设设置下对日常网络使用几乎无感，勾选只在 Wi-Fi、只在充电时运作，就不会动用移动网络的流量或电量。在公司或校园网络上执行，等于把那个网络的 IP 用来转发第三方流量，信息政策严格的环境建议先问过信息部门。
 
-如果你人在中国大陆，自身的网络本就受防火长城管控，能否稳定连上 Snowflake broker 完成注册是实际问题，让设备长期做这件事，风险与收益是否成比例，值得先想清楚。这支 App 更适合外部连接本身不受严格审查、又想帮上忙的华语读者：例如住在海外，或人在网络管制相对宽松地区的人。
+如果你人在中国大陆，自身的网络本就受防火长城管控，能否稳定连上 Snowflake broker 完成注册是实际问题，让设备长期做这件事，风险与收益是否成比例，值得先想清楚。这支 App 更适合外部连接本身不受严格审查、又想帮上忙的华语读者：例如住在海外，或人在网络管制相对宽松地区的人。已经在用 Orbot Kindness Mode 的人不必重复安装，可以继续用它，Snowflake Volunteer 的差别在于只做桥接一件事，能单独设置只在 Wi-Fi、只在充电时运作，不必连着整个 Orbot 一起开。
 
-如果你在香港，参与前请先看 [Tor Snowflake 桥接点](../../tools/tor-snowflake.md) 页里的风险提醒，把国安监控风险一并考虑进去。
+如果你在香港，参与前请先读 [Tor Snowflake 桥接点](../../tools/tor-snowflake.md) 页里的风险提醒，把国安监控风险一并评估。
+
+## 如何安装
+
+Snowflake Volunteer 可以从 [F-Droid](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}、[Google Play](https://play.google.com/store/apps/details?id=io.bloco.snowflake){target="_blank"} 下载，一般用户用 Google Play 即可，偏好开源商店的人可以用 F-Droid。源代码开源在 [GitHub](https://github.com/blocoio/snowflake){target="_blank"}，可以自行编译，遇到问题也可以直接[开 issue](https://github.com/blocoio/snowflake/issues/new){target="_blank"}。iOS 目前没有对应的 App，iPhone 用户可以改用[浏览器版桥接点](../../tools/tor-snowflake.md)。
 
 ## 相关阅读
 
-- [Tor Snowflake 桥接点](../../tools/tor-snowflake.md)：浏览器版桥接点怎么开，以及需要留意的风险
+- [Tor Snowflake 桥接点](../../tools/tor-snowflake.md)：浏览器版桥接点如何开，以及需要留意的风险
 - [伊朗封网 80 多天后重新开放，流量涌进社群架设的 Tor WebTunnel](iran-blackout-webtunnel.md)：桥接点在真实审查情境下的作用
 - [如何搭建 Tor Relay](../../community/setup-tor-relay.md)：想投入更多心力的下一步
+
+[^1]: 统计依据 2026 年 1 月 1 日至 6 月 30 日、共 180 份 Snowflake broker 每日报告，数据来自 Tor Metrics 的 [CollecTor 存档](https://metrics.torproject.org/collector/archive/snowflakes/){target="_blank"} 汇整的 snowflake-stats descriptor。

--- a/docs/zh-CN/blog/posts/snowflake-volunteer-android-app.md
+++ b/docs/zh-CN/blog/posts/snowflake-volunteer-android-app.md
@@ -1,0 +1,81 @@
+---
+date: 2026-08-04
+authors:
+    - anoni-net
+categories:
+    - 更新
+    - Tor
+    - 翻译文章
+slug: snowflake-volunteer-android-app
+image: "assets/images/tor.webp"
+summary: "Tor Project 8 月推出 Snowflake Volunteer，把当 Snowflake 志愿者桥接独立成一支 Android App，上线后三个月志愿者桥接数成长近 6 成。文末补充华语读者可以怎么看待这支 App。"
+description: "翻译 Tor Project 官方公告，介绍新上线的 Snowflake Volunteer Android App：背景由来、怎么运作、上线后的成长数字，以及华语读者可以怎么看待用手机贡献 Snowflake 桥接这件事。"
+---
+
+# Snowflake Volunteer 上线：Tor Project 推出手机志愿者桥接 App
+
+!!! info ""
+
+    以下内容改写自 Tor Project 官方部落格文章，主语角色为 Tor Project 与文章作者 Pavel：
+
+    - [Snowflake Volunteer, an Android app to help people bypass censorship | August 3, 2026](https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/){target="_blank"}
+
+<figure markdown="span">
+    <a href="https://forum.torproject.org/uploads/default/original/2X/c/c9143874b416a1c6e0d676145c11846ad63bad39.jpeg" target="_blank">
+        <img src="https://forum.torproject.org/uploads/default/original/2X/c/c9143874b416a1c6e0d676145c11846ad63bad39.jpeg"
+            alt="Snowflake Volunteer 官方宣传图，画面中多支手机显示 App 的启用开关、设置选项与统计画面"
+            style="border-radius: 10px;">
+    </a>
+    <figcaption>图片来源：<a target="_blank" href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/">Tor Project Blog</a>。</figcaption>
+</figure>
+
+Tor Project 在 2026 年 8 月 3 日发布 [Snowflake Volunteer](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}，一支专门让人用 Android 手机当 [Snowflake](../../tools/tor-snowflake.md) 志愿者桥接的独立 App。过去要贡献 Snowflake 桥接，需通过浏览器扩展、网站内嵌 widget、桌面命令行工具，或 Android 上的 [Orbot Kindness Mode](https://orbot.app/en/kindness/){target="_blank"}。新 App 把「当志愿者桥接」独立成一个单一用途的应用程序，界面与流程都只为此设计。
+
+<!-- more -->
+
+## 为什么要多做一支独立 App
+
+Snowflake 的原理是把用户的流量伪装成视频通话的样子，再通过志愿者提供的临时连接转发，让审查者更难侦测与封锁。这个机制要运作得好，需要一大群稳定在线的志愿者桥接。2026 年上半年，Snowflake broker 平均每天约有 14 万 6 千个不重复志愿者桥接 IP 地址回报[^1]，其中约三分之一来自 Orbot 的 Kindness Mode。Kindness Mode 会显示这个桥接帮过几个连接，让贡献变得具体可见。
+
+葡萄牙的 Android App 工作室 [Bloco](https://www.bloco.io/){target="_blank"} 看到 Kindness Mode 贡献的比重后，好奇一支「只做志愿者桥接」的独立 App，能不能吸引到更多人参与。他们主动找上 Tor 的反审查团队，发现对方本来就有类似计划，只是尚无余力着手，于是接下了开发工作。背后的原因，是 Bloco 团队先前参与 [OONI](https://ooni.org/){target="_blank"}（Open Observatory of Network Interference，全球最大规模的网络封锁观测计划）合作时，看到 NGO 与行动者有多依赖反审查工具维持安全与连接，发现贡献 Snowflake 桥接的门槛不高后，就想拿自己的专业回馈这个开源项目。
+
+## App 做了什么
+
+Bloco 站在 [Guardian Project](https://guardianproject.info){target="_blank"} 既有的移动端 Tor 生态基础上开发，特别是 [IPtProxy](https://github.com/tladesignz/IPtProxy){target="_blank"} 这个函式库，把 Tor 整合进移动 App 所需的工具与 pluggable transport 整合在一起。有这层基础，Bloco 就能把心力集中在三件事。第一是让 App 能长时间在后台稳定运作、尽量省电。第二是把用户体验做对，让每个人都看得懂 App 在做什么、能照自己的网络状况正确设置。第三是用统计数字持续呈现志愿者帮上了多少忙，维持参与的动力。
+
+成果是 Snowflake Volunteer，一支把「什么时候贡献、贡献多少」的控制权交给志愿者自己的单一用途 App。用户可以让它在后台执行、限制只在 Wi-Fi（非计量网络）下运作、设置只在充电时执行，也可以设置同时能帮几个连接。启用后，App 会自动跟需要 Snowflake 桥接的用户配对，协助把对方的连接导向 Tor 网络。
+
+<figure markdown="span">
+    <a href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/features-overview.png" target="_blank">
+        <img src="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/features-overview.png"
+            alt="Snowflake Volunteer App 三个画面的截图：启用中的主画面显示帮助人数与流量统计、设置页可调整后台运行与限制 Wi-Fi 或充电时运行、统计页列出逐日的连接数与流量"
+            style="border-radius: 10px;">
+    </a>
+    <figcaption>App 的主画面、设置页与统计页截图。图片来源：<a target="_blank" href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/">Tor Project Blog</a>。</figcaption>
+</figure>
+
+## 上线后的成效
+
+Snowflake Volunteer 经过一轮社群测试与意见反馈后，于 4 月正式公开上线。5 月平均每天约 1,300 个不重复志愿者桥接 IP，6 月成长到约 1,700 个，单月成长 29%。这段期间单日峰值曾超过 2,100 个桥接。这个数字显示，一支专用 App 确实能把额外的志愿者带进 Snowflake 社群。
+
+App 目前已支持 8 种语言（中文、英文、法文、德文、日文、葡萄牙文、土耳其文、越南文），要感谢社群本地化志愿者的贡献。想协助扩大语言覆盖，可以通过 [Weblate 项目页](https://hosted.weblate.org/projects/snowflake-volunteers/){target="_blank"} 或参考 [Tor 的本地化流程说明](https://community.torproject.org/localization/){target="_blank"} 加入。
+
+## 怎么安装
+
+Snowflake Volunteer 可以从 [F-Droid](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}、[Google Play](https://play.google.com/store/apps/details?id=io.bloco.snowflake){target="_blank"} 下载，源代码开源在 [GitHub](https://github.com/blocoio/snowflake){target="_blank"}，想自己编译或反馈问题都可以直接[开 issue](https://github.com/blocoio/snowflake/issues/new){target="_blank"}。
+
+[^1]: 统计依据 2026 年 1 月 1 日至 6 月 30 日、共 180 份 Snowflake broker 每日报告，数据来自 Tor Metrics 的 [CollecTor 存档](https://metrics.torproject.org/collector/archive/snowflakes/){target="_blank"} 汇整的 snowflake-stats descriptor。
+
+## 什么情况下适合用这支 App
+
+[Tor Snowflake 桥接点](../../tools/tor-snowflake.md) 页面已经说明过用浏览器贡献 Snowflake 桥接的风险，这支 App 改变的只是安装方式，判断原则不变：安装它代表你的设备会替审查地区的用户转发 Tor 流量。
+
+如果你人在中国大陆，自身的网络本就受防火长城管控，能否稳定连上 Snowflake broker 完成注册是实际问题，让设备长期做这件事，风险与收益是否成比例，值得先想清楚。这支 App 更适合外部连接本身不受严格审查、又想帮上忙的华语读者：例如住在海外，或人在网络管制相对宽松地区的人。
+
+如果你在香港，参与前请先看 [Tor Snowflake 桥接点](../../tools/tor-snowflake.md) 页里的风险提醒，把国安监控风险一并考虑进去。
+
+## 相关阅读
+
+- [Tor Snowflake 桥接点](../../tools/tor-snowflake.md)：浏览器版桥接点怎么开，以及需要留意的风险
+- [伊朗封网 80 多天后重新开放，流量涌进社群架设的 Tor WebTunnel](iran-blackout-webtunnel.md)：桥接点在真实审查情境下的作用
+- [如何搭建 Tor Relay](../../community/setup-tor-relay.md)：想投入更多心力的下一步

--- a/docs/zh-CN/blog/posts/snowflake-volunteer-android-app.md
+++ b/docs/zh-CN/blog/posts/snowflake-volunteer-android-app.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-04
+date: 2026-08-05
 authors:
     - anoni-net
 categories:

--- a/docs/zh-TW/blog/posts/snowflake-volunteer-android-app.md
+++ b/docs/zh-TW/blog/posts/snowflake-volunteer-android-app.md
@@ -8,11 +8,11 @@ categories:
     - 翻譯文章
 slug: snowflake-volunteer-android-app
 image: "assets/images/tor.webp"
-summary: "Tor Project 8 月推出 Snowflake Volunteer，把當 Snowflake 志工橋接獨立成一支 Android App，上線後三個月志工橋接數成長近 6 成。文末補上台灣讀者可以怎麼用這支 App 幫忙翻牆。"
-description: "翻譯 Tor Project 官方公告，介紹新上線的 Snowflake Volunteer Android App：背景由來、怎麼運作、上線後的成長數字，以及台灣讀者可以怎麼用手機貢獻 Snowflake 橋接。"
+summary: "Tor Project 8 月發文介紹 4 月上架的 Snowflake Volunteer，把貢獻 Snowflake 志工橋接做成一支 Android App，志工橋接數單月成長 29%。文末說明台灣讀者可以如何用這支 App 貢獻橋接。"
+description: "翻譯 Tor Project 官方公告，介紹 Snowflake Volunteer 這支 Android App：開發背景、如何運作、上線後的成長數字，以及台灣讀者可以如何用手機貢獻 Snowflake 橋接。"
 ---
 
-# Snowflake Volunteer 上線：Tor Project 推出手機志工橋接 App
+# Snowflake Volunteer：Tor Project 推出手機志工橋接 App
 
 !!! info ""
 
@@ -29,21 +29,23 @@ description: "翻譯 Tor Project 官方公告，介紹新上線的 Snowflake Vol
     <figcaption>圖片來源：<a target="_blank" href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/">Tor Project Blog</a>。</figcaption>
 </figure>
 
-Tor Project 在 2026 年 8 月 3 日發布 [Snowflake Volunteer](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}，一支專門讓人用 Android 手機當 [Snowflake](../../tools/tor-snowflake.md) 志工橋接的獨立 App。過去要貢獻 Snowflake 橋接，需透過瀏覽器擴充功能、網站內嵌 widget、桌機命令列工具，或 Android 上的 [Orbot Kindness Mode](https://orbot.app/en/kindness/){target="_blank"}。新 App 把「當志工橋接」獨立成一個單一用途的應用程式，介面與流程都只為此設計。
+我們在[伊朗封網後的那篇](iran-blackout-webtunnel.md)提過，[Snowflake](../../tools/tor-snowflake.md) 是幫人連上 Tor 門檻最低的方式：開一個瀏覽器分頁放著不動，就是在幫忙轉發流量。2026 年 8 月 3 日，Tor Project 發文介紹 4 月已經上架的 Snowflake Volunteer，把「貢獻志工橋接」做成一支獨立的 Android App，門檻又降了一階。過去要貢獻 Snowflake 橋接，需透過瀏覽器擴充功能、網站內嵌 widget、桌面版命令列工具，或 Android 上的 [Orbot Kindness Mode](https://orbot.app/en/kindness/){target="_blank"}。新 App 只做這一件事，介面與設定都只為此設計。
 
 <!-- more -->
 
-## 為什麼要多做一支獨立 App
+## 為什麼需要一支獨立的 App
 
-Snowflake 的原理是把使用者的流量偽裝成視訊通話的樣子，再透過志工提供的臨時連線轉送，讓審查者更難偵測與封鎖。這個機制要運作得好，需要一大群穩定在線的志工橋接。2026 年上半年，Snowflake broker 平均每天約有 14 萬 6 千個不重複志工橋接 IP 位址回報[^1]，其中約三分之一來自 Orbot 的 Kindness Mode。Kindness Mode 會顯示這個橋接幫過幾個連線，讓貢獻變得具體可見。
+Snowflake 的運作原理，是把使用者的流量偽裝成視訊通話，再透過志工提供的臨時連線轉發，讓審查者更難偵測與封鎖。機制要運作得好，需要大量穩定在線的志工橋接。2026 年上半年，Snowflake 的媒合伺服器（broker）平均每天約有 146,000 個不重複志工橋接 IP 位址回報[^1]，其中約三分之一來自 Orbot 的 Kindness Mode，它會顯示自己的裝置協助過多少條連線，讓貢獻變得具體可見。
 
-葡萄牙的 Android App 工作室 [Bloco](https://www.bloco.io/){target="_blank"} 看到 Kindness Mode 貢獻的比重後，好奇一支「只做志工橋接」的獨立 App，能不能吸引到更多人參與。他們主動找上 Tor 的反審查團隊，發現對方本來就有類似計畫，只是尚無餘裕著手，於是接下了開發工作。背後的原因，是 Bloco 團隊先前參與 [OONI](https://ooni.org/){target="_blank"}（Open Observatory of Network Interference，全球最大規模的網路封鎖觀測計畫）合作時，看到 NGO 與行動者有多依賴反審查工具維持安全與連線，發現貢獻 Snowflake 橋接的門檻不高後，就想拿自己的專業回饋這個開源專案。
+葡萄牙的 Android App 工作室 [Bloco](https://www.bloco.io/){target="_blank"} 先前參與 [OONI](https://ooni.org/){target="_blank"}（Open Observatory of Network Interference，網路干擾開放觀測，擁有全球最大的網路審查開放資料集）的合作，看到 NGO 與行動者高度依賴反審查工具維持安全與連線。他們發現貢獻 Snowflake 橋接的門檻不高，想以自身專業回饋這個開源專案，注意到 Kindness Mode 貢獻的比重後，好奇一支「只做志工橋接」的獨立 App 能不能吸引更多人參與，於是主動接洽 Tor 的反審查團隊。對方本來就有類似計畫，只是尚無餘力著手，這個任務便交給了 Bloco。
 
-## App 做了什麼
+## App 的功能
 
-Bloco 站在 [Guardian Project](https://guardianproject.info){target="_blank"} 既有的行動端 Tor 生態基礎上開發，特別是 [IPtProxy](https://github.com/tladesignz/IPtProxy){target="_blank"} 這個函式庫，把 Tor 整合進行動 App 所需的工具與 pluggable transport 整合在一起。有這層基礎，Bloco 就能把心力集中在三件事。第一是讓 App 能長時間在背景穩定運作、盡量省電。第二是把使用者體驗做對，讓每個人都看得懂 App 在做什麼、能照自己的網路狀況正確設定。第三是用統計數字持續呈現志工幫上了多少忙，維持參與的動力。
+Bloco 站在 [Guardian Project](https://guardianproject.info){target="_blank"} 既有的行動端 Tor 生態基礎上開發，特別是函式庫 [IPtProxy](https://github.com/tladesignz/IPtProxy){target="_blank"}，它把行動 App 串接 Tor 所需的工具與 pluggable transport（可插拔傳輸，讓流量偽裝成其他外觀以規避審查的技術模組）打包在一起。有了這些現成元件，Bloco 可以把心力放在背景穩定運作與省電、讓使用者看得懂並能照自己的網路狀況正確設定，以及用統計數字持續呈現志工協助了多少連線。
 
-成果是 Snowflake Volunteer，一支把「什麼時候貢獻、貢獻多少」的控制權交給志工自己的單一用途 App。使用者可以讓它在背景執行、限制只在 Wi-Fi（非計量網路）下運作、設定只在充電時執行，也可以設定同時能幫幾個連線。啟用後，App 會自動跟需要 Snowflake 橋接的使用者配對，協助把對方的連線導向 Tor 網路。
+成果是 Snowflake Volunteer：使用者可以設定讓它在背景執行、只在 Wi-Fi 等非計量網路下運作、只在充電時運作，也可以設定同時協助的連線數上限。啟用後，App 會自動與需要 Snowflake 橋接的使用者配對，協助把對方的連線導向 Tor 網路，過程中雙方互不知道彼此身分。
+
+瀏覽器分頁版本的 Snowflake 在手機上有已知限制：分頁進入背景後，Android 系統經常會直接中斷 WebRTC 連線，長時間貢獻一直都建議改用桌上型電腦或筆電。Snowflake Volunteer 是獨立 App，用的是 Android 允許持續執行的背景服務，不受分頁被系統回收的限制，正是手機能長期貢獻的關鍵差異。
 
 <figure markdown="span">
     <a href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/features-overview.png" target="_blank">
@@ -56,24 +58,26 @@ Bloco 站在 [Guardian Project](https://guardianproject.info){target="_blank"} �
 
 ## 上線後的成效
 
-Snowflake Volunteer 經過一輪社群測試與意見回饋後，於 4 月正式公開上線。5 月平均每天約 1,300 個不重複志工橋接 IP，6 月成長到約 1,700 個，單月成長 29%。這段期間單日尖峰曾超過 2,100 個橋接。這個數字顯示，一支專用 App 確實能把額外的志工帶進 Snowflake 社群。
+Snowflake Volunteer 經過一段社群測試與意見回饋後，於 4 月正式在 [F-Droid](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"} 與 [Google Play](https://play.google.com/store/apps/details?id=io.bloco.snowflake){target="_blank"} 上架。5 月平均每天約 1,300 個不重複志工橋接 IP，6 月成長到約 1,700 個，單月成長 29%，單日尖峰曾超過 2,100 個橋接。相對於整體約 146,000 個橋接的規模，這批新增志工還只是一小塊，但原本並不在池子裡，多半是過去被瀏覽器分頁版本擋在門外的手機使用者。
 
-App 目前已支援 8 種語言（中文、英文、法文、德文、日文、葡萄牙文、土耳其文、越南文），要感謝社群在地化志工的貢獻。想協助擴大語言覆蓋，可以透過 [Weblate 專案頁](https://hosted.weblate.org/projects/snowflake-volunteers/){target="_blank"} 或參考 [Tor 的在地化流程說明](https://community.torproject.org/localization/){target="_blank"} 加入。
-
-## 怎麼安裝
-
-Snowflake Volunteer 可以從 [F-Droid](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}、[Google Play](https://play.google.com/store/apps/details?id=io.bloco.snowflake){target="_blank"} 下載，原始碼開源在 [GitHub](https://github.com/blocoio/snowflake){target="_blank"}，想自己編譯或回報問題都可以直接[開 issue](https://github.com/blocoio/snowflake/issues/new){target="_blank"}。
-
-[^1]: 統計依據 2026 年 1 月 1 日至 6 月 30 日、共 180 份 Snowflake broker 每日報告，資料來自 Tor Metrics 的 [CollecTor 封存](https://metrics.torproject.org/collector/archive/snowflakes/){target="_blank"} 彙整的 snowflake-stats descriptor。
+App 目前支援 8 種語言（英文、法文、德文、日文、葡萄牙文、土耳其文、越南文，以及簡體中文），這些語言版本來自社群在地化志工的貢獻。目前還沒有正體中文版本，想協助的人可以到 [Weblate 專案頁](https://hosted.weblate.org/projects/snowflake-volunteers/){target="_blank"}，或先讀 [Tor 的在地化流程說明](https://community.torproject.org/localization/){target="_blank"}。
 
 ## 對台灣讀者來說多了一個選項
 
-[Tor Snowflake 橋接點](../../tools/tor-snowflake.md) 已經整理過台灣為什麼適合貢獻橋接：對外連線受審查程度低、頻寬充足，比起架設 [Tor Relay](../../community/setup-tor-relay.md) 門檻低很多。過去門檻是「開一個瀏覽器分頁、電腦留著運作」，現在多了「裝一支 Android App、手機留著運作」這個選項，對平常用手機比用電腦多的人來說更容易安裝，也更容易長期留著背景執行。
+[Tor Snowflake 橋接點](../../tools/tor-snowflake.md) 已經整理過台灣為什麼適合貢獻橋接：對外連線受審查程度低、頻寬充足，比起架設 [Tor Relay](../../community/setup-tor-relay.md) 門檻明顯較低。安裝這支 App，表示手機會替受審查地區的使用者轉發 Tor 流量，實際運作上有幾件事值得先知道：對外網站看到的是 Tor 出口節點，不是你的 IP，你自己也看不到流量內容，因為流量在轉發前已經被 Tor 加密。預設設定下對日常網路使用幾乎無感，勾選只在 Wi-Fi、只在充電時運作，就不會動用行動網路的流量或電量。在公司或學校網路上執行，等於把那個網路的 IP 用來轉發第三方流量，資訊政策嚴格的環境建議先問過資訊部門。
 
-跟瀏覽器分頁一樣，安裝這支 App 代表你的裝置會替受審查地區的使用者轉發 Tor 流量。如果你在香港，參與前請先看 [Tor Snowflake 橋接點](../../tools/tor-snowflake.md) 頁裡的香港讀者提醒，把國安監控風險一併考慮進去。
+已經在用 Orbot Kindness Mode 的人不必重複安裝，可以繼續用它。Snowflake Volunteer 的差別在於只做橋接一件事，能單獨設定只在 Wi-Fi、只在充電時運作，不必連著整個 Orbot 一起開，適合只想幫這個忙、不想順便用 Orbot 上網的人。
+
+跟瀏覽器版一樣，如果你在香港，參與前請先讀 [Tor Snowflake 橋接點](../../tools/tor-snowflake.md) 頁裡的香港讀者提醒，把國安監控風險一併評估。
+
+## 如何安裝
+
+Snowflake Volunteer 可以從 [F-Droid](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}、[Google Play](https://play.google.com/store/apps/details?id=io.bloco.snowflake){target="_blank"} 下載，一般使用者用 Google Play 即可，偏好開源商店的人可以用 F-Droid。原始碼開源在 [GitHub](https://github.com/blocoio/snowflake){target="_blank"}，可以自行編譯，遇到問題也可以直接[開 issue](https://github.com/blocoio/snowflake/issues/new){target="_blank"}。iOS 目前沒有對應的 App，iPhone 使用者可以改用[瀏覽器版橋接點](../../tools/tor-snowflake.md)。
 
 ## 相關閱讀
 
-- [Tor Snowflake 橋接點](../../tools/tor-snowflake.md)：瀏覽器版橋接點怎麼開，以及香港讀者要注意的風險
+- [Tor Snowflake 橋接點](../../tools/tor-snowflake.md)：瀏覽器版橋接點如何開，以及香港讀者要注意的風險
 - [伊朗封網 80 多天後重新開放，流量湧進社群架設的 Tor WebTunnel](iran-blackout-webtunnel.md)：橋接點在真實審查情境下的作用
 - [Tor Relay 校園建立研究專題](../../community/relay-on-campus.md)：想投入更多心力的下一步
+
+[^1]: 統計依據 2026 年 1 月 1 日至 6 月 30 日、共 180 份 Snowflake broker 每日報告，數據來自 Tor Metrics 的 [CollecTor 封存](https://metrics.torproject.org/collector/archive/snowflakes/){target="_blank"} 彙整的 snowflake-stats descriptor。

--- a/docs/zh-TW/blog/posts/snowflake-volunteer-android-app.md
+++ b/docs/zh-TW/blog/posts/snowflake-volunteer-android-app.md
@@ -1,0 +1,61 @@
+---
+date: 2026-08-04
+authors:
+    - anoni-net
+categories:
+    - 更新
+    - Tor
+    - 翻譯文章
+slug: snowflake-volunteer-android-app
+image: "assets/images/tor.webp"
+summary: "Tor Project 8 月推出 Snowflake Volunteer，把當 Snowflake 志工橋接獨立成一支 Android App，上線後三個月志工橋接數成長近 6 成。文末補上台灣讀者可以怎麼用這支 App 幫忙翻牆。"
+description: "翻譯 Tor Project 官方公告，介紹新上線的 Snowflake Volunteer Android App：背景由來、怎麼運作、上線後的成長數字，以及台灣讀者可以怎麼用手機貢獻 Snowflake 橋接。"
+---
+
+# Snowflake Volunteer 上線：Tor Project 推出手機志工橋接 App
+
+!!! info ""
+
+    以下內容改寫自 Tor Project 官方部落格文章，主詞角色為 Tor Project 與文章作者 Pavel：
+
+    - [Snowflake Volunteer, an Android app to help people bypass censorship | August 3, 2026](https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/){target="_blank"}
+
+Tor Project 在 2026 年 8 月 3 日發布 [Snowflake Volunteer](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}，一支專門讓人用 Android 手機當 [Snowflake](../../tools/tor-snowflake.md) 志工橋接的獨立 App。過去要貢獻 Snowflake 橋接，需透過瀏覽器擴充功能、網站內嵌 widget、桌機命令列工具，或 Android 上的 [Orbot Kindness Mode](https://orbot.app/en/kindness/){target="_blank"}。新 App 把「當志工橋接」獨立成一個單一用途的應用程式，介面與流程都只為此設計。
+
+<!-- more -->
+
+## 為什麼要多做一支獨立 App
+
+Snowflake 的原理是把使用者的流量偽裝成視訊通話的樣子，再透過志工提供的臨時連線轉送，讓審查者更難偵測與封鎖。這個機制要運作得好，需要一大群穩定在線的志工橋接。2026 年上半年，Snowflake broker 平均每天約有 14 萬 6 千個不重複志工橋接 IP 位址回報[^1]，其中約三分之一來自 Orbot 的 Kindness Mode。Kindness Mode 會顯示這個橋接幫過幾個連線，讓貢獻變得具體可見。
+
+葡萄牙的 Android App 工作室 [Bloco](https://www.bloco.io/){target="_blank"} 看到 Kindness Mode 貢獻的比重後，好奇一支「只做志工橋接」的獨立 App，能不能吸引到更多人參與。他們主動找上 Tor 的反審查團隊，發現對方本來就有類似計畫，只是尚無餘裕著手，於是接下了開發工作。背後的原因，是 Bloco 團隊先前參與 [OONI](https://ooni.org/){target="_blank"}（Open Observatory of Network Interference，全球最大規模的網路封鎖觀測計畫）合作時，看到 NGO 與行動者有多依賴反審查工具維持安全與連線，發現貢獻 Snowflake 橋接的門檻不高後，就想拿自己的專業回饋這個開源專案。
+
+## App 做了什麼
+
+Bloco 站在 [Guardian Project](https://guardianproject.info){target="_blank"} 既有的行動端 Tor 生態基礎上開發，特別是 [IPtProxy](https://github.com/tladesignz/IPtProxy){target="_blank"} 這個函式庫，把 Tor 整合進行動 App 所需的工具與 pluggable transport 整合在一起。有這層基礎，Bloco 就能把心力集中在三件事。第一是讓 App 能長時間在背景穩定運作、盡量省電。第二是把使用者體驗做對，讓每個人都看得懂 App 在做什麼、能照自己的網路狀況正確設定。第三是用統計數字持續呈現志工幫上了多少忙，維持參與的動力。
+
+成果是 Snowflake Volunteer，一支把「什麼時候貢獻、貢獻多少」的控制權交給志工自己的單一用途 App。使用者可以讓它在背景執行、限制只在 Wi-Fi（非計量網路）下運作、設定只在充電時執行，也可以設定同時能幫幾個連線。啟用後，App 會自動跟需要 Snowflake 橋接的使用者配對，協助把對方的連線導向 Tor 網路。
+
+## 上線後的成效
+
+Snowflake Volunteer 經過一輪社群測試與意見回饋後，於 4 月正式公開上線。5 月平均每天約 1,300 個不重複志工橋接 IP，6 月成長到約 1,700 個，單月成長 29%。這段期間單日尖峰曾超過 2,100 個橋接。這個數字顯示，一支專用 App 確實能把額外的志工帶進 Snowflake 社群。
+
+App 目前已支援 8 種語言（中文、英文、法文、德文、日文、葡萄牙文、土耳其文、越南文），要感謝社群在地化志工的貢獻。想協助擴大語言覆蓋，可以透過 [Weblate 專案頁](https://hosted.weblate.org/projects/snowflake-volunteers/){target="_blank"} 或參考 [Tor 的在地化流程說明](https://community.torproject.org/localization/){target="_blank"} 加入。
+
+## 怎麼安裝
+
+Snowflake Volunteer 可以從 [F-Droid](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}、[Google Play](https://play.google.com/store/apps/details?id=io.bloco.snowflake){target="_blank"} 下載，原始碼開源在 [GitHub](https://github.com/blocoio/snowflake){target="_blank"}，想自己編譯或回報問題都可以直接[開 issue](https://github.com/blocoio/snowflake/issues/new){target="_blank"}。
+
+[^1]: 統計依據 2026 年 1 月 1 日至 6 月 30 日、共 180 份 Snowflake broker 每日報告，資料來自 Tor Metrics 的 [CollecTor 封存](https://metrics.torproject.org/collector/archive/snowflakes/){target="_blank"} 彙整的 snowflake-stats descriptor。
+
+## 對台灣讀者來說多了一個選項
+
+[Tor Snowflake 橋接點](../../tools/tor-snowflake.md) 已經整理過台灣為什麼適合貢獻橋接：對外連線受審查程度低、頻寬充足，比起架設 [Tor Relay](../../community/setup-tor-relay.md) 門檻低很多。過去門檻是「開一個瀏覽器分頁、電腦留著運作」，現在多了「裝一支 Android App、手機留著運作」這個選項，對平常用手機比用電腦多的人來說更容易安裝，也更容易長期留著背景執行。
+
+跟瀏覽器分頁一樣，安裝這支 App 代表你的裝置會替受審查地區的使用者轉發 Tor 流量。如果你在香港，參與前請先看 [Tor Snowflake 橋接點](../../tools/tor-snowflake.md) 頁裡的香港讀者提醒，把國安監控風險一併考慮進去。
+
+## 相關閱讀
+
+- [Tor Snowflake 橋接點](../../tools/tor-snowflake.md)：瀏覽器版橋接點怎麼開，以及香港讀者要注意的風險
+- [伊朗封網 80 多天後重新開放，流量湧進社群架設的 Tor WebTunnel](iran-blackout-webtunnel.md)：橋接點在真實審查情境下的作用
+- [Tor Relay 校園建立研究專題](../../community/relay-on-campus.md)：想投入更多心力的下一步

--- a/docs/zh-TW/blog/posts/snowflake-volunteer-android-app.md
+++ b/docs/zh-TW/blog/posts/snowflake-volunteer-android-app.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-04
+date: 2026-08-05
 authors:
     - anoni-net
 categories:

--- a/docs/zh-TW/blog/posts/snowflake-volunteer-android-app.md
+++ b/docs/zh-TW/blog/posts/snowflake-volunteer-android-app.md
@@ -20,6 +20,15 @@ description: "翻譯 Tor Project 官方公告，介紹新上線的 Snowflake Vol
 
     - [Snowflake Volunteer, an Android app to help people bypass censorship | August 3, 2026](https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/){target="_blank"}
 
+<figure markdown="span">
+    <a href="https://forum.torproject.org/uploads/default/original/2X/c/c9143874b416a1c6e0d676145c11846ad63bad39.jpeg" target="_blank">
+        <img src="https://forum.torproject.org/uploads/default/original/2X/c/c9143874b416a1c6e0d676145c11846ad63bad39.jpeg"
+            alt="Snowflake Volunteer 官方宣傳圖，畫面中多支手機顯示 App 的啟用開關、設定選項與統計畫面"
+            style="border-radius: 10px;">
+    </a>
+    <figcaption>圖片來源：<a target="_blank" href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/">Tor Project Blog</a>。</figcaption>
+</figure>
+
 Tor Project 在 2026 年 8 月 3 日發布 [Snowflake Volunteer](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}，一支專門讓人用 Android 手機當 [Snowflake](../../tools/tor-snowflake.md) 志工橋接的獨立 App。過去要貢獻 Snowflake 橋接，需透過瀏覽器擴充功能、網站內嵌 widget、桌機命令列工具，或 Android 上的 [Orbot Kindness Mode](https://orbot.app/en/kindness/){target="_blank"}。新 App 把「當志工橋接」獨立成一個單一用途的應用程式，介面與流程都只為此設計。
 
 <!-- more -->
@@ -35,6 +44,15 @@ Snowflake 的原理是把使用者的流量偽裝成視訊通話的樣子，再�
 Bloco 站在 [Guardian Project](https://guardianproject.info){target="_blank"} 既有的行動端 Tor 生態基礎上開發，特別是 [IPtProxy](https://github.com/tladesignz/IPtProxy){target="_blank"} 這個函式庫，把 Tor 整合進行動 App 所需的工具與 pluggable transport 整合在一起。有這層基礎，Bloco 就能把心力集中在三件事。第一是讓 App 能長時間在背景穩定運作、盡量省電。第二是把使用者體驗做對，讓每個人都看得懂 App 在做什麼、能照自己的網路狀況正確設定。第三是用統計數字持續呈現志工幫上了多少忙，維持參與的動力。
 
 成果是 Snowflake Volunteer，一支把「什麼時候貢獻、貢獻多少」的控制權交給志工自己的單一用途 App。使用者可以讓它在背景執行、限制只在 Wi-Fi（非計量網路）下運作、設定只在充電時執行，也可以設定同時能幫幾個連線。啟用後，App 會自動跟需要 Snowflake 橋接的使用者配對，協助把對方的連線導向 Tor 網路。
+
+<figure markdown="span">
+    <a href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/features-overview.png" target="_blank">
+        <img src="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/features-overview.png"
+            alt="Snowflake Volunteer App 三個畫面的截圖：啟用中的主畫面顯示幫助人數與流量統計、設定頁可調整背景執行與限制 Wi-Fi 或充電時執行、統計頁列出逐日的連線數與流量"
+            style="border-radius: 10px;">
+    </a>
+    <figcaption>App 的主畫面、設定頁與統計頁截圖。圖片來源：<a target="_blank" href="https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/">Tor Project Blog</a>。</figcaption>
+</figure>
 
 ## 上線後的成效
 

--- a/docs/zh-TW/tools/tor-snowflake.md
+++ b/docs/zh-TW/tools/tor-snowflake.md
@@ -81,7 +81,7 @@ icon: material/snowflake
 
 ??? question "手機可以開嗎？"
 
-    可以，但效果有限。手機網路常變動 IP，App 進入背景後系統會中斷 WebRTC 連線。長時間貢獻建議用桌面或筆電。
+    瀏覽器分頁版本效果有限：手機網路常變動 IP，分頁進入背景後系統經常會中斷 WebRTC 連線，長時間貢獻建議用桌面或筆電。想用手機長期貢獻，可以改用官方推出的獨立 App [Snowflake Volunteer](https://f-droid.org/en/packages/io.bloco.snowflake/){target="_blank"}，它用的是背景服務而非瀏覽器分頁，不受這個限制，詳見[介紹文章](../blog/posts/snowflake-volunteer-android-app.md)。
 
 ??? question "跟架 Tor Relay 比，貢獻有差嗎？"
 


### PR DESCRIPTION
## 內容

翻譯 Tor Project 官方部落格文章 [Snowflake Volunteer, an Android app to help people bypass censorship](https://blog.torproject.org/snowflake-volunteer-standalone-app-to-help-people-bypass-censorship/)（2026-08-03 發布），介紹新上線的 Snowflake Volunteer：把「當 [Snowflake](../tools/tor-snowflake.md) 志工橋接」獨立成單一用途的 Android App。

涵蓋內容：

- 開發背景：葡萄牙 Android App 工作室 Bloco 主動找上 Tor 反審查團隊，站在 Guardian Project 的 IPtProxy 基礎上打造
- App 功能：背景執行、限制 Wi-Fi、只在充電時執行、同時連線數上限、統計數字
- 上線後成效：4 月公開上線後，5 月平均每天約 1,300 個志工橋接 IP，6 月成長到約 1,700 個（單月 +29%），單日尖峰破 2,100
- 8 種語言的在地化現況，以及 F-Droid／Google Play／原始碼下載方式

文末加一節「對台灣讀者來說多了一個選項」，接回既有的 `tools/tor-snowflake.md` 頁（台灣為什麼適合貢獻橋接、香港讀者的國安監控風險提醒），並補上「相關閱讀」連到 `tor-snowflake.md`、`iran-blackout-webtunnel.md`、`community/relay-on-campus.md`。

只做 zh-TW（single source of truth）。zh-CN／en 是否要跟進，等你決定。

## 驗證

- [x] `python3 tools/docs_style_lint.py` 0 error、0 warn
- [x] 「這」字堆疊自我檢查（句 2+／段 3+）0 命中
- [x] `mkdocs build`（zh-TW）exit 沿用既有 cairo strict-mode abort，過濾後無新增警告
- [x] 逐一確認 footnote、內部連結（`tor-snowflake.md`、`setup-tor-relay.md`、`relay-on-campus.md`、`iran-blackout-webtunnel.md`）在輸出 HTML 中正確解析
- [x] 所有外部連結都帶 `target="_blank"`

## 事實查核

原文列出的數字（146,000 平均每日志工橋接、1,300 → 1,700、+29%、>2,100 尖峰、8 種語言）已對照原始頁面原文逐一核對，非 WebFetch 摘要間接轉述。連結（F-Droid、Google Play、GitHub、Weblate、IPtProxy、Bloco、Guardian Project、CollecTor 封存）皆從原文頁面實際 `<a href>` 取得，非憑記憶重建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzFgTGBpSpj7rNL1iQUsob