### PR TITLE
ci(docs): 把 .onion 版建置納入 GitHub Action，推到同一個 bucket 的 docs-onion/

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -127,6 +127,29 @@ jobs:
         if: matrix.variant == 'onion'
         run: cp ./robots_onion.txt ./output/robots.txt
 
+      # replace_sitename_anoni_onion.sh 靠 GNU sed 的就地改寫，但它的結束碼來自最後
+      # 那行診斷用的 grep，改寫整批失敗也一樣回 0（在 BSD sed 上實測過，全部沒改到、
+      # 依然 exit 0）。沒驗的話這一格會把 clearnet 內容推上 docs-onion/，m6 同步過去
+      # 之後 onion 站就開始送 clearnet 網址跟 clearnet 的分析端點，而且不會有人發現。
+      #
+      # 兩個方向都要驗：只驗「沒有 clearnet 殘留」的話，產物是空的也會過關。
+      - name: Verify onion output
+        if: matrix.variant == 'onion'
+        run: |
+          onion='docs.anoninetru5tflukgfaehun7q6khowgmymcff3gtk5oyesqazhmfxtyd.onion'
+          leftover=0
+          for pattern in 'https://anoni.net/docs' 'aa.anoni.net'; do
+            n=$(grep -rl "$pattern" ./output/ | wc -l)
+            echo "clearnet 殘留 $pattern：$n 個檔案"
+            [ "$n" -eq 0 ] || leftover=1
+          done
+          rewritten=$(grep -rl "$onion" ./output/ | wc -l)
+          echo "含 onion 網址：$rewritten 個檔案"
+          if [ "$leftover" -ne 0 ] || [ "$rewritten" -eq 0 ]; then
+            echo "::error::onion 產物驗證失敗，中止上傳"
+            exit 1
+          fi
+
       - name: Clean the all files
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOC_S3_ID }}

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -6,12 +6,13 @@ on:
       - "docs"
   workflow_dispatch:
 
-# 最後兩步是先 `aws s3 rm --recursive` 清空 docs prefix，再 `s3 sync` 上傳。兩個 run
+# 最後兩步是先 `aws s3 rm --recursive` 清空該 prefix，再 `s3 sync` 上傳。兩個 run
 # 重疊時，後者的清空會發生在前者上傳到一半，S3 會有一段內容不完整的空窗。連續合併
 # 幾個 PR 再同步 docs 分支就會踩到。
 #
 # 全域一組（不帶 ref），因為 workflow_dispatch 可以從任何分支觸發，而所有 run 都寫
-# 同一個 bucket prefix，要序列化的是 S3 寫入本身。
+# 同一個 bucket，要序列化的是 S3 寫入本身。standard 與 onion 是同一個 run 裡的兩格，
+# 寫的是不同 prefix，彼此平行跑沒有問題，要擋的是 run 與 run 之間。
 #
 # 用 false 而非 true：run 被中途取消有機會停在 `s3 rm` 之後、`s3 sync` 之前，那會留下
 # 一個空的 bucket。排隊比取消安全。排隊中的 run 若被更新的 run 取代，它還沒開始執行，
@@ -23,10 +24,19 @@ concurrency:
 jobs:
   build:
     strategy:
+      # onion 那格失敗不要連帶取消 clearnet 的部署，兩份是各自獨立的產物。
+      fail-fast: false
       matrix:
         os: ["ubuntu-24.04"]
         python-version: ["3.12"]
+        # standard = clearnet（anoni.net/docs）。
+        # onion = docs.<onion>，站內絕對網址改寫成 onion，並拿掉只在 clearnet 生效的
+        # 分析區塊，等同 m6 上手動跑的 build_docs_anoni_onion.sh。
+        variant: ["standard", "onion"]
     runs-on: ${{ matrix.os }}
+    env:
+      # clearnet 產物維持在既有的 docs/，onion 產物放同一個 bucket 的 docs-onion/。
+      S3_PREFIX: ${{ matrix.variant == 'onion' && 'docs-onion' || 'docs' }}
     defaults:
       run:
         working-directory: ./docs
@@ -35,6 +45,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      # onion 版的改寫是就地 sed 整個工作目錄，所以一定要在任何 mkdocs build 之前跑。
+      # 擺在 uv sync 之前是刻意的：那支腳本用 `find ./ -type f -exec sed -i`，.venv 一旦
+      # 建好就是上萬個檔案要被逐一重寫，既慢又沒有意義（第三方套件不含站內網址）。
+      - name: Rewrite URLs for onion
+        if: matrix.variant == 'onion'
+        run: sh ./replace_sitename_anoni_onion.sh
+
       - name: Update libs
         run: sudo apt-get update
       - name: Install ca
@@ -62,12 +80,17 @@ jobs:
       #
       # 注意：快取全新或被 LRU 淘汰時（首次建置、長期沒跑）仍然要重新下載，
       # 那種情況下這層保護不存在。要根治得把外部圖片鏡像到 assets.anoni.net。
+      #
+      # 兩格會同時跑，共用同一把 key 會互相覆寫（後寫的那個拿到 "cache already exists"）。
+      # 依 variant 分開存，最後再留一層不分 variant 的 fallback：鏡像的是第三方外部
+      # 資產，兩個變體抓到的內容其實一樣，新增的 onion 格不必從零開始重抓一輪。
       - name: Cache privacy plugin external assets
         uses: actions/cache@v4
         with:
           path: docs/.cache/plugin/privacy
-          key: mkdocs-privacy-${{ github.sha }}
+          key: mkdocs-privacy-${{ matrix.variant }}-${{ github.sha }}
           restore-keys: |
+            mkdocs-privacy-${{ matrix.variant }}-
             mkdocs-privacy-
 
       - name: Install mkdocs-material social dependencies
