### PR TITLE
docs(community): OONI 系列四篇改用書面語，清除 AI 腔的鋪陳與口語

### DIFF
--- a/docs/en/community/asn-coverage-howto.md
+++ b/docs/en/community/asn-coverage-howto.md
@@ -28,7 +28,7 @@ OONI's observation data has three entry points serving quite different purposes.
 
 ## What the scripts can answer
 
-Know the tool's boundaries before starting. `ooni.py` currently produces coverage and verdict-distribution statistics, and its retrieval scope has three limits:
+`ooni.py` currently produces coverage and verdict-distribution statistics. Its retrieval scope has three limits:
 
 - **It reads the `webconnectivity` directory only.** The dozen-plus other nettests in the same hour are not included, so observations from `tor`, `telegram`, `signal` and the rest never reach the statistics. For what each nettest measures, see [OONI nettest quick reference](./ooni-nettests-map.md).
 - **It takes three fields per measurement**, `probe_asn`, `annotations.network_type` and `test_keys.blocking`. It never reads the evidence layer (`queries`, `tcp_connect`, `requests`), so the output can answer "which ASNs have someone measuring, how often, and how the verdicts break down" but not "what does the evidence for one measurement look like".

--- a/docs/en/community/ooni-blocking-determination.md
+++ b/docs/en/community/ooni-blocking-determination.md
@@ -98,7 +98,7 @@ An Egyptian measurement of `http://www.newipnow.com/` came back as `http-diff`, 
 | Probe | `520` | `newipnow.com \| 520: Web server is returning an unknown error` |
 | test helper | `200` | `Buy Private Proxies: $0.88 per Dedicated Premium IP - NewIPNow` |
 
-`520` is the error page Cloudflare returns when the origin server in front of the target site misbehaves, which means the site itself was failing at the time and Egyptian network controls had nothing to do with it. Worth noting too: that measurement's `probe_asn` is `AS13335` (Cloudflare), so the measuring end was also running on Cloudflare's network, which falls under the second category below.
+`520` is the error page Cloudflare returns when the origin server in front of the target site misbehaves, which means the site itself was failing at the time and Egyptian network controls had nothing to do with it. That measurement's `probe_asn` is `AS13335` (Cloudflare), so the measuring end was also running on Cloudflare's network, which falls under the second category below.
 
 Common sources of misreading group into a few kinds:
 

--- a/docs/en/community/ooni-data-format.md
+++ b/docs/en/community/ooni-data-format.md
@@ -6,9 +6,9 @@ icon: material/code-json
 
 # :material-code-json: Reading an OONI measurement
 
-[ASN observation data retrieval and analysis](./asn-coverage-howto.md) covers how to pull OONI's public data. Once you have it, the next problem shows up: a single measurement carries more than twenty top-level fields, with another twenty-odd inside `test_keys`. Which ones matter?
+A single OONI measurement carries more than twenty top-level fields, with another twenty-odd inside `test_keys`. [ASN observation data retrieval and analysis](./asn-coverage-howto.md) covers how to pull this public data; this page covers how to read it once retrieved.
 
