### PR TITLE
docs: 更新 COSCUP 隱私支付工作坊介紹，改為現場備模擬網路、可帶電腦操作

### DIFF
--- a/docs/zh-CN/activity/coscup-2026.md
+++ b/docs/zh-CN/activity/coscup-2026.md
@@ -66,7 +66,7 @@ og:
 | 13:40-14:10<br>30 分钟 | <span class="sess-tag sess-tag--payments">匿名支付</span> :material-account-check-outline: **The Privacy-preserving Identity Pipeline in KYC**<br>:material-arrow-right-bottom: 用一组密码学原语组出能通过 KYC，却不让服务器看到身份数据的流程 | ryanycw（Ryan Wang） |
 | 14:20-14:50<br>30 分钟 | <span class="sess-tag sess-tag--payments">匿名支付</span> :material-link-off: **从不可链接性出发：隐匿地址如何解决链上金融隐私（以 Fluidkey 为例）**<br>:material-arrow-right-bottom: 用隐匿地址让同一人每次收款都落在不相关的地址，外部串不成同一身份 | Jennifer HSU |
 | 15:00-15:30<br>30 分钟 | <span class="sess-tag sess-tag--payments">匿名支付</span> :material-bitcoin: **我不洗钱，为何要理解匿名支付？从零开始介绍隐私加密金流交易**<br>:material-arrow-right-bottom: 为什么倡议组织与捐款人也该懂加密货币金流的隐私风险，用白话走过几套解法 | 黄豆泥 mashbean |
-| 15:40-16:30<br>50 分钟 | <span class="sess-tag sess-tag--payments">匿名支付</span> :material-hammer-wrench: **隐私支付实作工作坊：从龙卷风现金到隐私池**<br>:material-arrow-right-bottom: 用道具与实机示范 Tornado Cash 与 Privacy Pool 的用法，不用自己实际操作、跟着看就好 | Liangcc |
+| 15:40-16:30<br>50 分钟 | <span class="sess-tag sess-tag--payments">匿名支付</span> :material-hammer-wrench: **隐私支付实作工作坊：从龙卷风现金到隐私池**<br>:material-arrow-right-bottom: 用道具与实机示范 Tornado Cash 与 Privacy Pool 的用法，现场备有模拟网络，有机会的话可带电脑来玩 | Liangcc |
 
 ### Day 2：2026/08/09（日）
 
@@ -173,7 +173,7 @@ og:
 
     工作坊从用户视角出发，介绍龙卷风现金（Tornado Cash）的设计哲学，以及隐私池（Privacy Pool）在它之上的改进。
 
-    现场会用道具与实机操作示范两样工具如何操作，不需自备电脑或自行撰写程序，跟着看就好，你能带走的是实际使用上的隐私眉角，密码学细节则点到为止。时间允许的话，也会谈这些工具的沿革与在现实世界造成的冲击。
+    现场会用道具与实机操作示范两样工具如何操作，有机会的话，带电脑来玩。现场备有模拟网络可以操作。时间允许的话，也会谈这些工具的沿革与在现实世界造成的冲击。
 
     :material-open-in-new: [COSCUP 官方议程页](https://pretalx.coscup.org/coscup-2026/talk/3WHJYA/){target="_blank"}
 

--- a/docs/zh-TW/activity/coscup-2026.md
+++ b/docs/zh-TW/activity/coscup-2026.md
@@ -66,7 +66,7 @@ og:
 | 13:40-14:10<br>30 分鐘 | <span class="sess-tag sess-tag--payments">匿名支付</span> :material-account-check-outline: **The Privacy-preserving Identity Pipeline in KYC**<br>:material-arrow-right-bottom: 用一組密碼學原語組出能通過 KYC，卻不讓伺服器看到身分資料的流程 | ryanycw（Ryan Wang） |
 | 14:20-14:50<br>30 分鐘 | <span class="sess-tag sess-tag--payments">匿名支付</span> :material-link-off: **從不可連結性出發：隱匿地址如何解決鏈上金融隱私（以 Fluidkey 為例）**<br>:material-arrow-right-bottom: 用隱匿地址讓同一人每次收款都落在不相關的位址，外部串不成同一身分 | Jennifer HSU |
 | 15:00-15:30<br>30 分鐘 | <span class="sess-tag sess-tag--payments">匿名支付</span> :material-bitcoin: **我不洗錢，為何要理解匿名支付？從零開始介紹隱私加密金流交易**<br>:material-arrow-right-bottom: 為什麼倡議組織與捐款人也該懂加密貨幣金流的隱私風險，用白話走過幾套解法 | 黃豆泥 mashbean |
-| 15:40-16:30<br>50 分鐘 | <span class="sess-tag sess-tag--payments">匿名支付</span> :material-hammer-wrench: **隱私支付實作工作坊：從龍捲風現金到隱私池**<br>:material-arrow-right-bottom: 用道具與實機示範 Tornado Cash 與 Privacy Pool 的用法，不用自己實際操作、跟著看就好 | Liangcc |
+| 15:40-16:30<br>50 分鐘 | <span class="sess-tag sess-tag--payments">匿名支付</span> :material-hammer-wrench: **隱私支付實作工作坊：從龍捲風現金到隱私池**<br>:material-arrow-right-bottom: 用道具與實機示範 Tornado Cash 與 Privacy Pool 的用法，現場備有模擬網路，有機會的話可帶電腦來玩 | Liangcc |
 
 ### Day 2：2026/08/09（日）
 
@@ -173,7 +173,7 @@ og:
 
     工作坊從使用者視角出發，介紹龍捲風現金（Tornado Cash）的設計哲學，以及隱私池（Privacy Pool）在它之上的改進。
 
-    現場會用道具與實機操作示範兩樣工具如何操作，不需自備電腦或自行撰寫程式，跟著看就好，你能帶走的是實際使用上的隱私眉角，密碼學細節則點到為止。時間允許的話，也會談這些工具的沿革與在現實世界造成的衝擊。
+    現場會用道具與實機操作示範兩樣工具如何操作，有機會的話，帶電腦來玩。現場備有模擬網路可以操作。時間允許的話，也會談這些工具的沿革與在現實世界造成的衝擊。
 
     :material-open-in-new: [COSCUP 官方議程頁](https://pretalx.coscup.org/coscup-2026/talk/3WHJYA/){target="_blank"}
 


### PR DESCRIPTION
## Summary
- 更正 COSCUP 2026「隱私支付實作工作坊」的過時說明：原文寫「不需自備電腦、跟著看就好」，實際上現場已備妥模擬網路與模擬鏈，鼓勵參加者攜帶電腦動手操作
- zh-TW／zh-CN 的議程表格列與展開摘要（`??? abstract` 區塊）皆已同步更新；en 版議程表格原本就沒有此說法，故不需修改

## Test plan
- [x] `grep` 全站確認「不需自備電腦」「跟著看就好」等舊敘述已無殘留
- [ ] `mkdocs serve` 目視確認頁面渲染正常（純文字修改，風險低）

🤖 Generated with [Claude Code](https://claude.com/claude-code)