@@ -97,13 +120,22 @@ jobs:
           done
       - name: Inject PWA build version
         run: find ./output -name 'sw.js' -exec sed -i "s/__BUILD_VERSION__/$(date +%Y%m%d%H%M)/" {} \;
+
+      # onion 站的 robots 指向 onion 的 sitemap，跟 clearnet 那份不同。對齊 m6 上
+      # build_docs_anoni_onion.sh 最後那步 `cp ./robots_onion.txt <root>/robots.txt`。
+      - name: Onion robots.txt
+        if: matrix.variant == 'onion'
+        run: cp ./robots_onion.txt ./output/robots.txt
+
       - name: Clean the all files
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOC_S3_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_S3_KEY }}
-        run: source ./.venv/bin/activate; aws s3 rm s3://${{ secrets.DOC_BUCKET }}/docs --recursive
+        # 結尾的斜線不能省。`s3://bucket/docs` 是前綴比對，會連 `docs-onion/` 底下的
+        # 物件一起刪掉，兩格同時跑就會互相清空。
+        run: source ./.venv/bin/activate; aws s3 rm "s3://${{ secrets.DOC_BUCKET }}/${S3_PREFIX}/" --recursive
       - name: Upload to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOC_S3_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_S3_KEY }}
-        run: source ./.venv/bin/activate; aws s3 sync ./output s3://${{ secrets.DOC_BUCKET }}/docs/ --acl public-read
+        run: source ./.venv/bin/activate; aws s3 sync ./output "s3://${{ secrets.DOC_BUCKET }}/${S3_PREFIX}/" --acl public-read


### PR DESCRIPTION
## 為什麼

clearnet 的 docs 已經由 Action 自動建置並推上 S3，onion 版還只能登進 m6 手動跑
`build_docs_anoni_onion.sh`，成了唯一還要進機器做的一步。這支 PR 把 onion 版接進同一條
pipeline，推到既有 bucket 的 `docs-onion/` prefix。

## 做法

改成 matrix 的第二格（`variant: standard | onion`），兩個變體共用同一套建置步驟，不會各自漂移。
onion 專屬的只有三個動作，對齊 m6 上那支腳本：

| 動作 | 位置 |
|---|---|
| `replace_sitename_anoni_onion.sh` 改寫站內網址、拿掉 clearnet 分析區塊 | 建置前 |
| `robots_onion.txt` → `output/robots.txt` | 建置後 |
| 推到 `docs-onion/` 而不是 `docs/` | 上傳 |

改寫步驟刻意擺在 `uv sync` **之前**。那支腳本是 `find ./ -type f -exec sed -i`，`.venv` 一旦
建好就是上萬個檔案要被逐一重寫，既慢又沒有意義。乾淨 checkout 上實測 0.4s。

## 順帶修掉兩個會被新 prefix 引爆的問題

**`aws s3 rm s3://bucket/docs --recursive` 是前綴比對**，加上 `docs-onion/` 之後會把 onion 的
產物一起刪掉。補上結尾斜線。

**privacy 外掛的快取 key 沒帶 variant**，兩格同時跑會互相覆寫。依 variant 分開存，另外保留
一層不分 variant 的 restore fallback，因為鏡像的是第三方外部資產，兩個變體抓到的內容一樣，
新增的 onion 格不必從零重抓一輪。

## 加了一道產物驗證

`replace_sitename_anoni_onion.sh` 的結束碼來自最後那行診斷用的 `grep`，不是改寫本身。在 BSD
sed 上實測：每次 `sed -i` 都報 `invalid command code`、整棵樹一個字都沒改，腳本依然 exit 0。
runner 是 GNU sed 所以現在不會踩到，但這個失敗模式一旦發生，`docs-onion/` 會收到一份 clearnet
內容，m6 同步過去之後 onion 站開始送 clearnet 網址跟 `aa.anoni.net` 分析端點，而且沒有任何訊號。

所以建置完直接驗產物，正反兩個方向都看（只驗「沒有 clearnet 殘留」的話，產物是空的也會過關）。
拿 m6 上兩份現成產物對過：

- `/srv/ooni-docs-output/`（onion）→ 殘留 0 / 0，含 onion 網址 798 檔 → **PASS**
- `/srv/anoni-net/.../website/docs/`（clearnet）→ 殘留 799 / 765 → **exit 1**

## 合併之後還要做的事

1. **這支 workflow 觸發在 push 到 `docs` 分支**，而 `docs` 目前落後 main 23 個 commit。合併到
   main 不會馬上生效，要同步 `docs` 分支（或用 `workflow_dispatch` 手動觸發）才會跑到。
2. **m6 那端還沒接**。這支 PR 只負責把 onion 產物送上 S3，`/srv/ooni-docs-output/` 目前仍是手動
   `cp` 進去的。要真的免手動，還需要在 m6 加一支從 `docs-onion/` 拉下來的 sync（rclone 已經裝了）。
3. `--acl public-read` 沿用 clearnet 那格的設定。如果 m6 改用唯讀 IAM 憑證來拉，這個可以拿掉。

## 一個沒解釋的現象（不影響本 PR）

m6 上 clearnet 產物有 `sw.js`，onion 產物沒有，兩者同一個 checkout、同一支 `run.sh`。mkdocs 設定
裡沒有任何排除規則。因為 service worker 只在 `host === "anoni.net"` 註冊（`overrides/base.html`），
onion 少這支檔案沒有實際影響。CI 會忠實重現 m6 的行為，`Inject PWA build version` 那步在檔案不
存在時是 no-op，所以不論哪種結果都安全。

🤖 Generated with [Claude Code](https://claude.com/claude-code)