### PR TITLE
ci(docs): BuildDocs 加上 concurrency group，避免兩次 S3 清理交錯

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -6,6 +6,20 @@ on:
       - "docs"
   workflow_dispatch:
 
+# 最後兩步是先 `aws s3 rm --recursive` 清空 docs prefix，再 `s3 sync` 上傳。兩個 run
+# 重疊時，後者的清空會發生在前者上傳到一半，S3 會有一段內容不完整的空窗。連續合併
+# 幾個 PR 再同步 docs 分支就會踩到。
+#
+# 全域一組（不帶 ref），因為 workflow_dispatch 可以從任何分支觸發，而所有 run 都寫
+# 同一個 bucket prefix，要序列化的是 S3 寫入本身。
+#
+# 用 false 而非 true：run 被中途取消有機會停在 `s3 rm` 之後、`s3 sync` 之前，那會留下
+# 一個空的 bucket。排隊比取消安全。排隊中的 run 若被更新的 run 取代，它還沒開始執行，
+# 不會碰到 S3。
+concurrency:
+  group: build-docs-s3
+  cancel-in-progress: false
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## 這個 PR 做了什麼 / What this PR does

`build_docs.yml` 加上 workflow 層級的 concurrency group，讓 BuildDocs 的 run 自動排隊，避免兩個 run 的 S3 清理與上傳交錯。

相關 Issue / Related issue：無

## 問題 / The problem

Workflow 的最後兩步是：

```yaml
- name: Clean the all files
  run: aws s3 rm s3://${{ secrets.DOC_BUCKET }}/docs --recursive
- name: Upload to S3
  run: aws s3 sync ./output s3://${{ secrets.DOC_BUCKET }}/docs/ --acl public-read
```

先清空再上傳，中間沒有任何互斥保護。兩個 run 重疊時，後者的 `s3 rm` 會落在前者 `s3 sync` 進行到一半，S3 上會出現一段內容不完整的空窗。

2026-08-05 連續同步兩次 `docs` 分支時實際遇到：前一個 run 還停在 `Clean the all files`，第二次推送就會再觸發一個。當時是靠人工等前一個跑完才推，這個 PR 讓它自動化。

## 改動 / The change

```yaml
concurrency:
  group: build-docs-s3
  cancel-in-progress: false
```

兩個設計選擇：

- **group 不帶 ref**。`workflow_dispatch` 可以從任何分支觸發，而所有 run 都寫同一個 bucket prefix。要序列化的是 S3 寫入本身，不是分支，所以用單一全域 group。
- **`cancel-in-progress: false`**。取消執行中的 run 有機會剛好停在 `s3 rm` 之後、`s3 sync` 之前，那會留下一個空的 bucket，比原本的問題更糟。排隊中的 run 若被更新的 run 取代，它還沒開始執行，不會碰到 S3，所以排隊這個方向是安全的。

## 驗證 / Verification

- `yaml.safe_load` 解析通過，`concurrency` 與 `jobs` 結構如預期
- `grep` 確認 `build_docs.yml` 是唯一會寫 S3 的 workflow（`check-ripe.yml`、`lookback-ooni.yml` 都不碰），一組 group 涵蓋全部

## 後續可考慮（不在本 PR）/ Possible follow-up

即使只有單一 run，`rm --recursive` 再 `sync` 本身就有一段 S3 內容不完整的空窗。改成 `aws s3 sync ./output s3://.../docs/ --delete` 可以完全消除那個空窗，最終狀態與現在相同（一樣會清掉已移除的檔案），但不需要先清空。這是部署機制的改動，範圍比本 PR 大，另外開比較合適。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uFosDifjwskLuhUzQ1pgr