-Below, two real measurements from Taiwan are compared side by side to explain how a Web Connectivity (`web_connectivity`) measurement is put together, and which upstream [ooni/spec](https://github.com/ooni/spec){target="_blank"} document defines each field. Once the layout is clear you can judge for yourself what a measurement says, and decide which fields your analysis code needs to read.
+Two real measurements from Taiwan are compared side by side below to set out how a Web Connectivity (`web_connectivity`) measurement is put together, and which upstream [ooni/spec](https://github.com/ooni/spec){target="_blank"} document defines each field.
 
 !!! info "Where these examples come from"
 
@@ -21,17 +21,17 @@ Below, two real measurements from Taiwan are compared side by side to explain ho
 
 ## Three layers in one measurement
 
-There is no need to memorise every field up front. A measurement reads as three layers:
+A measurement divides into three layers:
 
 1. **The envelope**: who measured, from where, with which software, and when. Every nettest shares this same set of fields, defined in [df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"}.
 2. **The verdict**: the conclusion the measurement reached. These fields vary by nettest and all live under `test_keys`. For `web_connectivity` they are defined in [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}.
 3. **The evidence**: the raw record behind the conclusion, covering every DNS query, TCP connection, TLS handshake and HTTP request, plus the control's equivalent records. Also under `test_keys`, each with its own `df-` specification.
 
-The verdict layer tells you the conclusion. The evidence layer lets you check it. Read them separately and each field's role becomes clear.
+The verdict layer states the conclusion; the evidence layer holds the records supporting it.
 
-## Pull one for yourself
+## Retrieving a measurement
 
-Following along with a sample in hand is much faster. You do not need a local environment first, since the public API returns a single measurement directly. Start by listing measurements that match your criteria:
+The public API returns a single measurement directly, with no local environment required. Start by listing measurements that match your criteria:
 
 ```bash title="List recent Web Connectivity measurements from Taiwan"
 curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&limit=5" \
@@ -77,7 +77,7 @@ Envelope fields are identical across every nettest. These are the ones you reach
 
 Verdict fields all live under `test_keys`. One thing to know before reading them: `web_connectivity` reaches its verdict by comparison. After the Probe finishes, an OONI test helper on an unrestricted network measures the same URL again, and the difference between the two sides is what the verdict is built from. The test helper's side is recorded under `test_keys.control`, which is what "the control" refers to below.
 
-Eight fields carry the verdict and the content comparison. Side by side, the difference is obvious:
+Eight fields carry the verdict and the content comparison, shown side by side below:
 
 | Field | Passed | Flagged as anomalous | Meaning |
 |---|---|---|---|

--- a/docs/en/community/ooni-nettests-map.md
+++ b/docs/en/community/ooni-nettests-map.md
@@ -18,9 +18,9 @@ This page condenses all 41 into one reference table, noting each one's upstream 
 
     **Taiwan** comes from the S3 public dataset, spot-checking the nettest directories that appeared under Taiwan across five time slots on 2026-08-03.
 
-## First, one thing: a status marker is not a data supply
+## A status marker is not a data supply
 
-Specification markers and actual data do disagree. Before the tables below, note the gap runs in both directions:
+Specification markers and actual data do disagree, and the gap runs in both directions:
 
 - **Marked `current` with no data to be found**: `tlsmiddlebox`, `portfiltering` and `captiveportal`.
 - **Marked `experimental` with data every day**: `dnscheck`, `echcheck`, `openvpn`, `stunreachability` and `vanilla_tor` among others, at volumes comparable to some `current` nettests.
@@ -29,7 +29,7 @@ Specification markers and actual data do disagree. Before the tables below, note
 
 ## Grouped by purpose
 
-Arriving with a question about what to observe, pick a direction here first and then check the tables for detail:
+The groupings below are by observation purpose; the tables that follow carry the detail:
 
 - **Website blocking detection**: `web_connectivity`
 - **Middleboxes and interference techniques**: `http_header_field_manipulation`, `http_invalid_request_line`, `sni_blocking`, `echcheck`
@@ -40,7 +40,7 @@ Arriving with a question about what to observe, pick a direction here first and 
 
 ## Nettests still producing data
 
-Every nettest below had public measurements available on the day of writing. These are the ones you meet most often when reading OONI data.
+Every nettest below had public measurements available on the day of writing, and these are also the ones encountered most often when reading OONI data.
 
 | Nettest | What it measures | Spec status | Taiwan |
 |---|---|---|---|

--- a/docs/zh-CN/community/asn-coverage-howto.md
+++ b/docs/zh-CN/community/asn-coverage-howto.md
@@ -6,17 +6,17 @@ icon: material/database-search
 
 # :material-database-search: ASN 观测资料撷取与分析
 
-本页是 [ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md) 的技术延伸：当你想自己撷取 OONI 公开资料、计算特定区域 ASN 的观测覆盖率时，以下介绍 [anoni-net/docs](https://github.com/anoni-net/docs){target="_blank"} 提供的撷取程序如何设置与使用。
+本页是 [ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md) 的技术延伸，说明 [anoni-net/docs](https://github.com/anoni-net/docs){target="_blank"} 提供的撷取程序如何设置与使用，用于撷取 OONI 公开资料并计算特定区域 ASN 的观测覆盖率。
 
-开始前建议先读 [项目研究预先准备](./setup-repo.md) 把开发环境建好。
+开始前建议先读 [项目研究预先准备](./setup-repo.md) 建置开发环境。
 
 !!! tip "执行位置"
 
-    下面的指令都在 `anoni-net-docs/asn_coverage/` 目录下执行。第一次使用先 `cd` 进该目录，执行 `uv sync` 安装依赖，接着依下方范例以 `uv run python ooni.py ...` 执行。
+    以下指令均在 `anoni-net-docs/asn_coverage/` 目录下执行。初次使用先 `cd` 进该目录，执行 `uv sync` 安装依赖，再依下方范例以 `uv run python ooni.py ...` 执行。
 
 ## 三种取用路径
 
-OONI 的观测资料有三个入口，用途差异很大，先选对再着手：
+OONI 的观测资料有三个入口，用途差异很大，着手前需先选定：
 
 | 入口 | 适合的情境 | 限制 |
 |---|---|---|
@@ -24,19 +24,19 @@ OONI 的观测资料有三个入口，用途差异很大，先选对再着手：
 | [OONI API](https://api.ooni.io/api/v1/measurements){target="_blank"} | 依条件筛选、取单笔完整测量 | 单次回传笔数有上限 |
 | [OONI Explorer](https://explorer.ooni.org/){target="_blank"} | 人工查阅、确认个别测量 | 不适合程序化取用 |
 
-`asn_coverage` 采用 S3 路径，目的是统计覆盖率而非查单笔。想查单笔或做小量筛选，[OONI 测量资料结构导览](./ooni-data-format.md) 有 API 的用法。
+`asn_coverage` 采用 S3 路径，目的是统计覆盖率而非查询单笔。单笔查询与小量筛选的 API 用法见 [OONI 测量资料结构导览](./ooni-data-format.md)。
 
 ## 程序能回答什么
 
-着手之前先确认工具的边界，`ooni.py` 现阶段做覆盖率与判定分布统计，取用范围有三个限制：
+`ooni.py` 现阶段做覆盖率与判定分布统计，取用范围有三个限制：
 
-- **只读 `webconnectivity` 目录**。同一小时底下其他十几个测项没有纳入，`tor`、`telegram`、`signal` 等测项的观测不会出现在统计里。各测项分别测什么见 [OONI 测项速查表](./ooni-nettests-map.md)。
-- **每笔测量只取三个栏位**，`probe_asn`、`annotations.network_type` 与 `test_keys.blocking`。证据层的 `queries`、`tcp_connect`、`requests` 没有读取，因此输出能回答「哪些 ASN 有人在测、测了几次、判定结果的分布」，无法回答「某一笔测量的证据长什么样」。
+- **只读 `webconnectivity` 目录**。同一小时底下其他十几个测项未纳入，`tor`、`telegram`、`signal` 等测项的观测不会出现在统计中。各测项的量测对象见 [OONI 测项速查表](./ooni-nettests-map.md)。
+- **每笔测量只取三个栏位**，`probe_asn`、`annotations.network_type` 与 `test_keys.blocking`。证据层的 `queries`、`tcp_connect`、`requests` 未读取，因此输出可回答「哪些 ASN 有人在测、测了几次、判定结果的分布」，无法回答「单笔测量的证据内容」。
 - **只取 `.jsonl.gz`**，同目录的 `.tar.gz` 会跳过。
 
 `blocking` 未观测到干预时是布尔值 `false`、有干预时是字串，程序在计数前已统一为同一组键，没有判定结果的测量记为 `none`，因此每个 ASN 的判定分布加总必然等于测量笔数。判读前提见 [OONI 怎么判定一个网站被封锁](./ooni-blocking-determination.md)。
 
-想再往下一层，下一步是取证据层的栏位逐笔比对，那需要另外设计储存方式，单纯的计数统计装不下。
+再往下一层须取证据层的栏位逐笔比对，该作法需要另行设计储存方式，单纯的计数统计无法容纳。
 
 ## S3 资料集的摆放方式
 
@@ -48,22 +48,22 @@ raw/{YYYYMMDD}/{HH}/{国码}/{测项}/{YYYYMMDDHH}_{国码}_{测项}.n{编号}.{
 
 !!! warning "日期与小时都是 UTC"
 
-    路径中的 `{YYYYMMDD}` 与 `{HH}`、以及后面 CSV 输出的 `date` 与 `hour` 栏位，全部使用 UTC。程序内部一律以 `arrow.Arrow.utcnow()` 取时间。要分析「台湾某个时段的观测分布」时记得加 8 小时换算，否则图表会整体偏移。
+    路径中的 `{YYYYMMDD}` 与 `{HH}`，以及后续 CSV 输出的 `date` 与 `hour` 栏位，全部使用 UTC。程序内部一律以 `arrow.Arrow.utcnow()` 取时间。分析「台湾某个时段的观测分布」时须加 8 小时换算，否则图表会整体偏移。
 
-文件名尾端的 `.n{编号}.{序号}` 是 OONI 内部的批次编号，解析时可以忽略。
+文件名尾端的 `.n{编号}.{序号}` 是 OONI 内部的批次编号，解析时可忽略。
 
-不必安装任何工具，也能先确认里面有什么：
+确认目录内容不需安装任何工具：
 
 ```bash title="列出台湾某小时的所有测项"
 curl -s "https://ooni-data-eu-fra.s3.eu-central-1.amazonaws.com/?list-type=2&prefix=raw/20260804/00/TW/&delimiter=/" \
   | grep -oE '<Prefix>raw/[^<]+</Prefix>'
 ```
 
-回应是未断行的 XML，上面接了 `grep` 只取出目录名称。台湾在单一小时内通常会有十几个测项目录，`webconnectivity` 只是其中之一，同层还有 `tor`、`telegram`、`signal`、`whatsapp`、`dnscheck`、`echcheck`、`openvpn`、`psiphon`、`ndt`、`dash` 等。
+回应是未断行的 XML，上例接 `grep` 只取出目录名称。台湾在单一小时内通常有十几个测项目录，`webconnectivity` 仅为其中之一，同层还有 `tor`、`telegram`、`signal`、`whatsapp`、`dnscheck`、`echcheck`、`openvpn`、`psiphon`、`ndt`、`dash` 等。
 
-每个测项目录底下同一批资料有两种封装，`.jsonl.gz` 与 `.tar.gz`。`.jsonl.gz` 解开后一行一笔测量，适合逐行解析，程序取用的正是 `.jsonl.gz`。以 2026-08-04 台湾的 `webconnectivity` 为例，单一文件约 10 MB，换算成整月全国资料会相当可观，实际执行前先估算频宽与执行时间。程序采串流处理，原始文件不会落地保存，最后只输出 CSV。
+每个测项目录底下同一批资料有两种封装，`.jsonl.gz` 与 `.tar.gz`。`.jsonl.gz` 解开后一行一笔测量，适合逐行解析，程序取用的即为 `.jsonl.gz`。以 2026-08-04 台湾的 `webconnectivity` 为例，单一文件约 10 MB，换算成整月全国资料相当可观，执行前应先估算频宽与执行时间。程序采串流处理，原始文件不会落地保存，最终只输出 CSV。
 
-每一行的栏位怎么读，见 [OONI 测量资料结构导览](./ooni-data-format.md)。判定栏位代表什么，见 [OONI 怎么判定一个网站被封锁](./ooni-blocking-determination.md)。
+各栏位的判读方式见 [OONI 测量资料结构导览](./ooni-data-format.md)，判定栏位的含义见 [OONI 怎么判定一个网站被封锁](./ooni-blocking-determination.md)。
 
 ## 撷取与分析指令
 
@@ -73,11 +73,11 @@ curl -s "https://ooni-data-eu-fra.s3.eu-central-1.amazonaws.com/?list-type=2&pre
 uv run python ooni.py lookback --units=36 --loc=TW --frame=hours
 ```
 
-三个参数都可省略，默认值即为上例。`--frame` 决定回溯总长度的单位，可填 `hours`、`days`、`weeks` 等，无论填什么，资料一律按小时切分。输出文件名格式：
+三个参数均可省略，默认值即为上例。`--frame` 决定回溯总长度的单位，可填 `hours`、`days`、`weeks` 等，无论何者，资料一律按小时切分。输出文件名格式：
 
 - `lookback_{loc}_{YYYYMMDD}_{units}_{frame}.csv`
 
-文件名中的 `{YYYYMMDD}` 是执行当日的 UTC 日期，并非资料涵盖的区间，资料范围要看文件内容。文件写在目前的工作目录。
+文件名中的 `{YYYYMMDD}` 是执行当日的 UTC 日期，并非资料涵盖的区间，实际范围须查看文件内容。文件写入当前的工作目录。
 
 ### 取得区间资料
 
@@ -85,7 +85,7 @@ uv run python ooni.py lookback --units=36 --loc=TW --frame=hours
 uv run python ooni.py span --start=2026/08/01 --end=2026/08/03 --loc=TW --chunk=40
 ```
 
-带入开始时间（`start`）与结束时间（`end`），取得该期间各小时区间的资料。`--chunk` 控制同时处理的小时数，默认 `40`，网络或内存不足时调小。输出文件名格式：
+带入开始时间（`start`）与结束时间（`end`），取得该期间各小时区间的资料。`--chunk` 控制同时处理的小时数，默认 `40`，网络或内存不足时应调小。输出文件名格式：
 
 - `span_{loc}_{开始YYYYMMDD}_{结束YYYYMMDD}.csv`
 
@@ -95,7 +95,7 @@ uv run python ooni.py span --start=2026/08/01 --end=2026/08/03 --loc=TW --chunk=
 uv run python ooni.py sheetrow --path=./span_TW_20260801_20260803.csv
 ```
 
-将已撷取的资料展开，方便在试算表中计算。输出文件名是原文件名前面加上 `rows_`，以上例而言是 `rows_span_TW_20260801_20260803.csv`。
+将已撷取的资料展开，便于在试算表中计算。输出文件名为原文件名前加上 `rows_`，上例即 `rows_span_TW_20260801_20260803.csv`。
 
 ## 输出的 CSV 栏位格式
 
@@ -119,18 +119,18 @@ uv run python ooni.py sheetrow --path=./span_TW_20260801_20260803.csv
               "AS24158": {"false": 51}}}
 ```
 
-`counts` 与 `blocking` 的加总逐 ASN 相等，`network_type` 则不会对上。`network_type` 由 Probe 自行标记，行动版 App 通常会写入，CLI 与桌面版多半不会，上例 551 笔中只有 51 笔带标记，程序会跳过没有标记的测量。其中 `no_internet` 代表 Probe 在测量当下判定自身没有连线。标记涵盖率不到一成，适合看趋势，不适合当作行动与固网的比例依据。
+`counts` 与 `blocking` 的加总逐 ASN 相等，`network_type` 则不会对上。`network_type` 由 Probe 自行标记，行动版 App 通常会写入，CLI 与桌面版多半不会，上例 551 笔中仅 51 笔带标记，程序会跳过未标记的测量。其中 `no_internet` 代表 Probe 在测量当下判定自身没有连线。标记涵盖率不到一成，适合观察趋势，不适合作为行动与固网的比例依据。
 
-`blocking` 里的 `none` 代表该笔没有判定结果，缺 `test_keys` 或 `blocking` 为 `null` 都算。上例 551 笔中有 11 笔属于此类，占比不高但每个 ASN 都出现，做异常率统计时要决定放进分母或排除。
+`blocking` 中的 `none` 代表该笔没有判定结果，缺 `test_keys` 或 `blocking` 为 `null` 均计入此类。上例 551 笔中有 11 笔属之，占比不高但每个 ASN 都出现，计算异常率前须决定是否纳入分母。
 
-巢状 JSON 不易在试算表里计算，`sheetrow` 的作用就是把它摊平成一列一个 ASN：
+巢状 JSON 不易在试算表中计算，`sheetrow` 的作用即是将其摊平为一列一个 ASN：
 
 | `loc` | `date` | `hour` | `asn` | `count` | `anomaly` | `blocking_false` | `blocking_dns` | `blocking_tcp_ip` |
 |---|---|---|---|---|---|---|---|---|
 | `TW` | `2026/08/04` | `00` | `AS3462` | `300` | `2` | `294` | `1` | `1` |
 | `TW` | `2026/08/04` | `00` | `AS17716` | `100` | `0` | `94` | `0` | `0` |
 
-完整栏位还有 `blocking_http_failure`、`blocking_http_diff`、`blocking_none` 与 `blocking_other`，上表为版面只列前几栏。`anomaly` 是四种干预类型的加总，可以直接在试算表当分子用。`blocking_other` 收 ts-017 尚未定义的值，正常情况下应为 `0`，出现非零代表上游新增了判定类型。
+完整栏位还有 `blocking_http_failure`、`blocking_http_diff`、`blocking_none` 与 `blocking_other`，上表受限于版面仅列前几栏。`anomaly` 是四种干预类型的加总，可直接在试算表中作为分子。`blocking_other` 收 ts-017 尚未定义的值，正常情况下应为 `0`，出现非零即代表上游新增了判定类型。
 
 实际分析输出的试算表范例（2023-09 至 2023-12）：
 
@@ -138,7 +138,7 @@ uv run python ooni.py sheetrow --path=./span_TW_20260801_20260803.csv
 
 ## 计算 ASN 覆盖率
 
-覆盖率需要两份数字，观测资料中出现过的不重复 ASN 数，以及该区域登记在案的 ASN 总数。前者从上一节摊平后的 CSV 用枢纽分析取得，后者用 `ripe.py` 向 RIPE NCC 索取：
+覆盖率需要两份数字，观测资料中出现过的不重复 ASN 数，以及该区域登记在案的 ASN 总数。前者由上一节摊平后的 CSV 以枢纽分析取得，后者以 `ripe.py` 向 RIPE NCC 索取：
 
 ```bash title="取得该区域的全量 ASN 清单"
 uv run python ripe.py save --loc=TW
@@ -146,9 +146,9 @@ uv run python ripe.py save --loc=TW
 
 输出文件名为 `asns_{YYYYMMDDTHH}.csv`，六个栏位分别是 `no`、`location`、`org_id`、`registrar`、`reserved`、`name`。
 
-!!! warning "两边的 ASN 格式不同，比对前要先统一"
+!!! warning "两边的 ASN 格式不同，比对前须先统一"
 
-    `ripe.py` 输出的 `no` 栏位是纯数字（`3462`），OONI 资料的 `probe_asn` 带 `AS` 前缀（`AS3462`）。直接用 VLOOKUP 比对会全部落空，比对前要先替其中一边补上或去掉 `AS`。
+    `ripe.py` 输出的 `no` 栏位是纯数字（`3462`），OONI 资料的 `probe_asn` 带 `AS` 前缀（`AS3462`）。迳以 VLOOKUP 比对会全部落空，须先为其中一边补上或去除 `AS`。
 
 两份数字备齐后即可计算：
 
@@ -156,11 +156,11 @@ uv run python ripe.py save --loc=TW
 覆盖率 = 观测资料中出现的不重复 ASN 数 ÷ 该区域登记的 ASN 总数
 ```
 
-以 [ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md) 引用的 2023-12 报告为例，台湾当时约有 437 组 ASN，观测资料涵盖的不重复 ASN 占 7.32%。你可以用同样的算式重算近期区间，对照覆盖率是否改善。
+以 [ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md) 引用的 2023-12 报告为例，台湾当时约有 437 组 ASN，观测资料涵盖的不重复 ASN 占 7.32%。同一算式可用于重算近期区间，对照覆盖率是否改善。
 
 ## 下一步
 
-抓到资料之后，接着看每一行的栏位怎么读。
+取得资料之后，接续判读各栏位的内容。
 
 <div class="grid cards" markdown>
 

--- a/docs/zh-CN/community/ooni-blocking-determination.md
+++ b/docs/zh-CN/community/ooni-blocking-determination.md
@@ -6,9 +6,9 @@ icon: material/shield-search
 
 # :material-shield-search: OONI 怎么判定一个网站被封锁
 
-[OONI 测量资料结构导览](./ooni-data-format.md) 说明了栏位放在哪里，接下来的问题是栏位值怎么算出来。看到 `blocking: "dns"` 时，多数情况还不足以断定某个网站在台湾被封锁。
+[OONI 测量资料结构导览](./ooni-data-format.md) 说明各栏位的位置，本页说明判定栏位的计算方式。`blocking: "dns"` 在多数情况下并不足以断定某个网站在台湾被封锁。
 
-`blocking` 只纪录单次测量与对照组不一致，距离「确认封锁」还有几步。以下拆解判定机制、四种类型各自对应的证据，以及把单笔测量推到可信结论需要补上什么。
+`blocking` 纪录的是单次测量与对照组不一致，与「确认封锁」尚有距离。以下拆解判定机制、四种类型各自对应的证据，以及单笔测量推向可信结论所需的补强。
 
 ## 判定的基础：双边对照
 
@@ -24,11 +24,11 @@ test helper 是 OONI 架设在外部网络的测量服务器，观测结果收�
 | HTTP 有回应，内容与 test helper 取得的不同 | `blocking: "http-diff"` |
 | 两边都正常且内容相符 | `blocking: false`、`accessible: true` |
 
-判定顺序由前往后，DNS 阶段就出问题时不会继续往下比对。四个 `*_match` 栏位在前三种情况下全是 `null`，原因正是比对在更早的阶段就中止。
+判定顺序由前往后，DNS 阶段出问题即不再往下比对。四个 `*_match` 栏位在前三种情况下全为 `null`，原因正是比对已在更早的阶段中止。
 
 !!! tip "先看 `control` 再看 `blocking`"
 
-    `blocking` 是双边比对的结果，不是 Probe 单方面的观测。判读任何一笔异常测量时，先确认 `test_keys.control` 里 test helper 看到什么，再回头读 `blocking`。下一节的 `tcp_ip` 范例会示范，忽略 `control` 会把网站自身的问题误判成封锁。
+    `blocking` 是双边比对的结果，并非 Probe 单方面的观测。判读异常测量时，应先确认 `test_keys.control` 中 test helper 的观测内容，再回头读 `blocking`。下一节的 `tcp_ip` 范例即说明，忽略 `control` 会把网站自身的问题误判成封锁。
 
 ## 四种判定对应的证据
 
@@ -43,41 +43,41 @@ test helper 是 OONI 架设在外部网络的测量服务器，观测结果收�
 {"query_type": "AAAA", "failure": "dns_nxdomain_error", "answers": []}
 ```
 
-DNS 判定要留意解析器归属。该笔的 `resolver_asn` 是 `AS13335`（Cloudflare），`probe_asn` 则是 `AS3462`（中华电信）。测量者把 DNS 指向境外服务时，DNS 阶段的异常未必反映本地电信商的行为。
+DNS 判定须留意解析器归属。该笔的 `resolver_asn` 是 `AS13335`（Cloudflare），`probe_asn` 则是 `AS3462`（中华电信）。测量者将 DNS 指向境外服务时，DNS 阶段的异常未必反映本地电信商的行为。
 
 ### `tcp_ip`：连不到目标位址
 
 台湾 `http://www.tkec.com.tw/` 的测量判定为 `tcp_ip`，DNS 正常解析到 `210.64.193.1`，Probe 连 `80` 埠逾时。
 
-只看 Probe 端容易误读成封锁，对照 `control` 的结果就会得到不同结论：
+单看 Probe 端容易误读成封锁，对照 `control` 的结果则得出不同结论：
 
 ```json title="test_keys.control.tcp_connect"
 {"210.64.193.1:443": {"status": true,  "failure": null},
  "210.64.193.1:80":  {"status": false, "failure": "generic_timeout_error"}}
 ```
 
-test helper 从外部连 `80` 埠同样逾时，代表该网站的 `80` 埠从外部一样连不上，与台湾的网络环境无关。同一个 IP 的 `443` 埠两边都通，更说明问题出在该埠而非路径。
+test helper 从外部连 `80` 埠同样逾时，代表该网站的 `80` 埠从外部亦无法连通，与台湾的网络环境无关。同一个 IP 的 `443` 埠两侧皆通，进一步显示问题出在该埠而非路径。
 
-### `http-failure`：连得上但取不到内容
+### `http-failure`：连线建立后取不到内容
 
-台湾 `https://bit.ly/` 的测量判定为 `http-failure`。DNS 正常，两个目标 IP 的 `443` 埠都连得上，`control` 显示 test helper 端也一样，差异出现在 HTTP 阶段的 `generic_timeout_error`。
+台湾 `https://bit.ly/` 的测量判定为 `http-failure`。DNS 正常，两个目标 IP 的 `443` 埠皆可连通，`control` 显示 test helper 端亦同，差异出现在 HTTP 阶段的 `generic_timeout_error`。
 
-连线层没问题而应用层失败，常见于服务器端的速率限制、对特定来源的拒绝服务，以及 TLS 层的中断。要区分成因需要看 `tls_handshakes` 与 `network_events` 的时序。
+连线层正常而应用层失败，常见于服务器端的速率限制、对特定来源的拒绝服务，以及 TLS 层的中断。区分成因须查看 `tls_handshakes` 与 `network_events` 的时序。
 
 ### `http-diff`：取得的内容不一致
 
-台湾的资料里有 `http-diff`，但样态与封锁告示页不同（见文末台湾现况），以下改用印尼的测量说明典型的告示页长什么样。
+台湾的资料中有 `http-diff`，但样态与封锁告示页不同（见文末台湾现况），以下改用印尼的测量说明典型的告示页样态。
 
-四种类型里只有 `http-diff` 会让四个 `*_match` 栏位派上用场。印尼 `http://www.sportsinteraction.com/` 的测量是典型例子：
+四种类型中只有 `http-diff` 会用到四个 `*_match` 栏位。印尼 `http://www.sportsinteraction.com/` 的测量是典型例子：
 
 | 观测方 | 状态码 | 标题 | 内容长度 |
 |---|---|---|---|
 | Probe | `200` | `Trustpositif` | 7,044 |
 | test helper | `403` | `Maintenance` | 7,067 |
 
-Probe 的请求被重导向到 `http://lamanlabuh.aduankonten.id/`，落在印尼官方的内容申诉域名，页面标题 `Trustpositif` 是当地网络内容过滤系统的名称。ISP 在连线途中把使用者导向告示页，是 `http-diff` 最典型的成因。
+Probe 的请求被重导向到 `http://lamanlabuh.aduankonten.id/`，落在印尼官方的内容申诉域名，页面标题 `Trustpositif` 是当地网络内容过滤系统的名称。ISP 在连线途中将使用者导向告示页，是 `http-diff` 最典型的成因。
 
-该笔同时示范了单一栏位不可靠：
+该笔同时显示单一栏位不足以作为判准：
 
 ```text title="四个 *_match 栏位与 body_proportion"
 title_match: false        status_code_match: false
@@ -85,44 +85,44 @@ headers_match: true       body_length_match: true
 body_proportion: 0.9967
 ```
 
-`body_length_match` 为 `true`、`body_proportion` 逼近 `1`，纯粹因为封锁告示页与对照组页面的长度刚好接近。只看长度会得到错误结论，四个栏位要一起读，其中 `title_match` 与 `status_code_match` 的鉴别力通常最高。
+`body_length_match` 为 `true`、`body_proportion` 逼近 `1`，起因仅是封锁告示页与对照组页面的长度接近。单看长度会得到错误结论，四个栏位须一并判读，其中 `title_match` 与 `status_code_match` 的鉴别力通常最高。
 
-## 误判从哪里来
+## 误判的来源
 
-`blocking` 有值而实际上没有网络干预，是资料集里的常态。前面 `tkec.com.tw` 的 `80` 埠不通已经是一例，再看一笔更隐蔽的。
+`blocking` 有值而实际上没有网络干预，是资料集中的常态。前述 `tkec.com.tw` 的 `80` 埠不通即为一例，以下是一笔更隐蔽的。
 
-埃及 `http://www.newipnow.com/` 的测量判定为 `http-diff`，四个 `*_match` 有三个不符，`body_proportion` 只有 `0.02`。看起来像被插入封锁页，实际内容是：
+埃及 `http://www.newipnow.com/` 的测量判定为 `http-diff`，四个 `*_match` 有三个不符，`body_proportion` 仅 `0.02`，表面上近似被插入封锁页。实际内容如下：
 
 | 观测方 | 状态码 | 标题 |
 |---|---|---|
 | Probe | `520` | `newipnow.com \| 520: Web server is returning an unknown error` |
 | test helper | `200` | `Buy Private Proxies: $0.88 per Dedicated Premium IP - NewIPNow` |
 
-`520` 是目标网站前方的 Cloudflare 在来源服务器异常时回应的错误页，代表该网站当下发生异常，与埃及的网络管制无关。另外值得留意的是，该笔的 `probe_asn` 是 `AS13335`（Cloudflare），测量端本身也走在 Cloudflare 的网络上，属于下面第二类的测量环境因素。
+`520` 是目标网站前方的 Cloudflare 在来源服务器异常时回应的错误页，代表该网站当下发生异常，与埃及的网络管制无关。该笔的 `probe_asn` 是 `AS13335`（Cloudflare），测量端本身亦位于 Cloudflare 的网络上，属于下列第二类的测量环境因素。
 
-常见的误判来源可以归成几类：
+常见的误判来源可分为几类：
 
 - **来源网站自身状态**：服务器错误、维护页、CDN 错误页、地理限制。
-- **测量环境**：Probe 开着 VPN 或 Tor 时，测到的是出口所在地的网络。
-- **网站的动态内容**：轮播广告、个人化内容、A/B 测试会让两边的内容本来就不同。
+- **测量环境**：Probe 启用 VPN 或 Tor 时，测得的是出口所在地的网络。
+- **网站的动态内容**：轮播广告、个人化内容、A/B 测试会使两侧内容原本即不相同。
 - **对照组本身失败**：`control_failure` 有值时，双边比对的前提不成立。
 
-OONI 在资料集层级也处理同一类问题，作法可参考 [OONI 如何分辨坏掉的量测资料](../blog/posts/2026-ooni-faulty-measurements.md)，该文整理了 OONI 用哪些启发式规则过滤异常投稿。
+OONI 在资料集层级亦处理同一类问题，作法见 [OONI 如何分辨坏掉的量测资料](../blog/posts/2026-ooni-faulty-measurements.md)，该文整理了 OONI 过滤异常投稿所用的启发式规则。
 
 ## 从单笔测量到可信结论
 
-要把观测推进到「某个网站在某地被封锁」，单笔资料不够。实务上补上几个维度：
+将观测推进到「某个网站在某地被封锁」，单笔资料并不足够。实务上须补上几个维度：
 
-1. **跨时间**：同一个网址在数天到数周内反覆出现同样的判定，才能排除偶发故障。
-2. **跨 ASN**：多家电信商都测到相同结果，指向网络层的普遍行为。只在单一 ASN 出现，较可能是该业者的个别设置。
-3. **跨解析器**：换不同 DNS 解析器仍然异常，才能排除解析器自身问题。
-4. **看 `confirmed` 栏位**：OONI 后端会用已知的封锁告示页指纹比对测量，命中时把 `confirmed` 标为 `true`。该栏位在 [measurements API](https://api.ooni.io/api/v1/measurements){target="_blank"} 的回应中，属于后端分析结果，不在 Probe 产生的原始资料里。
+1. **跨时间**：同一个网址在数天到数周内反覆出现同样的判定，方能排除偶发故障。
+2. **跨 ASN**：多家电信商测得相同结果，指向网络层的普遍行为。仅在单一 ASN 出现者，较可能是该业者的个别设置。
+3. **跨解析器**：更换 DNS 解析器后仍然异常，方能排除解析器自身问题。
+4. **`confirmed` 栏位**：OONI 后端以已知的封锁告示页指纹比对测量，命中时将 `confirmed` 标为 `true`。该栏位位于 [measurements API](https://api.ooni.io/api/v1/measurements){target="_blank"} 的回应中，属于后端分析结果，不在 Probe 产生的原始资料内。
 
-想自己执行跨时间或跨 ASN 的比对，[ASN 观测资料撷取与分析](./asn-coverage-howto.md) 有批次取用的作法。
+跨时间与跨 ASN 比对的批次取用作法，见 [ASN 观测资料撷取与分析](./asn-coverage-howto.md)。
 
 !!! warning "`confirmed` 为 `true` 不等于 `http-diff`"
 
-    两者容易混淆。`confirmed` 标记的依据是封锁指纹比对，DNS 被导向已知的封锁用 IP 也会标记为 `confirmed`，判定类型仍是 `dns`。撰稿时抽查伊朗、俄罗斯、土耳其、中国各 5 笔 `confirmed` 测量，样本全部落在 `blocking: "dns"`。样本数少，仅能说明两者并非同一件事，不足以推论一般规律。
+    两者易于混淆。`confirmed` 标记的依据是封锁指纹比对，DNS 被导向已知的封锁用 IP 同样会标记为 `confirmed`，判定类型仍是 `dns`。撰稿时抽查伊朗、俄罗斯、土耳其、中国各 5 笔 `confirmed` 测量，样本全部落在 `blocking: "dns"`。样本数少，仅能说明两者并非同一件事，不足以推论一般规律。
 
 ## 台湾现况
 
@@ -137,34 +137,34 @@ OONI 在资料集层级也处理同一类问题，作法可参考 [OONI 如何�
 | `http-failure` | 67 | 0.30% |
 | `http-diff` | 35 | 0.16% |
 
-四种干预类型合计 564 笔，占全部测量的 2.55%。`none` 是缺 `test_keys` 或 `blocking` 为 `null` 的测量，做异常率统计时要先决定放进分母或排除。
+四种干预类型合计 564 笔，占全部测量的 2.55%。`none` 是缺 `test_keys` 或 `blocking` 为 `null` 的测量，计算异常率前须先决定是否纳入分母。
 
 另外抽查 100 笔异常测量，`confirmed` 为 `true` 的有 0 笔，与 [ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md) 长期以来的描述一致。
 
 !!! warning "小样本会给出错误的分布"
 
-    本页初稿曾以 measurements API 异常清单的 40 笔抽样估计判定分布，得到 `dns` 最多、`http-diff` 挂零的结论。改用全量统计后两点都不成立：实际上 `tcp_ip` 是 `dns` 的两倍以上，`http-diff` 也确实存在。API 的异常清单有自己的排序，直接当随机样本用会失准。要看分布请走全量统计，作法见 [ASN 观测资料撷取与分析](./asn-coverage-howto.md)。
+    本页初稿曾以 measurements API 异常清单的 40 笔抽样估计判定分布，得到 `dns` 最多、`http-diff` 为零的结论。改用全量统计后两点皆不成立：`tcp_ip` 为 `dns` 的两倍以上，`http-diff` 亦确实存在。API 的异常清单另有排序逻辑，迳自视为随机样本会失准。判定分布应以全量统计取得，作法见 [ASN 观测资料撷取与分析](./asn-coverage-howto.md)。
 
-台湾的 `http-diff` 与前面印尼的例子不是同一回事。抽查 4 小时区间内的 15 笔，`body_proportion` 全部落在 `0.004` 到 `0.21`，Probe 取到的内容远短于对照组，与封锁告示页那种逼近 `1` 的样态相反。内容极短通常指向错误页或空回应，成因需要逐笔查验证据层才能判断，本页不下结论。
+台湾的 `http-diff` 与前述印尼的例子属于不同现象。抽查 4 小时区间内的 15 笔，`body_proportion` 全部落在 `0.004` 到 `0.21`，Probe 取得的内容远短于对照组，与封锁告示页逼近 `1` 的样态相反。内容极短通常指向错误页或空回应，成因须逐笔查验证据层方能判断，本页不下结论。
 
-要自己重新执行上面的统计：
+重新执行上述统计的指令：
 
 ```bash title="取得判定分布"
 uv run python ooni.py lookback --units=24 --loc=TW --frame=hours
 ```
 
-指令会印出 `blocking` 的合计，并把逐 ASN 的分布写进 CSV。单笔查验仍走 API：
+该指令会印出 `blocking` 的合计，并将逐 ASN 的分布写入 CSV。单笔查验仍使用 API：
 
 ```bash title="列出台湾的异常测量"
 curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&anomaly=true&limit=100" \
   | python3 -m json.tool | head -40
 ```
 
-以上是单一 24 小时区间的快照，反映的是当日样态，不足以当作长期趋势的结论。要看趋势需要涵盖更长时间，而台湾的观测本身就存在 ASN 集中度过高的限制，细节见前面提到的 [ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md)。
+以上是单一 24 小时区间的快照，反映当日样态，不足以作为长期趋势的结论。趋势分析须涵盖更长时间，而台湾的观测本身即存在 ASN 集中度过高的限制，细节见前述 [ASN 自治网络观测资料分析](../taiwan/ooni-asn-coverage.md)。
 
 ## 延伸阅读
 
-想自己执行跨时间、跨 ASN 的比对，从撷取指南开始。
+跨时间、跨 ASN 的比对从撷取指南开始。
 
 <div class="grid cards" markdown>
 

--- a/docs/zh-CN/community/ooni-data-format.md
+++ b/docs/zh-CN/community/ooni-data-format.md
@@ -6,9 +6,9 @@ icon: material/code-json
 
 # :material-code-json: OONI 测量资料结构导览
 
-[ASN 观测资料撷取与分析](./asn-coverage-howto.md) 说明了如何撷取 OONI 公开资料，取得资料之后会遇到下一个问题：一笔测量有二十多个顶层栏位，`test_keys` 里还有二十几个，该看哪一个。
+一笔 OONI 测量有二十多个顶层栏位，`test_keys` 底下还有二十几个。[ASN 观测资料撷取与分析](./asn-coverage-howto.md) 说明撷取公开资料的方法，本页接续说明撷取之后如何判读栏位。
 
-以下用两笔台湾的真实测量对照，说明一笔网络连线测试（`web_connectivity`）的组成，以及每个栏位对应到上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的哪份规格。看懂之后，你可以自己判断一笔测量说了什么，也能决定分析程序该取哪些栏位。
+以下以两笔台湾的真实测量对照，拆解网络连线测试（`web_connectivity`）的组成，并标出各栏位对应上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的哪份规格。
 
 !!! info "范例资料来源"
 
@@ -21,17 +21,17 @@ icon: material/code-json
 
 ## 一笔测量的三层结构
 
-不用一开始就记住所有栏位。一笔测量可以拆成三层来读：
+一笔测量可以拆成三层：
 
 1. **外壳**：谁在哪里、用什么软件、什么时候测的。所有测项共用同一套栏位，规格是 [df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"}。
 2. **判定**：测量得出的结论。栏位随测项而异，全部收在 `test_keys` 底下，`web_connectivity` 的定义在 [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}。
 3. **证据**：支撑结论的原始纪录，包含每一次 DNS 查询、TCP 连线、TLS 握手与 HTTP 请求，以及对照组的同类纪录。同样放在 `test_keys` 底下，各自对应一份 `df-` 开头的规格。
 
-判定层告诉你结论，证据层让你验证结论。两者分开读，各栏位的角色就清楚了。
+判定层给出结论，证据层保留支撑结论的纪录。
 
-## 自己取一笔来看
+## 取得一笔测量
 
-边读边对照手上的样本会快很多。不必先架好环境，用公开 API 就能取得单笔资料。先列出符合条件的测量：
+公开 API 可直接取得单笔测量，不需事先架设环境。先列出符合条件的测量：
 
 ```bash title="列出台湾最近的网络连线测试"
 curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&limit=5" \
@@ -45,13 +45,13 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
   | python3 -m json.tool | head -60
 ```
 
-原始回应是未断行的长字串，直接输出到终端机不易阅读，上面两段都接了 `python3 -m json.tool` 排版。加上 `anomaly=true` 可以只列出被判定异常的测量，适合用来找对照范例。把 `probe_cc` 换成所在地区、`probe_asn` 换成自己的 ASN，就能看到本地网络上的观测纪录。
+原始回应是未断行的长字串，上面两段接 `python3 -m json.tool` 排版后才易于阅读。查询参数加上 `anomaly=true` 可筛出判定异常的测量，适合用于寻找对照范例。改写 `probe_cc` 与 `probe_asn` 即可查询指定地区与网络的观测纪录。
 
-需要批次处理大量资料时，改走 AWS S3 公开资料集会更有效率，作法见 [ASN 观测资料撷取与分析](./asn-coverage-howto.md)。
+批次处理大量资料时，AWS S3 公开资料集的效率较高，作法见 [ASN 观测资料撷取与分析](./asn-coverage-howto.md)。
 
 ## 外壳：谁在哪里测的
 
-外壳层的栏位在所有测项中都一样，实务上最常用到的如下：
+外壳层的栏位在所有测项中一致，其中常用者如下：
 
 | 栏位 | 正常通过那笔 | 判定异常那笔 | 说明 |
 |---|---|---|---|
@@ -67,17 +67,17 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 | `measurement_start_time` | `2026-08-04 08:59:30` | `2026-08-04 08:45:45` | 测量开始时间（UTC）|
 | `report_id` | `20260804T062033Z_webconnectivity_TW_3462_n4_uEH5rGoD07cN2oYQ` | `20260804T084446Z_webconnectivity_TW_3462_n4_dFfWCDrwouM0TsT2` | 同一次执行产生的多笔测量共用此值 |
 
-`probe_asn` 与 `resolver_asn` 可能不同，上表就是实例。两笔都在中华电信的网络上执行，但其中一笔的使用者把 DNS 指向 Cloudflare。做 ASN 分析时两者要分开看，混用会让「哪家电信商的网络上看到什么」失准。
+`probe_asn` 与 `resolver_asn` 可能分属不同网络，上表即为实例。两笔测量都在中华电信的网络上执行，其中一笔的使用者将 DNS 指向 Cloudflare。ASN 分析须将两者分开计算，混用会使「特定电信商网络上的观测结果」失准。
 
 !!! note "`probe_ip` 永远是 `127.0.0.1`"
 
-    OONI 刻意不收集测量者的真实 IP，`probe_ip` 固定写入本机位址。想追测量来源只能仰赖 `probe_asn` 加时间，同一条隐私边界在 [OONI Run v2 操作说明](../tools/ooni-run-v2.md) 也提醒协助者留意。
+    OONI 刻意不收集测量者的真实 IP，`probe_ip` 固定写入本机位址。回溯测量来源只能仰赖 `probe_asn` 与时间，[OONI Run v2 操作说明](../tools/ooni-run-v2.md) 针对同一条隐私边界另有提醒。
 
 ## 判定：测量得出的结论
 
-判定栏位全部收在 `test_keys` 底下。读之前要先知道一件事：`web_connectivity` 的判定建立在双边对照上。Probe 测完之后，OONI 架设在外部网络的测量服务器（test helper）会对同一个网址再测一次，两边结果的差异才是判定的依据。test helper 那一侧的纪录收在 `test_keys.control`，下表的「对照组」指的就是它。
+判定栏位全部收在 `test_keys` 底下，其计算基础是双边对照。Probe 测完之后，OONI 架设在外部网络的测量服务器（test helper）会对同一个网址再测一次，两边结果的差异即为判定依据。test helper 那一侧的纪录收在 `test_keys.control`，下表的「对照组」即指该侧纪录。
 
-判定结果与内容比对共八个栏位。把两笔并排，差异一眼可见：
+判定结果与内容比对共八个栏位，两笔并排如下：
 
 | 栏位 | 正常通过 | 判定异常 | 说明 |
 |---|---|---|---|
@@ -90,7 +90,7 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 | `body_length_match` | `true` | `null` | 回应内容长度是否相近 |
 | `body_proportion` | `1` | `0` | 内容长度与对照组的比值 |
 
-各阶段的失败原因另有三个栏位，判读时要一起看：
+各阶段的失败原因另有三个栏位，须与上表一并判读：
 
 | 栏位 | 纪录什么 |
 |---|---|
@@ -98,25 +98,25 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 | `http_experiment_failure` | HTTP 阶段的失败原因，例如 `"generic_timeout_error"` |
 | `control_failure` | 对照组本身是否失败。有值时双边比对的前提不成立，判定结果不可信 |
 
-`blocking` 的四种值分别对应不同阶段的异常：`dns` 是解析结果与对照组不一致、`tcp_ip` 是封包送不到目标位址、`http-failure` 是连线建立后 HTTP 阶段失败、`http-diff` 是取得的内容与对照组不同（常见于封锁告示页）。四种手法在 [什么是 OONI](../tools/what-is-ooni.md) 有概念层的介绍。
+`blocking` 的四种值分别对应不同阶段的异常：`dns` 是解析结果与对照组不一致、`tcp_ip` 是封包送不到目标位址、`http-failure` 是连线建立后 HTTP 阶段失败、`http-diff` 是取得的内容与对照组不同（常见于封锁告示页）。四种干预手法的概念说明见 [什么是 OONI](../tools/what-is-ooni.md)。
 
 !!! tip "两个容易误判的类型问题"
 
-    `blocking` 未观测到干预时是布尔值 `false`，有干预时是字串。拿它做统计前要先统一处理，否则 `false` 与 `"dns"` 会被算成两类不同的东西。
+    `blocking` 未观测到干预时是布尔值 `false`，有干预时是字串。统计前需先统一类型，否则 `false` 与 `"dns"` 会被归为两类。
 
-    四种值的命名本身不一致，`tcp_ip` 用下划线，`http-failure` 与 `http-diff` 用连字号。上游如此定义，照抄即可，不要自行统一。
+    四种值的命名本身不一致，`tcp_ip` 用下划线，`http-failure` 与 `http-diff` 用连字号。上游即如此定义，引用时照原样写入，不应自行统一。
 
-四个 `*_match` 栏位在异常那笔全是 `null`，原因是 DNS 阶段就失败，连线没有建立，后续没有东西可以比对。看到一整排 `null` 时，回头找测量流程中第一个有值的 failure 栏位，那里才是问题发生的地方。
+四个 `*_match` 栏位在异常那笔全为 `null`，原因是 DNS 阶段即失败，连线未建立，后续无可比对的内容。遇到整排 `null`，应回溯测量流程中第一个有值的 failure 栏位，该处才是问题发生的阶段。
 
 !!! warning "异常不等于封锁"
 
-    `blocking` 有值只代表该笔测量的结果与对照组不一致，判断是否真的存在网络干预需要更多佐证。以判定异常那笔为例，Probe 对 `ntc.party` 的 A 与 AAAA 查询都回报 `dns_nxdomain_error`（域名不存在），但撰稿时从多个公开 DNS 解析器查询，该域名可解析到 IPv6 位址。单笔测量无法区分网络干预、解析器当下的暂时状态，以及域名本身的设置变动。
+    `blocking` 有值仅代表该笔测量的结果与对照组不一致，确认是否存在网络干预需要更多佐证。以判定异常那笔为例，Probe 对 `ntc.party` 的 A 与 AAAA 查询都回报 `dns_nxdomain_error`（域名不存在），但撰稿时以多个公开 DNS 解析器查询，该域名可解析到 IPv6 位址。单笔测量无法区分网络干预、解析器的暂时状态与域名自身的设置变动。
 
-    要下封锁结论，需要跨时间、跨 ASN、跨解析器的多笔测量交叉比对。判定机制的完整拆解与常见误判来源见 [OONI 怎么判定一个网站被封锁](./ooni-blocking-determination.md)，资料集层级的品质控制则可参考 [OONI 如何分辨坏掉的量测资料](../blog/posts/2026-ooni-faulty-measurements.md)。
+    认定封锁需以跨时间、跨 ASN、跨解析器的多笔测量交叉比对。判定机制的完整拆解与常见误判来源见 [OONI 怎么判定一个网站被封锁](./ooni-blocking-determination.md)，资料集层级的品质控制见 [OONI 如何分辨坏掉的量测资料](../blog/posts/2026-ooni-faulty-measurements.md)。
 
 ## 证据：支撑结论的原始纪录
 
-`test_keys` 底下另有几个栏位，纪录测量过程中每一次网络操作。每个栏位各有一份规格：
+`test_keys` 底下另有数个栏位，纪录测量过程中的每一次网络操作，各对应一份规格：
 
 | 栏位 | 内容 | 规格 |
 |---|---|---|
@@ -128,7 +128,7 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 | `control` | 对照组的同类纪录，结构与 Probe 侧对应，判定栏位全部由它与 Probe 端的差异算出 | [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} |
 | 各栏位的 `failure` 字串 | 所有失败原因的统一命名，例如 `dns_nxdomain_error`、`generic_timeout_error`、`ssl_unknown_authority` | [df-007-errors](https://github.com/ooni/spec/blob/master/data-formats/df-007-errors.md){target="_blank"} |
 
-把两笔的 `queries` 摊开对照，就能看到判定的依据：
+两笔的 `queries` 对照如下：
 
 ```json title="正常通过：查到位址"
 {
@@ -148,21 +148,21 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 }
 ```
 
-判定层的 `dns_consistency` 是结论，`queries` 与 `control` 是它的依据。想确认一笔测量的判定是否合理，往证据层查验即可。
+判定层的 `dns_consistency` 是结论，`queries` 与 `control` 是其依据。判定是否合理，查验证据层即可确认。
 
 ## 版本与相容性
 
-读 spec 之前先确认版本，能避免不少困惑：
+对照 spec 前需先确认版本：
 
 - **`data_format_version` 目前是 `0.2.0`**。外壳层的栏位定义稳定，[df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"} 可以直接对照。
 - **`web_connectivity` 实际流通的 `test_version` 是 `0.4.3`**。[ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} 的规格内容已更新为描述 v0.5 演算法，但生产环境仍以 v0.4 为主。spec 明订新版演算法必须使用不同的 test_keys 栏位，v0.4 的栏位定义保持相容，因此上表的栏位读法对两个版本都适用。
 - **`x_` 开头的栏位不在 spec 内**。实际资料中会看到 `x_dns_runtime`、`x_status`、`x_th_runtime` 等栏位，属于实作端的实验性扩充，随版本增减，分析程序不应依赖它们。
 
-上游 spec 的 master 分支自 2025-06 起没有新的合并，但 issue 与 PR 讨论持续进行（进行中的提案包含 ICMP 资料格式与 DPI 分片测项）。spec 现阶段适合当作稳定参考，引用时建议连回上游原文，避免自行复制规格内容而在上游更新后失准。
+上游 spec 的 master 分支自 2025-06 起没有新的合并，但 issue 与 PR 讨论持续进行（进行中的提案包含 ICMP 资料格式与 DPI 分片测项）。spec 现阶段可作为稳定参考。引用时应连回上游原文，避免复制规格内容后因上游更新而失准。
 
 ## 延伸阅读
 
-看懂栏位之后，接着看判定栏位怎么算出来，以及为什么有值不等于封锁。
+判定栏位的计算方式，以及有值为何不等于封锁，见以下各篇。
 
 <div class="grid cards" markdown>
 

--- a/docs/zh-CN/community/ooni-nettests-map.md
+++ b/docs/zh-CN/community/ooni-nettests-map.md
@@ -6,11 +6,11 @@ icon: material/table-search
 
 # :material-table-search: OONI 测项速查表
 
-[ooni/spec](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 的 `nettests` 目录收录 41 份测项规格，其中有相当比例已经停止使用。要挑测项或解读手上的资料时，先知道哪些还在产出资料，比逐份读规格有效率。
+[ooni/spec](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 的 `nettests` 目录收录 41 份测项规格，其中有相当比例已停止使用。挑选测项或解读既有资料时，先确认哪些仍在产出资料，效率高于逐份阅读规格。
 
-本页把 41 份规格整理成一张对照表，标注上游规格的状态、实际是否还有公开资料，以及台湾观测到哪几个。
+本页将 41 份规格整理成一张对照表，标注上游规格的状态、实际是否仍有公开资料，以及台湾观测到的项目。
 
-!!! info "状态栏位怎么读"
+!!! info "状态栏位的定义"
 
     **spec 状态**取自各份规格开头的 `_status_` 标记，分为 `current`、`experimental`、`obsolete` 三种，反映上游对该测项的定位。
 
@@ -18,18 +18,18 @@ icon: material/table-search
 
     **台湾**栏位来自 S3 公开资料集，抽查 2026-08-03 五个时段台湾底下出现过的测项目录。
 
-## 先看一件事：状态标记不等于实际有资料
+## 状态标记不等于实际有资料
 
-规格标记与实际资料不一致的情况存在，看下面的表格前先知道两个方向的落差：
+规格标记与实际资料不一致的情况确实存在，落差有两个方向：
 
 - **标为 `current` 却查不到资料**：`tlsmiddlebox`、`portfiltering`、`captiveportal` 三个。
 - **标为 `experimental` 却每日都有资料**：`dnscheck`、`echcheck`、`openvpn`、`stunreachability`、`vanilla_tor` 等，资料量与部分 `current` 测项相当。
 
-`experimental` 只反映规格本身的成熟度，与资料量多寡没有必然关系。要判断某个测项是否适合用于分析，直接查 API 是否有资料，比看状态标记可靠。
+`experimental` 仅反映规格本身的成熟度，与资料量多寡没有必然关系。判断测项是否适合用于分析，直接查询 API 是否有资料，较状态标记可靠。
 
 ## 依用途分群
 
-带着「我想观测什么」进来的话，先从下面挑方向，再到表格查细节：
+以下依观测目的分群，细节再对照后方表格：
 
 - **网站封锁侦测**：`web_connectivity`
 - **中间设备与干扰手法**：`http_header_field_manipulation`、`http_invalid_request_line`、`sni_blocking`、`echcheck`
@@ -40,9 +40,9 @@ icon: material/table-search
 
 ## 仍在产出资料的测项
 
-以下测项在撰稿当日都查得到公开测量，是解读 OONI 资料时最常遇到的一批。
+以下测项在撰稿当日皆查得到公开测量，也是解读 OONI 资料时最常遇到的测项。
 
-| 测项 | 测什么 | spec 状态 | 台湾 |
+| 测项 | 量测内容 | spec 状态 | 台湾 |
 |---|---|---|---|
 | [`web_connectivity`](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} | 网站可达性与封锁判定，资料量最大的测项 | current | 有 |
 | [`tor`](https://github.com/ooni/spec/blob/master/nettests/ts-023-tor.md){target="_blank"} | Tor 目录权威节点与桥接的可达性 | current | 有 |
@@ -75,16 +75,16 @@ icon: material/table-search
 
 ## 偶尔才有资料的测项
 
-| 测项 | 测什么 | spec 状态 | 最近一笔 |
+| 测项 | 量测内容 | spec 状态 | 最近一笔 |
 |---|---|---|---|
 | [`quicping`](https://github.com/ooni/spec/blob/master/nettests/ts-031-quicping.md){target="_blank"} | QUIC 协定的可达性 | experimental | 2026-07-30 |
 | [`sni_blocking`](https://github.com/ooni/spec/blob/master/nettests/ts-024-sni-blocking.md){target="_blank"} | 针对 TLS SNI 栏位的封锁侦测 | experimental | 2026-07-20 |
 
 ## 查不到公开资料的测项
 
-以下七个测项在 API 查不到公开测量。规格仍在上游仓库里，设计新测项或研究方法时可以参考。
+以下七个测项在 API 查不到公开测量。规格仍保留在上游仓库，可供设计新测项或研究方法时参考。
 
-| 测项 | 测什么 | spec 状态 |
+| 测项 | 量测内容 | spec 状态 |
 |---|---|---|
 | [`tlsmiddlebox`](https://github.com/ooni/spec/blob/master/nettests/ts-037-tlsmiddlebox.md){target="_blank"} | TLS 连线路径上的中间设备行为 | current |
 | [`portfiltering`](https://github.com/ooni/spec/blob/master/nettests/ts-038-port-filtering.md){target="_blank"} | 特定连接埠是否被过滤 | current |
@@ -96,7 +96,7 @@ icon: material/table-search
 
 ## 标记为 obsolete 的历史测项
 
-上游标为 `obsolete` 的有 12 份，多数功能已被 `web_connectivity` 吸收，或随着测量方法演进而退场。处理历史资料时可能会遇到它们的纪录，规划新的观测时没有理由采用它们。
+上游标为 `obsolete` 的有 12 份，多数功能已被 `web_connectivity` 吸收，或随测量方法演进而退场。处理历史资料时仍可能遇到这些测项的纪录，规划新的观测则无采用的理由。
 
 | 测项 | 规格 |
 |---|---|
@@ -115,17 +115,17 @@ icon: material/table-search
 
 !!! note "编号重复的两份 OpenVPN 规格"
 
-    上游有两份规格都编为 `ts-016`，分别是上表标为 `obsolete` 的 `ts-016-openvpn.md` 与标为 `experimental` 的 `ts-016-vanilla-tor.md`。现行的 OpenVPN 测项规格是 `ts-040-openvpn.md`，引用时留意不要取到旧的那份。
+    上游有两份规格同编为 `ts-016`，分别是上表标为 `obsolete` 的 `ts-016-openvpn.md` 与标为 `experimental` 的 `ts-016-vanilla-tor.md`。现行的 OpenVPN 测项规格是 `ts-040-openvpn.md`，引用时须留意勿取到旧版。
 
 ## 台湾观测到哪些测项
 
 抽查 2026-08-03 五个时段，台湾底下出现过 17 个测项（以下用 API 的下划线写法）：`web_connectivity`、`tor`、`vanilla_tor`、`telegram`、`whatsapp`、`signal`、`facebook_messenger`、`dnscheck`、`echcheck`、`http_header_field_manipulation`、`http_invalid_request_line`、`openvpn`、`psiphon`、`riseupvpn`、`stunreachability`、`ndt`、`dash`。
 
-S3 上的目录名与 `test_name` 写法不同，目录名没有下划线（`webconnectivity`、`vanillator`、`facebookmessenger`），API 查询要用下划线形式（`web_connectivity`、`vanilla_tor`、`facebook_messenger`）。取用路径的细节见 [ASN 观测资料撷取与分析](./asn-coverage-howto.md)。
+S3 上的目录名与 `test_name` 写法不同，目录名没有下划线（`webconnectivity`、`vanillator`、`facebookmessenger`），API 查询须用下划线形式（`web_connectivity`、`vanilla_tor`、`facebook_messenger`）。取用路径的细节见 [ASN 观测资料撷取与分析](./asn-coverage-howto.md)。
 
-台湾目前的观测集中在 `web_connectivity`，其他测项的样本量偏小。想扩充在地观测的涵盖面，`tor` 与 `dnscheck` 是与社群既有主题最接近的两个方向。
+台湾目前的观测集中在 `web_connectivity`，其他测项的样本量偏小。扩充在地观测的涵盖面时，`tor` 与 `dnscheck` 是与社群既有主题最接近的两个方向。
 
-实际执行特定测项有两条路径。用 [OONI Probe](https://ooni.org/install/){target="_blank"} 桌面或行动版，在设置里挑选要启用的测项。想邀请其他人一起测固定的网址清单，改用 [OONI Run v2](../tools/ooni-run-v2.md) 建立连结分享，社群目前维运的连结 ID 是 `10328`。
+执行特定测项有两条路径。[OONI Probe](https://ooni.org/install/){target="_blank"} 桌面或行动版可在设置中挑选启用的测项。若要邀集他人共同测试固定的网址清单，则以 [OONI Run v2](../tools/ooni-run-v2.md) 建立连结分享，社群目前维运的连结 ID 是 `10328`。
 
 ## 延伸阅读
 

--- a/docs/zh-TW/community/asn-coverage-howto.md
+++ b/docs/zh-TW/community/asn-coverage-howto.md
@@ -6,17 +6,17 @@ icon: material/database-search
 
 # :material-database-search: ASN 觀測資料擷取與分析
 
-本頁是 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md) 的技術延伸：當你想自己擷取 OONI 公開資料、計算特定區域 ASN 的觀測覆蓋率時，以下介紹 [anoni-net/docs](https://github.com/anoni-net/docs){target="_blank"} 提供的擷取程式如何設定與使用。
+本頁是 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md) 的技術延伸，說明 [anoni-net/docs](https://github.com/anoni-net/docs){target="_blank"} 提供的擷取程式如何設定與使用，用於擷取 OONI 公開資料並計算特定區域 ASN 的觀測覆蓋率。
 
-開始前建議先讀 [專案研究預先準備](./setup-repo.md) 把開發環境建好。
+開始前建議先讀 [專案研究預先準備](./setup-repo.md) 建置開發環境。
 
 !!! tip "執行位置"
 
-    下面的指令都在 `anoni-net-docs/asn_coverage/` 目錄下執行。第一次使用先 `cd` 進該目錄，執行 `uv sync` 安裝依賴，接著依下方範例以 `uv run python ooni.py ...` 執行。
+    以下指令均在 `anoni-net-docs/asn_coverage/` 目錄下執行。初次使用先 `cd` 進該目錄，執行 `uv sync` 安裝依賴，再依下方範例以 `uv run python ooni.py ...` 執行。
 
 ## 三種取用路徑
 
-OONI 的觀測資料有三個入口，用途差異很大，先選對再著手：
+OONI 的觀測資料有三個入口，用途差異很大，著手前需先選定：
 
 | 入口 | 適合的情境 | 限制 |
 |---|---|---|
@@ -24,19 +24,19 @@ OONI 的觀測資料有三個入口，用途差異很大，先選對再著手：
 | [OONI API](https://api.ooni.io/api/v1/measurements){target="_blank"} | 依條件篩選、取單筆完整測量 | 單次回傳筆數有上限 |
 | [OONI Explorer](https://explorer.ooni.org/zh-Hant){target="_blank"} | 人工查閱、確認個別測量 | 不適合程式化取用 |
 
-`asn_coverage` 採用 S3 路徑，目的是統計覆蓋率而非查單筆。想查單筆或做小量篩選，[OONI 測量資料結構導覽](./ooni-data-format.md) 有 API 的用法。
+`asn_coverage` 採用 S3 路徑，目的是統計覆蓋率而非查詢單筆。單筆查詢與小量篩選的 API 用法見 [OONI 測量資料結構導覽](./ooni-data-format.md)。
 
 ## 程式能回答什麼
 
-著手之前先確認工具的邊界，`ooni.py` 現階段做覆蓋率與判定分布統計，取用範圍有三個限制：
+`ooni.py` 現階段做覆蓋率與判定分布統計，取用範圍有三個限制：
 
-- **只讀 `webconnectivity` 目錄**。同一小時底下其他十幾個測項沒有納入，`tor`、`telegram`、`signal` 等測項的觀測不會出現在統計裡。各測項分別測什麼見 [OONI 測項速查表](./ooni-nettests-map.md)。
-- **每筆測量只取三個欄位**，`probe_asn`、`annotations.network_type` 與 `test_keys.blocking`。證據層的 `queries`、`tcp_connect`、`requests` 沒有讀取，因此輸出能回答「哪些 ASN 有人在測、測了幾次、判定結果的分布」，無法回答「某一筆測量的證據長什麼樣」。
+- **只讀 `webconnectivity` 目錄**。同一小時底下其他十幾個測項未納入，`tor`、`telegram`、`signal` 等測項的觀測不會出現在統計中。各測項的量測對象見 [OONI 測項速查表](./ooni-nettests-map.md)。
+- **每筆測量只取三個欄位**，`probe_asn`、`annotations.network_type` 與 `test_keys.blocking`。證據層的 `queries`、`tcp_connect`、`requests` 未讀取，因此輸出可回答「哪些 ASN 有人在測、測了幾次、判定結果的分布」，無法回答「單筆測量的證據內容」。
 - **只取 `.jsonl.gz`**，同目錄的 `.tar.gz` 會跳過。
 
 `blocking` 未觀測到干預時是布林值 `false`、有干預時是字串，程式在計數前已統一為同一組鍵，沒有判定結果的測量記為 `none`，因此每個 ASN 的判定分布加總必然等於測量筆數。判讀前提見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)。
 
-想再往下一層，下一步是取證據層的欄位逐筆比對，那需要另外設計儲存方式，單純的計數統計裝不下。
+再往下一層須取證據層的欄位逐筆比對，該作法需要另行設計儲存方式，單純的計數統計無法容納。
 
 ## S3 資料集的擺放方式
 
@@ -48,22 +48,22 @@ raw/{YYYYMMDD}/{HH}/{國碼}/{測項}/{YYYYMMDDHH}_{國碼}_{測項}.n{編號}.{
 
 !!! warning "日期與小時都是 UTC"
 
-    路徑中的 `{YYYYMMDD}` 與 `{HH}`、以及後面 CSV 輸出的 `date` 與 `hour` 欄位，全部使用 UTC。程式內部一律以 `arrow.Arrow.utcnow()` 取時間。要分析「台灣某個時段的觀測分布」時記得加 8 小時換算，否則圖表會整體偏移。
+    路徑中的 `{YYYYMMDD}` 與 `{HH}`，以及後續 CSV 輸出的 `date` 與 `hour` 欄位，全部使用 UTC。程式內部一律以 `arrow.Arrow.utcnow()` 取時間。分析「台灣某個時段的觀測分布」時須加 8 小時換算，否則圖表會整體偏移。
 
-檔名尾端的 `.n{編號}.{序號}` 是 OONI 內部的批次編號，解析時可以忽略。
+檔名尾端的 `.n{編號}.{序號}` 是 OONI 內部的批次編號，解析時可忽略。
 
-不必安裝任何工具，也能先確認裡面有什麼：
+確認目錄內容不需安裝任何工具：
 
 ```bash title="列出台灣某小時的所有測項"
 curl -s "https://ooni-data-eu-fra.s3.eu-central-1.amazonaws.com/?list-type=2&prefix=raw/20260804/00/TW/&delimiter=/" \
   | grep -oE '<Prefix>raw/[^<]+</Prefix>'
 ```
 
-回應是未斷行的 XML，上面接了 `grep` 只取出目錄名稱。台灣在單一小時內通常會有十幾個測項目錄，`webconnectivity` 只是其中之一，同層還有 `tor`、`telegram`、`signal`、`whatsapp`、`dnscheck`、`echcheck`、`openvpn`、`psiphon`、`ndt`、`dash` 等。
+回應是未斷行的 XML，上例接 `grep` 只取出目錄名稱。台灣在單一小時內通常有十幾個測項目錄，`webconnectivity` 僅為其中之一，同層還有 `tor`、`telegram`、`signal`、`whatsapp`、`dnscheck`、`echcheck`、`openvpn`、`psiphon`、`ndt`、`dash` 等。
 
-每個測項目錄底下同一批資料有兩種封裝，`.jsonl.gz` 與 `.tar.gz`。`.jsonl.gz` 解開後一行一筆測量，適合逐行解析，程式取用的正是 `.jsonl.gz`。以 2026-08-04 台灣的 `webconnectivity` 為例，單一檔案約 10 MB，換算成整月全國資料會相當可觀，實際執行前先估算頻寬與執行時間。程式採串流處理，原始檔不會落地保存，最後只輸出 CSV。
+每個測項目錄底下同一批資料有兩種封裝，`.jsonl.gz` 與 `.tar.gz`。`.jsonl.gz` 解開後一行一筆測量，適合逐行解析，程式取用的即為 `.jsonl.gz`。以 2026-08-04 台灣的 `webconnectivity` 為例，單一檔案約 10 MB，換算成整月全國資料相當可觀，執行前應先估算頻寬與執行時間。程式採串流處理，原始檔不會落地保存，最終只輸出 CSV。
 
-每一行的欄位怎麼讀，見 [OONI 測量資料結構導覽](./ooni-data-format.md)。判定欄位代表什麼，見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)。
+各欄位的判讀方式見 [OONI 測量資料結構導覽](./ooni-data-format.md)，判定欄位的含義見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)。
 
 ## 擷取與分析指令
 
@@ -73,11 +73,11 @@ curl -s "https://ooni-data-eu-fra.s3.eu-central-1.amazonaws.com/?list-type=2&pre
 uv run python ooni.py lookback --units=36 --loc=TW --frame=hours
 ```
 
-三個參數都可省略，預設值即為上例。`--frame` 決定回溯總長度的單位，可填 `hours`、`days`、`weeks` 等，無論填什麼，資料一律按小時切分。輸出檔名格式：
+三個參數均可省略，預設值即為上例。`--frame` 決定回溯總長度的單位，可填 `hours`、`days`、`weeks` 等，無論何者，資料一律按小時切分。輸出檔名格式：
 
 - `lookback_{loc}_{YYYYMMDD}_{units}_{frame}.csv`
 
-檔名中的 `{YYYYMMDD}` 是執行當日的 UTC 日期，並非資料涵蓋的區間，資料範圍要看檔案內容。檔案寫在目前的工作目錄。
+檔名中的 `{YYYYMMDD}` 是執行當日的 UTC 日期，並非資料涵蓋的區間，實際範圍須查看檔案內容。檔案寫入當前的工作目錄。
 
 ### 取得區間資料
 
@@ -85,7 +85,7 @@ uv run python ooni.py lookback --units=36 --loc=TW --frame=hours
 uv run python ooni.py span --start=2026/08/01 --end=2026/08/03 --loc=TW --chunk=40
 ```
 
-帶入開始時間（`start`）與結束時間（`end`），取得該期間各小時區間的資料。`--chunk` 控制同時處理的小時數，預設 `40`，網路或記憶體不足時調小。輸出檔名格式：
+帶入開始時間（`start`）與結束時間（`end`），取得該期間各小時區間的資料。`--chunk` 控制同時處理的小時數，預設 `40`，網路或記憶體不足時應調小。輸出檔名格式：
 
 - `span_{loc}_{開始YYYYMMDD}_{結束YYYYMMDD}.csv`
 
@@ -95,7 +95,7 @@ uv run python ooni.py span --start=2026/08/01 --end=2026/08/03 --loc=TW --chunk=
 uv run python ooni.py sheetrow --path=./span_TW_20260801_20260803.csv
 ```
 
-將已擷取的資料展開，方便在試算表中計算。輸出檔名是原檔名前面加上 `rows_`，以上例而言是 `rows_span_TW_20260801_20260803.csv`。
+將已擷取的資料展開，便於在試算表中計算。輸出檔名為原檔名前加上 `rows_`，上例即 `rows_span_TW_20260801_20260803.csv`。
 
 ## 輸出的 CSV 欄位格式
 
@@ -119,18 +119,18 @@ uv run python ooni.py sheetrow --path=./span_TW_20260801_20260803.csv
               "AS24158": {"false": 51}}}
 ```
 
-`counts` 與 `blocking` 的加總逐 ASN 相等，`network_type` 則不會對上。`network_type` 由 Probe 自行標記，行動版 App 通常會寫入，CLI 與桌面版多半不會，上例 551 筆中只有 51 筆帶標記，程式會跳過沒有標記的測量。其中 `no_internet` 代表 Probe 在測量當下判定自身沒有連線。標記涵蓋率不到一成，適合看趨勢，不適合當作行動與固網的比例依據。
+`counts` 與 `blocking` 的加總逐 ASN 相等，`network_type` 則不會對上。`network_type` 由 Probe 自行標記，行動版 App 通常會寫入，CLI 與桌面版多半不會，上例 551 筆中僅 51 筆帶標記，程式會跳過未標記的測量。其中 `no_internet` 代表 Probe 在測量當下判定自身沒有連線。標記涵蓋率不到一成，適合觀察趨勢，不適合作為行動與固網的比例依據。
 
-`blocking` 裡的 `none` 代表該筆沒有判定結果，缺 `test_keys` 或 `blocking` 為 `null` 都算。上例 551 筆中有 11 筆屬於此類，佔比不高但每個 ASN 都出現，做異常率統計時要決定放進分母或排除。
+`blocking` 中的 `none` 代表該筆沒有判定結果，缺 `test_keys` 或 `blocking` 為 `null` 均計入此類。上例 551 筆中有 11 筆屬之，佔比不高但每個 ASN 都出現，計算異常率前須決定是否納入分母。
 
-巢狀 JSON 不易在試算表裡計算，`sheetrow` 的作用就是把它攤平成一列一個 ASN：
+巢狀 JSON 不易在試算表中計算，`sheetrow` 的作用即是將其攤平為一列一個 ASN：
 
 | `loc` | `date` | `hour` | `asn` | `count` | `anomaly` | `blocking_false` | `blocking_dns` | `blocking_tcp_ip` |
 |---|---|---|---|---|---|---|---|---|
 | `TW` | `2026/08/04` | `00` | `AS3462` | `300` | `2` | `294` | `1` | `1` |
 | `TW` | `2026/08/04` | `00` | `AS17716` | `100` | `0` | `94` | `0` | `0` |
 
-完整欄位還有 `blocking_http_failure`、`blocking_http_diff`、`blocking_none` 與 `blocking_other`，上表為版面只列前幾欄。`anomaly` 是四種干預類型的加總，可以直接在試算表當分子用。`blocking_other` 收 ts-017 尚未定義的值，正常情況下應為 `0`，出現非零代表上游新增了判定類型。
+完整欄位還有 `blocking_http_failure`、`blocking_http_diff`、`blocking_none` 與 `blocking_other`，上表受限於版面僅列前幾欄。`anomaly` 是四種干預類型的加總，可直接在試算表中作為分子。`blocking_other` 收 ts-017 尚未定義的值，正常情況下應為 `0`，出現非零即代表上游新增了判定類型。
 
 實際分析輸出的試算表範例（2023-09 至 2023-12）：
 
@@ -138,7 +138,7 @@ uv run python ooni.py sheetrow --path=./span_TW_20260801_20260803.csv
 
 ## 計算 ASN 覆蓋率
 
-覆蓋率需要兩份數字，觀測資料中出現過的不重複 ASN 數，以及該區域登記在案的 ASN 總數。前者從上一節攤平後的 CSV 用樞紐分析取得，後者用 `ripe.py` 向 RIPE NCC 索取：
+覆蓋率需要兩份數字，觀測資料中出現過的不重複 ASN 數，以及該區域登記在案的 ASN 總數。前者由上一節攤平後的 CSV 以樞紐分析取得，後者以 `ripe.py` 向 RIPE NCC 索取：
 
 ```bash title="取得該區域的全量 ASN 清單"
 uv run python ripe.py save --loc=TW
@@ -146,9 +146,9 @@ uv run python ripe.py save --loc=TW
 
 輸出檔名為 `asns_{YYYYMMDDTHH}.csv`，六個欄位分別是 `no`、`location`、`org_id`、`registrar`、`reserved`、`name`。
 
-!!! warning "兩邊的 ASN 格式不同，比對前要先統一"
+!!! warning "兩邊的 ASN 格式不同，比對前須先統一"
 
-    `ripe.py` 輸出的 `no` 欄位是純數字（`3462`），OONI 資料的 `probe_asn` 帶 `AS` 前綴（`AS3462`）。直接用 VLOOKUP 比對會全部落空，比對前要先替其中一邊補上或去掉 `AS`。
+    `ripe.py` 輸出的 `no` 欄位是純數字（`3462`），OONI 資料的 `probe_asn` 帶 `AS` 前綴（`AS3462`）。逕以 VLOOKUP 比對會全部落空，須先為其中一邊補上或去除 `AS`。
 
 兩份數字備齊後即可計算：
 
@@ -156,11 +156,11 @@ uv run python ripe.py save --loc=TW
 覆蓋率 = 觀測資料中出現的不重複 ASN 數 ÷ 該區域登記的 ASN 總數
 ```
 
-以 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md) 引用的 2023-12 報告為例，台灣當時約有 437 組 ASN，觀測資料涵蓋的不重複 ASN 佔 7.32%。你可以用同樣的算式重算近期區間，對照覆蓋率是否改善。
+以 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md) 引用的 2023-12 報告為例，台灣當時約有 437 組 ASN，觀測資料涵蓋的不重複 ASN 佔 7.32%。同一算式可用於重算近期區間，對照覆蓋率是否改善。
 
 ## 下一步
 
-抓到資料之後，接著看每一行的欄位怎麼讀。
+取得資料之後，接續判讀各欄位的內容。
 
 <div class="grid cards" markdown>
 

--- a/docs/zh-TW/community/ooni-blocking-determination.md
+++ b/docs/zh-TW/community/ooni-blocking-determination.md
@@ -6,9 +6,9 @@ icon: material/shield-search
 
 # :material-shield-search: OONI 怎麼判定一個網站被封鎖
 
-[OONI 測量資料結構導覽](./ooni-data-format.md) 說明了欄位放在哪裡，接下來的問題是欄位值怎麼算出來。看到 `blocking: "dns"` 時，多數情況還不足以斷定某個網站在台灣被封鎖。
+[OONI 測量資料結構導覽](./ooni-data-format.md) 說明各欄位的位置，本頁說明判定欄位的計算方式。`blocking: "dns"` 在多數情況下並不足以斷定某個網站在台灣被封鎖。
 
-`blocking` 只記錄單次測量與對照組不一致，距離「確認封鎖」還有幾步。以下拆解判定機制、四種類型各自對應的證據，以及把單筆測量推到可信結論需要補上什麼。
+`blocking` 記錄的是單次測量與對照組不一致，與「確認封鎖」尚有距離。以下拆解判定機制、四種類型各自對應的證據，以及單筆測量推向可信結論所需的補強。
 
 ## 判定的基礎：雙邊對照
 
@@ -24,11 +24,11 @@ test helper 是 OONI 架設在外部網路的測量伺服器，觀測結果收�
 | HTTP 有回應，內容與 test helper 取得的不同 | `blocking: "http-diff"` |
 | 兩邊都正常且內容相符 | `blocking: false`、`accessible: true` |
 
-判定順序由前往後，DNS 階段就出問題時不會繼續往下比對。四個 `*_match` 欄位在前三種情況下全是 `null`，原因正是比對在更早的階段就中止。
+判定順序由前往後，DNS 階段出問題即不再往下比對。四個 `*_match` 欄位在前三種情況下全為 `null`，原因正是比對已在更早的階段中止。
 
 !!! tip "先看 `control` 再看 `blocking`"
 
-    `blocking` 是雙邊比對的結果，不是 Probe 單方面的觀測。判讀任何一筆異常測量時，先確認 `test_keys.control` 裡 test helper 看到什麼，再回頭讀 `blocking`。下一節的 `tcp_ip` 範例會示範，忽略 `control` 會把網站自身的問題誤判成封鎖。
+    `blocking` 是雙邊比對的結果，並非 Probe 單方面的觀測。判讀異常測量時，應先確認 `test_keys.control` 中 test helper 的觀測內容，再回頭讀 `blocking`。下一節的 `tcp_ip` 範例即說明，忽略 `control` 會把網站自身的問題誤判成封鎖。
 
 ## 四種判定對應的證據
 
@@ -43,41 +43,41 @@ test helper 是 OONI 架設在外部網路的測量伺服器，觀測結果收�
 {"query_type": "AAAA", "failure": "dns_nxdomain_error", "answers": []}
 ```
 
-DNS 判定要留意解析器歸屬。該筆的 `resolver_asn` 是 `AS13335`（Cloudflare），`probe_asn` 則是 `AS3462`（中華電信）。測量者把 DNS 指向境外服務時，DNS 階段的異常未必反映本地電信商的行為。
+DNS 判定須留意解析器歸屬。該筆的 `resolver_asn` 是 `AS13335`（Cloudflare），`probe_asn` 則是 `AS3462`（中華電信）。測量者將 DNS 指向境外服務時，DNS 階段的異常未必反映本地電信商的行為。
 
 ### `tcp_ip`：連不到目標位址
 
 台灣 `http://www.tkec.com.tw/` 的測量判定為 `tcp_ip`，DNS 正常解析到 `210.64.193.1`，Probe 連 `80` 埠逾時。
 
-只看 Probe 端容易誤讀成封鎖，對照 `control` 的結果就會得到不同結論：
+單看 Probe 端容易誤讀成封鎖，對照 `control` 的結果則得出不同結論：
 
 ```json title="test_keys.control.tcp_connect"
 {"210.64.193.1:443": {"status": true,  "failure": null},
  "210.64.193.1:80":  {"status": false, "failure": "generic_timeout_error"}}
 ```
 
-test helper 從外部連 `80` 埠同樣逾時，代表該網站的 `80` 埠從外部一樣連不上，與台灣的網路環境無關。同一個 IP 的 `443` 埠兩邊都通，更說明問題出在該埠而非路徑。
+test helper 從外部連 `80` 埠同樣逾時，代表該網站的 `80` 埠從外部亦無法連通，與台灣的網路環境無關。同一個 IP 的 `443` 埠兩側皆通，進一步顯示問題出在該埠而非路徑。
 
-### `http-failure`：連得上但取不到內容
+### `http-failure`：連線建立後取不到內容
 
-台灣 `https://bit.ly/` 的測量判定為 `http-failure`。DNS 正常，兩個目標 IP 的 `443` 埠都連得上，`control` 顯示 test helper 端也一樣，差異出現在 HTTP 階段的 `generic_timeout_error`。
+台灣 `https://bit.ly/` 的測量判定為 `http-failure`。DNS 正常，兩個目標 IP 的 `443` 埠皆可連通，`control` 顯示 test helper 端亦同，差異出現在 HTTP 階段的 `generic_timeout_error`。
 
-連線層沒問題而應用層失敗，常見於伺服器端的速率限制、對特定來源的拒絕服務，以及 TLS 層的中斷。要區分成因需要看 `tls_handshakes` 與 `network_events` 的時序。
+連線層正常而應用層失敗，常見於伺服器端的速率限制、對特定來源的拒絕服務，以及 TLS 層的中斷。區分成因須查看 `tls_handshakes` 與 `network_events` 的時序。
 
 ### `http-diff`：取得的內容不一致
 
-台灣的資料裡有 `http-diff`，但樣態與封鎖告示頁不同（見文末台灣現況），以下改用印尼的測量說明典型的告示頁長什麼樣。
+台灣的資料中有 `http-diff`，但樣態與封鎖告示頁不同（見文末台灣現況），以下改用印尼的測量說明典型的告示頁樣態。
 
-四種類型裡只有 `http-diff` 會讓四個 `*_match` 欄位派上用場。印尼 `http://www.sportsinteraction.com/` 的測量是典型例子：
+四種類型中只有 `http-diff` 會用到四個 `*_match` 欄位。印尼 `http://www.sportsinteraction.com/` 的測量是典型例子：
 
 | 觀測方 | 狀態碼 | 標題 | 內容長度 |
 |---|---|---|---|
 | Probe | `200` | `Trustpositif` | 7,044 |
 | test helper | `403` | `Maintenance` | 7,067 |
 
-Probe 的請求被重導向到 `http://lamanlabuh.aduankonten.id/`，落在印尼官方的內容申訴網域，頁面標題 `Trustpositif` 是當地網路內容過濾系統的名稱。ISP 在連線途中把使用者導向告示頁，是 `http-diff` 最典型的成因。
+Probe 的請求被重導向到 `http://lamanlabuh.aduankonten.id/`，落在印尼官方的內容申訴網域，頁面標題 `Trustpositif` 是當地網路內容過濾系統的名稱。ISP 在連線途中將使用者導向告示頁，是 `http-diff` 最典型的成因。
 
-該筆同時示範了單一欄位不可靠：
+該筆同時顯示單一欄位不足以作為判準：
 
 ```text title="四個 *_match 欄位與 body_proportion"
 title_match: false        status_code_match: false
@@ -85,44 +85,44 @@ headers_match: true       body_length_match: true
 body_proportion: 0.9967
 ```
 
-`body_length_match` 為 `true`、`body_proportion` 逼近 `1`，純粹因為封鎖告示頁與對照組頁面的長度剛好接近。只看長度會得到錯誤結論，四個欄位要一起讀，其中 `title_match` 與 `status_code_match` 的鑑別力通常最高。
+`body_length_match` 為 `true`、`body_proportion` 逼近 `1`，起因僅是封鎖告示頁與對照組頁面的長度接近。單看長度會得到錯誤結論，四個欄位須一併判讀，其中 `title_match` 與 `status_code_match` 的鑑別力通常最高。
 
-## 誤判從哪裡來
+## 誤判的來源
 
-`blocking` 有值而實際上沒有網路干預，是資料集裡的常態。前面 `tkec.com.tw` 的 `80` 埠不通已經是一例，再看一筆更隱蔽的。
+`blocking` 有值而實際上沒有網路干預，是資料集中的常態。前述 `tkec.com.tw` 的 `80` 埠不通即為一例，以下是一筆更隱蔽的。
 
-埃及 `http://www.newipnow.com/` 的測量判定為 `http-diff`，四個 `*_match` 有三個不符，`body_proportion` 只有 `0.02`。看起來像被插入封鎖頁，實際內容是：
+埃及 `http://www.newipnow.com/` 的測量判定為 `http-diff`，四個 `*_match` 有三個不符，`body_proportion` 僅 `0.02`，表面上近似被插入封鎖頁。實際內容如下：
 
 | 觀測方 | 狀態碼 | 標題 |
 |---|---|---|
 | Probe | `520` | `newipnow.com \| 520: Web server is returning an unknown error` |
 | test helper | `200` | `Buy Private Proxies: $0.88 per Dedicated Premium IP - NewIPNow` |
 
-`520` 是目標網站前方的 Cloudflare 在來源伺服器異常時回應的錯誤頁，代表該網站當下發生異常，與埃及的網路管制無關。另外值得留意的是，該筆的 `probe_asn` 是 `AS13335`（Cloudflare），測量端本身也走在 Cloudflare 的網路上，屬於下面第二類的測量環境因素。
+`520` 是目標網站前方的 Cloudflare 在來源伺服器異常時回應的錯誤頁，代表該網站當下發生異常，與埃及的網路管制無關。該筆的 `probe_asn` 是 `AS13335`（Cloudflare），測量端本身亦位於 Cloudflare 的網路上，屬於下列第二類的測量環境因素。
 
-常見的誤判來源可以歸成幾類：
+常見的誤判來源可分為幾類：
 
 - **來源網站自身狀態**：伺服器錯誤、維護頁、CDN 錯誤頁、地理限制。
-- **測量環境**：Probe 開著 VPN 或 Tor 時，測到的是出口所在地的網路。
-- **網站的動態內容**：輪播廣告、個人化內容、A/B 測試會讓兩邊的內容本來就不同。
+- **測量環境**：Probe 啟用 VPN 或 Tor 時，測得的是出口所在地的網路。
+- **網站的動態內容**：輪播廣告、個人化內容、A/B 測試會使兩側內容原本即不相同。
 - **對照組本身失敗**：`control_failure` 有值時，雙邊比對的前提不成立。
 
-OONI 在資料集層級也處理同一類問題，作法可參考 [OONI 如何分辨壞掉的量測資料](../blog/posts/2026-ooni-faulty-measurements.md)，該文整理了 OONI 用哪些啟發式規則過濾異常投稿。
+OONI 在資料集層級亦處理同一類問題，作法見 [OONI 如何分辨壞掉的量測資料](../blog/posts/2026-ooni-faulty-measurements.md)，該文整理了 OONI 過濾異常投稿所用的啟發式規則。
 
 ## 從單筆測量到可信結論
 
-要把觀測推進到「某個網站在某地被封鎖」，單筆資料不夠。實務上補上幾個維度：
+將觀測推進到「某個網站在某地被封鎖」，單筆資料並不足夠。實務上須補上幾個維度：
 
-1. **跨時間**：同一個網址在數天到數週內反覆出現同樣的判定，才能排除偶發故障。
-2. **跨 ASN**：多家電信商都測到相同結果，指向網路層的普遍行為。只在單一 ASN 出現，較可能是該業者的個別設定。
-3. **跨解析器**：換不同 DNS 解析器仍然異常，才能排除解析器自身問題。
-4. **看 `confirmed` 欄位**：OONI 後端會用已知的封鎖告示頁指紋比對測量，命中時把 `confirmed` 標為 `true`。該欄位在 [measurements API](https://api.ooni.io/api/v1/measurements){target="_blank"} 的回應中，屬於後端分析結果，不在 Probe 產生的原始資料裡。
+1. **跨時間**：同一個網址在數天到數週內反覆出現同樣的判定，方能排除偶發故障。
+2. **跨 ASN**：多家電信商測得相同結果，指向網路層的普遍行為。僅在單一 ASN 出現者，較可能是該業者的個別設定。
+3. **跨解析器**：更換 DNS 解析器後仍然異常，方能排除解析器自身問題。
+4. **`confirmed` 欄位**：OONI 後端以已知的封鎖告示頁指紋比對測量，命中時將 `confirmed` 標為 `true`。該欄位位於 [measurements API](https://api.ooni.io/api/v1/measurements){target="_blank"} 的回應中，屬於後端分析結果，不在 Probe 產生的原始資料內。
 
-想自己執行跨時間或跨 ASN 的比對，[ASN 觀測資料擷取與分析](./asn-coverage-howto.md) 有批次取用的作法。
+跨時間與跨 ASN 比對的批次取用作法，見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
 
 !!! warning "`confirmed` 為 `true` 不等於 `http-diff`"
 
-    兩者容易混淆。`confirmed` 標記的依據是封鎖指紋比對，DNS 被導向已知的封鎖用 IP 也會標記為 `confirmed`，判定類型仍是 `dns`。撰稿時抽查伊朗、俄羅斯、土耳其、中國各 5 筆 `confirmed` 測量，樣本全部落在 `blocking: "dns"`。樣本數少，僅能說明兩者並非同一件事，不足以推論一般規律。
+    兩者易於混淆。`confirmed` 標記的依據是封鎖指紋比對，DNS 被導向已知的封鎖用 IP 同樣會標記為 `confirmed`，判定類型仍是 `dns`。撰稿時抽查伊朗、俄羅斯、土耳其、中國各 5 筆 `confirmed` 測量，樣本全部落在 `blocking: "dns"`。樣本數少，僅能說明兩者並非同一件事，不足以推論一般規律。
 
 ## 台灣現況
 
@@ -137,34 +137,34 @@ OONI 在資料集層級也處理同一類問題，作法可參考 [OONI 如何�
 | `http-failure` | 67 | 0.30% |
 | `http-diff` | 35 | 0.16% |
 
-四種干預類型合計 564 筆，佔全部測量的 2.55%。`none` 是缺 `test_keys` 或 `blocking` 為 `null` 的測量，做異常率統計時要先決定放進分母或排除。
+四種干預類型合計 564 筆，佔全部測量的 2.55%。`none` 是缺 `test_keys` 或 `blocking` 為 `null` 的測量，計算異常率前須先決定是否納入分母。
 
 另外抽查 100 筆異常測量，`confirmed` 為 `true` 的有 0 筆，與 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md) 長期以來的描述一致。
 
 !!! warning "小樣本會給出錯誤的分布"
 
-    本頁初稿曾以 measurements API 異常清單的 40 筆抽樣估計判定分布，得到 `dns` 最多、`http-diff` 掛零的結論。改用全量統計後兩點都不成立：實際上 `tcp_ip` 是 `dns` 的兩倍以上，`http-diff` 也確實存在。API 的異常清單有自己的排序，直接當隨機樣本用會失準。要看分布請走全量統計，作法見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
+    本頁初稿曾以 measurements API 異常清單的 40 筆抽樣估計判定分布，得到 `dns` 最多、`http-diff` 為零的結論。改用全量統計後兩點皆不成立：`tcp_ip` 為 `dns` 的兩倍以上，`http-diff` 亦確實存在。API 的異常清單另有排序邏輯，逕自視為隨機樣本會失準。判定分布應以全量統計取得，作法見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
 
-台灣的 `http-diff` 與前面印尼的例子不是同一回事。抽查 4 小時區間內的 15 筆，`body_proportion` 全部落在 `0.004` 到 `0.21`，Probe 取到的內容遠短於對照組，與封鎖告示頁那種逼近 `1` 的樣態相反。內容極短通常指向錯誤頁或空回應，成因需要逐筆查驗證據層才能判斷，本頁不下結論。
+台灣的 `http-diff` 與前述印尼的例子屬於不同現象。抽查 4 小時區間內的 15 筆，`body_proportion` 全部落在 `0.004` 到 `0.21`，Probe 取得的內容遠短於對照組，與封鎖告示頁逼近 `1` 的樣態相反。內容極短通常指向錯誤頁或空回應，成因須逐筆查驗證據層方能判斷，本頁不下結論。
 
-要自己重新執行上面的統計：
+重新執行上述統計的指令：
 
 ```bash title="取得判定分布"
 uv run python ooni.py lookback --units=24 --loc=TW --frame=hours
 ```
 
-指令會印出 `blocking` 的合計，並把逐 ASN 的分布寫進 CSV。單筆查驗仍走 API：
+該指令會印出 `blocking` 的合計，並將逐 ASN 的分布寫入 CSV。單筆查驗仍使用 API：
 
 ```bash title="列出台灣的異常測量"
 curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&anomaly=true&limit=100" \
   | python3 -m json.tool | head -40
 ```
 
-以上是單一 24 小時區間的快照，反映的是當日樣態，不足以當作長期趨勢的結論。要看趨勢需要涵蓋更長時間，而台灣的觀測本身就存在 ASN 集中度過高的限制，細節見前面提到的 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)。
+以上是單一 24 小時區間的快照，反映當日樣態，不足以作為長期趨勢的結論。趨勢分析須涵蓋更長時間，而台灣的觀測本身即存在 ASN 集中度過高的限制，細節見前述 [ASN 自治網路觀測資料分析](../taiwan/ooni-asn-coverage.md)。
 
 ## 延伸閱讀
 
-想自己執行跨時間、跨 ASN 的比對，從擷取指南開始。
+跨時間、跨 ASN 的比對從擷取指南開始。
 
 <div class="grid cards" markdown>
 

--- a/docs/zh-TW/community/ooni-data-format.md
+++ b/docs/zh-TW/community/ooni-data-format.md
@@ -6,9 +6,9 @@ icon: material/code-json
 
 # :material-code-json: OONI 測量資料結構導覽
 
-[ASN 觀測資料擷取與分析](./asn-coverage-howto.md) 說明了如何擷取 OONI 公開資料，取得資料之後會遇到下一個問題：一筆測量有二十多個頂層欄位，`test_keys` 裡還有二十幾個，該看哪一個。
+一筆 OONI 測量有二十多個頂層欄位，`test_keys` 底下還有二十幾個。[ASN 觀測資料擷取與分析](./asn-coverage-howto.md) 說明擷取公開資料的方法，本頁接續說明擷取之後如何判讀欄位。
 
-以下用兩筆台灣的真實測量對照，說明一筆網路連線測試（`web_connectivity`）的組成，以及每個欄位對應到上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的哪份規格。看懂之後，你可以自己判斷一筆測量說了什麼，也能決定分析程式該取哪些欄位。
+以下以兩筆台灣的真實測量對照，拆解網路連線測試（`web_connectivity`）的組成，並標出各欄位對應上游 [ooni/spec](https://github.com/ooni/spec){target="_blank"} 的哪份規格。
 
 !!! info "範例資料來源"
 
@@ -21,17 +21,17 @@ icon: material/code-json
 
 ## 一筆測量的三層結構
 
-不用一開始就記住所有欄位。一筆測量可以拆成三層來讀：
+一筆測量可以拆成三層：
 
 1. **外殼**：誰在哪裡、用什麼軟體、什麼時候測的。所有測項共用同一套欄位，規格是 [df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"}。
 2. **判定**：測量得出的結論。欄位隨測項而異，全部收在 `test_keys` 底下，`web_connectivity` 的定義在 [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"}。
 3. **證據**：支撐結論的原始紀錄，包含每一次 DNS 查詢、TCP 連線、TLS 握手與 HTTP 請求，以及對照組的同類紀錄。同樣放在 `test_keys` 底下，各自對應一份 `df-` 開頭的規格。
 
-判定層告訴你結論，證據層讓你驗證結論。兩者分開讀，各欄位的角色就清楚了。
+判定層給出結論，證據層保留支撐結論的紀錄。
 
-## 自己取一筆來看
+## 取得一筆測量
 
-邊讀邊對照手上的樣本會快很多。不必先架好環境，用公開 API 就能取得單筆資料。先列出符合條件的測量：
+公開 API 可直接取得單筆測量，不需事先架設環境。先列出符合條件的測量：
 
 ```bash title="列出台灣最近的網路連線測試"
 curl -s "https://api.ooni.io/api/v1/measurements?probe_cc=TW&test_name=web_connectivity&limit=5" \
@@ -45,13 +45,13 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
   | python3 -m json.tool | head -60
 ```
 
-原始回應是未斷行的長字串，直接輸出到終端機不易閱讀，上面兩段都接了 `python3 -m json.tool` 排版。加上 `anomaly=true` 可以只列出被判定異常的測量，適合用來找對照範例。把 `probe_cc` 換成所在地區、`probe_asn` 換成自己的 ASN，就能看到本地網路上的觀測紀錄。
+原始回應是未斷行的長字串，上面兩段接 `python3 -m json.tool` 排版後才易於閱讀。查詢參數加上 `anomaly=true` 可篩出判定異常的測量，適合用於尋找對照範例。改寫 `probe_cc` 與 `probe_asn` 即可查詢指定地區與網路的觀測紀錄。
 
-需要批次處理大量資料時，改走 AWS S3 公開資料集會更有效率，作法見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
+批次處理大量資料時，AWS S3 公開資料集的效率較高，作法見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
 
 ## 外殼：誰在哪裡測的
 
-外殼層的欄位在所有測項中都一樣，實務上最常用到的如下：
+外殼層的欄位在所有測項中一致，其中常用者如下：
 
 | 欄位 | 正常通過那筆 | 判定異常那筆 | 說明 |
 |---|---|---|---|
@@ -67,17 +67,17 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 | `measurement_start_time` | `2026-08-04 08:59:30` | `2026-08-04 08:45:45` | 測量開始時間（UTC）|
 | `report_id` | `20260804T062033Z_webconnectivity_TW_3462_n4_uEH5rGoD07cN2oYQ` | `20260804T084446Z_webconnectivity_TW_3462_n4_dFfWCDrwouM0TsT2` | 同一次執行產生的多筆測量共用此值 |
 
-`probe_asn` 與 `resolver_asn` 可能不同，上表就是實例。兩筆都在中華電信的網路上執行，但其中一筆的使用者把 DNS 指向 Cloudflare。做 ASN 分析時兩者要分開看，混用會讓「哪家電信商的網路上看到什麼」失準。
+`probe_asn` 與 `resolver_asn` 可能分屬不同網路，上表即為實例。兩筆測量都在中華電信的網路上執行，其中一筆的使用者將 DNS 指向 Cloudflare。ASN 分析須將兩者分開計算，混用會使「特定電信商網路上的觀測結果」失準。
 
 !!! note "`probe_ip` 永遠是 `127.0.0.1`"
 
-    OONI 刻意不收集測量者的真實 IP，`probe_ip` 固定寫入本機位址。想追測量來源只能仰賴 `probe_asn` 加時間，同一條隱私邊界在 [OONI Run v2 操作說明](../tools/ooni-run-v2.md) 也提醒協助者留意。
+    OONI 刻意不收集測量者的真實 IP，`probe_ip` 固定寫入本機位址。回溯測量來源只能仰賴 `probe_asn` 與時間，[OONI Run v2 操作說明](../tools/ooni-run-v2.md) 針對同一條隱私邊界另有提醒。
 
 ## 判定：測量得出的結論
 
-判定欄位全部收在 `test_keys` 底下。讀之前要先知道一件事：`web_connectivity` 的判定建立在雙邊對照上。Probe 測完之後，OONI 架設在外部網路的測量伺服器（test helper）會對同一個網址再測一次，兩邊結果的差異才是判定的依據。test helper 那一側的紀錄收在 `test_keys.control`，下表的「對照組」指的就是它。
+判定欄位全部收在 `test_keys` 底下，其計算基礎是雙邊對照。Probe 測完之後，OONI 架設在外部網路的測量伺服器（test helper）會對同一個網址再測一次，兩邊結果的差異即為判定依據。test helper 那一側的紀錄收在 `test_keys.control`，下表的「對照組」即指該側紀錄。
 
-判定結果與內容比對共八個欄位。把兩筆並排，差異一眼可見：
+判定結果與內容比對共八個欄位，兩筆並排如下：
 
 | 欄位 | 正常通過 | 判定異常 | 說明 |
 |---|---|---|---|
@@ -90,7 +90,7 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 | `body_length_match` | `true` | `null` | 回應內容長度是否相近 |
 | `body_proportion` | `1` | `0` | 內容長度與對照組的比值 |
 
-各階段的失敗原因另有三個欄位，判讀時要一起看：
+各階段的失敗原因另有三個欄位，須與上表一併判讀：
 
 | 欄位 | 記錄什麼 |
 |---|---|
@@ -98,25 +98,25 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 | `http_experiment_failure` | HTTP 階段的失敗原因，例如 `"generic_timeout_error"` |
 | `control_failure` | 對照組本身是否失敗。有值時雙邊比對的前提不成立，判定結果不可信 |
 
-`blocking` 的四種值分別對應不同階段的異常：`dns` 是解析結果與對照組不一致、`tcp_ip` 是封包送不到目標位址、`http-failure` 是連線建立後 HTTP 階段失敗、`http-diff` 是取得的內容與對照組不同（常見於封鎖告示頁）。四種手法在 [什麼是 OONI](../tools/what-is-ooni.md) 有概念層的介紹。
+`blocking` 的四種值分別對應不同階段的異常：`dns` 是解析結果與對照組不一致、`tcp_ip` 是封包送不到目標位址、`http-failure` 是連線建立後 HTTP 階段失敗、`http-diff` 是取得的內容與對照組不同（常見於封鎖告示頁）。四種干預手法的概念說明見 [什麼是 OONI](../tools/what-is-ooni.md)。
 
 !!! tip "兩個容易誤判的型別問題"
 
-    `blocking` 未觀測到干預時是布林值 `false`，有干預時是字串。拿它做統計前要先統一處理，否則 `false` 與 `"dns"` 會被算成兩類不同的東西。
+    `blocking` 未觀測到干預時是布林值 `false`，有干預時是字串。統計前需先統一型別，否則 `false` 與 `"dns"` 會被歸為兩類。
 
-    四種值的命名本身不一致，`tcp_ip` 用底線，`http-failure` 與 `http-diff` 用連字號。上游如此定義，照抄即可，不要自行統一。
+    四種值的命名本身不一致，`tcp_ip` 用底線，`http-failure` 與 `http-diff` 用連字號。上游即如此定義，引用時照原樣寫入，不應自行統一。
 
-四個 `*_match` 欄位在異常那筆全是 `null`，原因是 DNS 階段就失敗，連線沒有建立，後續沒有東西可以比對。看到一整排 `null` 時，回頭找測量流程中第一個有值的 failure 欄位，那裡才是問題發生的地方。
+四個 `*_match` 欄位在異常那筆全為 `null`，原因是 DNS 階段即失敗，連線未建立，後續無可比對的內容。遇到整排 `null`，應回溯測量流程中第一個有值的 failure 欄位，該處才是問題發生的階段。
 
 !!! warning "異常不等於封鎖"
 
-    `blocking` 有值只代表該筆測量的結果與對照組不一致，判斷是否真的存在網路干預需要更多佐證。以判定異常那筆為例，Probe 對 `ntc.party` 的 A 與 AAAA 查詢都回報 `dns_nxdomain_error`（網域不存在），但撰稿時從多個公開 DNS 解析器查詢，該網域可解析到 IPv6 位址。單筆測量無法區分網路干預、解析器當下的暫時狀態，以及網域本身的設定變動。
+    `blocking` 有值僅代表該筆測量的結果與對照組不一致，確認是否存在網路干預需要更多佐證。以判定異常那筆為例，Probe 對 `ntc.party` 的 A 與 AAAA 查詢都回報 `dns_nxdomain_error`（網域不存在），但撰稿時以多個公開 DNS 解析器查詢，該網域可解析到 IPv6 位址。單筆測量無法區分網路干預、解析器的暫時狀態與網域自身的設定變動。
 
-    要下封鎖結論，需要跨時間、跨 ASN、跨解析器的多筆測量交叉比對。判定機制的完整拆解與常見誤判來源見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)，資料集層級的品質控制則可參考 [OONI 如何分辨壞掉的量測資料](../blog/posts/2026-ooni-faulty-measurements.md)。
+    認定封鎖需以跨時間、跨 ASN、跨解析器的多筆測量交叉比對。判定機制的完整拆解與常見誤判來源見 [OONI 怎麼判定一個網站被封鎖](./ooni-blocking-determination.md)，資料集層級的品質控制見 [OONI 如何分辨壞掉的量測資料](../blog/posts/2026-ooni-faulty-measurements.md)。
 
 ## 證據：支撐結論的原始紀錄
 
-`test_keys` 底下另有幾個欄位，記錄測量過程中每一次網路操作。每個欄位各有一份規格：
+`test_keys` 底下另有數個欄位，記錄測量過程中的每一次網路操作，各對應一份規格：
 
 | 欄位 | 內容 | 規格 |
 |---|---|---|
@@ -128,7 +128,7 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 | `control` | 對照組的同類紀錄，結構與 Probe 側對應，判定欄位全部由它與 Probe 端的差異算出 | [ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} |
 | 各欄位的 `failure` 字串 | 所有失敗原因的統一命名，例如 `dns_nxdomain_error`、`generic_timeout_error`、`ssl_unknown_authority` | [df-007-errors](https://github.com/ooni/spec/blob/master/data-formats/df-007-errors.md){target="_blank"} |
 
-把兩筆的 `queries` 攤開對照，就能看到判定的依據：
+兩筆的 `queries` 對照如下：
 
 ```json title="正常通過：查到位址"
 {
@@ -148,21 +148,21 @@ curl -s "https://api.ooni.io/api/v1/raw_measurement?measurement_uid=<measurement
 }
 ```
 
-判定層的 `dns_consistency` 是結論，`queries` 與 `control` 是它的依據。想確認一筆測量的判定是否合理，往證據層查驗即可。
+判定層的 `dns_consistency` 是結論，`queries` 與 `control` 是其依據。判定是否合理，查驗證據層即可確認。
 
 ## 版本與相容性
 
-讀 spec 之前先確認版本，能避免不少困惑：
+對照 spec 前需先確認版本：
 
 - **`data_format_version` 目前是 `0.2.0`**。外殼層的欄位定義穩定，[df-000-base](https://github.com/ooni/spec/blob/master/data-formats/df-000-base.md){target="_blank"} 可以直接對照。
 - **`web_connectivity` 實際流通的 `test_version` 是 `0.4.3`**。[ts-017](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} 的規格內容已更新為描述 v0.5 演算法，但生產環境仍以 v0.4 為主。spec 明訂新版演算法必須使用不同的 test_keys 欄位，v0.4 的欄位定義保持相容，因此上表的欄位讀法對兩個版本都適用。
 - **`x_` 開頭的欄位不在 spec 內**。實際資料中會看到 `x_dns_runtime`、`x_status`、`x_th_runtime` 等欄位，屬於實作端的實驗性擴充，隨版本增減，分析程式不應依賴它們。
 
-上游 spec 的 master 分支自 2025-06 起沒有新的合併，但 issue 與 PR 討論持續進行（進行中的提案包含 ICMP 資料格式與 DPI 分片測項）。spec 現階段適合當作穩定參考，引用時建議連回上游原文，避免自行複製規格內容而在上游更新後失準。
+上游 spec 的 master 分支自 2025-06 起沒有新的合併，但 issue 與 PR 討論持續進行（進行中的提案包含 ICMP 資料格式與 DPI 分片測項）。spec 現階段可作為穩定參考。引用時應連回上游原文，避免複製規格內容後因上游更新而失準。
 
 ## 延伸閱讀
 
-看懂欄位之後，接著看判定欄位怎麼算出來，以及為什麼有值不等於封鎖。
+判定欄位的計算方式，以及有值為何不等於封鎖，見以下各篇。
 
 <div class="grid cards" markdown>
 

--- a/docs/zh-TW/community/ooni-nettests-map.md
+++ b/docs/zh-TW/community/ooni-nettests-map.md
@@ -6,11 +6,11 @@ icon: material/table-search
 
 # :material-table-search: OONI 測項速查表
 
-[ooni/spec](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 的 `nettests` 目錄收錄 41 份測項規格，其中有相當比例已經停止使用。要挑測項或解讀手上的資料時，先知道哪些還在產出資料，比逐份讀規格有效率。
+[ooni/spec](https://github.com/ooni/spec/tree/master/nettests){target="_blank"} 的 `nettests` 目錄收錄 41 份測項規格，其中有相當比例已停止使用。挑選測項或解讀既有資料時，先確認哪些仍在產出資料，效率高於逐份閱讀規格。
 
-本頁把 41 份規格整理成一張對照表，標註上游規格的狀態、實際是否還有公開資料，以及台灣觀測到哪幾個。
+本頁將 41 份規格整理成一張對照表，標註上游規格的狀態、實際是否仍有公開資料，以及台灣觀測到的項目。
 
-!!! info "狀態欄位怎麼讀"
+!!! info "狀態欄位的定義"
 
     **spec 狀態**取自各份規格開頭的 `_status_` 標記，分為 `current`、`experimental`、`obsolete` 三種，反映上游對該測項的定位。
 
@@ -18,18 +18,18 @@ icon: material/table-search
 
     **台灣**欄位來自 S3 公開資料集，抽查 2026-08-03 五個時段台灣底下出現過的測項目錄。
 
-## 先看一件事：狀態標記不等於實際有資料
+## 狀態標記不等於實際有資料
 
-規格標記與實際資料不一致的情況存在，看下面的表格前先知道兩個方向的落差：
+規格標記與實際資料不一致的情況確實存在，落差有兩個方向：
 
 - **標為 `current` 卻查不到資料**：`tlsmiddlebox`、`portfiltering`、`captiveportal` 三個。
 - **標為 `experimental` 卻每日都有資料**：`dnscheck`、`echcheck`、`openvpn`、`stunreachability`、`vanilla_tor` 等，資料量與部分 `current` 測項相當。
 
-`experimental` 只反映規格本身的成熟度，與資料量多寡沒有必然關係。要判斷某個測項是否適合用於分析，直接查 API 是否有資料，比看狀態標記可靠。
+`experimental` 僅反映規格本身的成熟度，與資料量多寡沒有必然關係。判斷測項是否適合用於分析，直接查詢 API 是否有資料，較狀態標記可靠。
 
 ## 依用途分群
 
-帶著「我想觀測什麼」進來的話，先從下面挑方向，再到表格查細節：
+以下依觀測目的分群，細節再對照後方表格：
 
 - **網站封鎖偵測**：`web_connectivity`
 - **中間設備與干擾手法**：`http_header_field_manipulation`、`http_invalid_request_line`、`sni_blocking`、`echcheck`
@@ -40,9 +40,9 @@ icon: material/table-search
 
 ## 仍在產出資料的測項
 
-以下測項在撰稿當日都查得到公開測量，是解讀 OONI 資料時最常遇到的一批。
+以下測項在撰稿當日皆查得到公開測量，也是解讀 OONI 資料時最常遇到的測項。
 
-| 測項 | 測什麼 | spec 狀態 | 台灣 |
+| 測項 | 量測內容 | spec 狀態 | 台灣 |
 |---|---|---|---|
 | [`web_connectivity`](https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md){target="_blank"} | 網站可達性與封鎖判定，資料量最大的測項 | current | 有 |
 | [`tor`](https://github.com/ooni/spec/blob/master/nettests/ts-023-tor.md){target="_blank"} | Tor 目錄權威節點與橋接的可達性 | current | 有 |
@@ -75,16 +75,16 @@ icon: material/table-search
 
 ## 偶爾才有資料的測項
 
-| 測項 | 測什麼 | spec 狀態 | 最近一筆 |
+| 測項 | 量測內容 | spec 狀態 | 最近一筆 |
 |---|---|---|---|
 | [`quicping`](https://github.com/ooni/spec/blob/master/nettests/ts-031-quicping.md){target="_blank"} | QUIC 協定的可達性 | experimental | 2026-07-30 |
 | [`sni_blocking`](https://github.com/ooni/spec/blob/master/nettests/ts-024-sni-blocking.md){target="_blank"} | 針對 TLS SNI 欄位的封鎖偵測 | experimental | 2026-07-20 |
 
 ## 查不到公開資料的測項
 
-以下七個測項在 API 查不到公開測量。規格仍在上游倉庫裡，設計新測項或研究方法時可以參考。
+以下七個測項在 API 查不到公開測量。規格仍保留在上游倉庫，可供設計新測項或研究方法時參考。
 
-| 測項 | 測什麼 | spec 狀態 |
+| 測項 | 量測內容 | spec 狀態 |
 |---|---|---|
 | [`tlsmiddlebox`](https://github.com/ooni/spec/blob/master/nettests/ts-037-tlsmiddlebox.md){target="_blank"} | TLS 連線路徑上的中間設備行為 | current |
 | [`portfiltering`](https://github.com/ooni/spec/blob/master/nettests/ts-038-port-filtering.md){target="_blank"} | 特定連接埠是否被過濾 | current |
@@ -96,7 +96,7 @@ icon: material/table-search
 
 ## 標記為 obsolete 的歷史測項
 
-上游標為 `obsolete` 的有 12 份，多數功能已被 `web_connectivity` 吸收，或隨著測量方法演進而退場。處理歷史資料時可能會遇到它們的紀錄，規劃新的觀測時沒有理由採用它們。
+上游標為 `obsolete` 的有 12 份，多數功能已被 `web_connectivity` 吸收，或隨測量方法演進而退場。處理歷史資料時仍可能遇到這些測項的紀錄，規劃新的觀測則無採用的理由。
 
 | 測項 | 規格 |
 |---|---|
@@ -115,17 +115,17 @@ icon: material/table-search
 
 !!! note "編號重複的兩份 OpenVPN 規格"
 
-    上游有兩份規格都編為 `ts-016`，分別是上表標為 `obsolete` 的 `ts-016-openvpn.md` 與標為 `experimental` 的 `ts-016-vanilla-tor.md`。現行的 OpenVPN 測項規格是 `ts-040-openvpn.md`，引用時留意不要取到舊的那份。
+    上游有兩份規格同編為 `ts-016`，分別是上表標為 `obsolete` 的 `ts-016-openvpn.md` 與標為 `experimental` 的 `ts-016-vanilla-tor.md`。現行的 OpenVPN 測項規格是 `ts-040-openvpn.md`，引用時須留意勿取到舊版。
 
 ## 台灣觀測到哪些測項
 
 抽查 2026-08-03 五個時段，台灣底下出現過 17 個測項（以下用 API 的底線寫法）：`web_connectivity`、`tor`、`vanilla_tor`、`telegram`、`whatsapp`、`signal`、`facebook_messenger`、`dnscheck`、`echcheck`、`http_header_field_manipulation`、`http_invalid_request_line`、`openvpn`、`psiphon`、`riseupvpn`、`stunreachability`、`ndt`、`dash`。
 
-S3 上的目錄名與 `test_name` 寫法不同，目錄名沒有底線（`webconnectivity`、`vanillator`、`facebookmessenger`），API 查詢要用底線形式（`web_connectivity`、`vanilla_tor`、`facebook_messenger`）。取用路徑的細節見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
+S3 上的目錄名與 `test_name` 寫法不同，目錄名沒有底線（`webconnectivity`、`vanillator`、`facebookmessenger`），API 查詢須用底線形式（`web_connectivity`、`vanilla_tor`、`facebook_messenger`）。取用路徑的細節見 [ASN 觀測資料擷取與分析](./asn-coverage-howto.md)。
 
-台灣目前的觀測集中在 `web_connectivity`，其他測項的樣本量偏小。想擴充在地觀測的涵蓋面，`tor` 與 `dnscheck` 是與社群既有主題最接近的兩個方向。
+台灣目前的觀測集中在 `web_connectivity`，其他測項的樣本量偏小。擴充在地觀測的涵蓋面時，`tor` 與 `dnscheck` 是與社群既有主題最接近的兩個方向。
 
-實際執行特定測項有兩條路徑。用 [OONI Probe](https://ooni.org/install/){target="_blank"} 桌面或行動版，在設定裡挑選要啟用的測項。想邀請其他人一起測固定的網址清單，改用 [OONI Run v2](../tools/ooni-run-v2.md) 建立連結分享，社群目前維運的連結 ID 是 `10328`。
+執行特定測項有兩條路徑。[OONI Probe](https://ooni.org/install/){target="_blank"} 桌面或行動版可在設定中挑選啟用的測項。若要邀集他人共同測試固定的網址清單，則以 [OONI Run v2](../tools/ooni-run-v2.md) 建立連結分享，社群目前維運的連結 ID 是 `10328`。
 
 ## 延伸閱讀
 


### PR DESCRIPTION
## 這個 PR 做什麼

OONI 系列四篇的 AI 腔太重，改用書面語。三語系同步，純文字替換，沒有動到任何數據或結構。

## AI 味集中在三類

**一、對讀者的教學鋪陳。** 這類句子在向讀者預告接下來會學到什麼，刪掉之後語意不減。

| 原文 | 改後 |
|---|---|
| 不用一開始就記住所有欄位。一筆測量可以拆成三層來讀： | 一筆測量可以拆成三層： |
| 判定層告訴你結論，證據層讓你驗證結論。兩者分開讀，各欄位的角色就清楚了。 | 判定層給出結論，證據層保留支撐結論的紀錄。 |
| 邊讀邊對照手上的樣本會快很多。不必先架好環境，用公開 API 就能取得單筆資料。 | 公開 API 可直接取得單筆測量，不需事先架設環境。 |
| 看懂之後，你可以自己判斷一筆測量說了什麼 | （整句刪除） |

**二、宣稱效果的過渡句。** 在陳述句前面加一層評價，改成直述。

| 原文 | 改後 |
|---|---|
| 把兩筆並排，差異一眼可見： | 兩筆並排如下： |
| 把兩筆的 `queries` 攤開對照，就能看到判定的依據： | 兩筆的 `queries` 對照如下： |
| 讀 spec 之前先確認版本，能避免不少困惑： | 對照 spec 前需先確認版本： |
| 帶著「我想觀測什麼」進來的話，先從下面挑方向 | 以下依觀測目的分群 |

**三、口語詞。** 逐一換書面語：「東西」、「照抄即可」、「該看哪一個」、「長什麼樣」、「不是同一回事」、「掛零」、「派上用場」、「一批」、「抓到資料」。表格欄名「測什麼」改為「量測內容」。

## 另外處理的兩處

**規則明文禁止的 AI 開頭語。** 判定判讀篇有一句「另外值得留意的是」，`docs-writing-style` 明文列為要避免的開頭，已移除。

**兩個標題。** 「先看一件事：狀態標記不等於實際有資料」去掉懸疑式前綴；「自己取一筆來看」改為「取得一筆測量」。

## 語氣的取捨

貢獻者百科要求「語氣像社群成員解釋，不像百科條目」，與往書面語推有張力。這次的作法是**去掉鋪陳與口語，保留解釋語氣**，沒有推到規格書那種純陳述加被動語態的程度。例如保留「先列出符合條件的測量：」，沒有改成「查詢條件如下：」。

## en 版

英文有同型的鋪陳句，一併處理：

- `There is no need to memorise every field up front.` → 刪除
- `Following along with a sample in hand is much faster.` → 刪除
- `Side by side, the difference is obvious:` → `shown side by side below:`
- `Worth noting too:` → 刪除
- `First, one thing: a status marker is not a data supply` → `A status marker is not a data supply`

## 驗證

- diff 為 **229 增 229 刪**，逐檔行數不變，確認屬純文字替換
- 掃過整個 diff 的數字，**每個數字的增刪次數皆成對**，無資料遭更動
- `docs_style_lint.py` 掃八個中文檔案 0 error 0 warn
- linter 自身回歸測試 49 個案例全過
- `run_zh-tw.sh`、`run_en.sh`、`run_zh-cn.sh` 三份建置腳本（含 `-s` strict）全部通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDKynnUECxWh8c5xBL8Hjh
