### PR TITLE
ci(docs): onion 版不要帶 service worker，解掉首次上線的驗證誤判

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -127,6 +127,15 @@ jobs:
         if: matrix.variant == 'onion'
         run: cp ./robots_onion.txt ./output/robots.txt
 
+      # service worker 只在 clearnet 註冊：overrides/base.html 用 `host === "anoni.net"`
+      # 擋著，onion 主機上兩個分支都不會進，這支檔案永遠不會被要求。留著只是兩份各
+      # 14KB 的死重量，而且它的註解提到 aa.anoni.net，會讓下一步的驗證誤判。
+      #
+      # 這也是 m6 上 onion 產物本來就沒有 sw.js 的原因，刪掉是回到既有行為。
+      - name: Drop service worker from onion build
+        if: matrix.variant == 'onion'
+        run: find ./output -name 'sw.js' -delete
+
       # replace_sitename_anoni_onion.sh 靠 GNU sed 的就地改寫，但它的結束碼來自最後
       # 那行診斷用的 grep，改寫整批失敗也一樣回 0（在 BSD sed 上實測過，全部沒改到、
       # 依然 exit 0）。沒驗的話這一格會把 clearnet 內容推上 docs-onion/，m6 同步過去


### PR DESCRIPTION
取代 #202。內容完全相同,只是換一條從 `main` 開出來的乾淨分支:#201 是 squash merge,
原分支還留著被壓掉的那兩個 commit,同一份改動在 main 上已經以另一個 SHA 存在,所以 GitHub
判定衝突。這條分支相對 main 只有一個 commit、9 行新增。

## 背景

#201 合併後第一次跑,onion 那格卡在 `Verify onion output`,上傳被擋下(`Clean`/`Upload`
都 skipped),`docs-onion/` 沒被寫進任何東西。clearnet 那格照常成功。

```
clearnet 殘留 https://anoni.net/docs：0 個檔案
clearnet 殘留 aa.anoni.net：2 個檔案
含 onion 網址：800 個檔案
```

網址改寫是好的。卡住的 2 個檔案是 `output/sw.js` 與 `output/zh-tw/sw.js`,兩處 `aa.anoni.net`
都在**註解**裡:

```
 * - 跨域請求（含 aa.anoni.net 分析）一律放行不快取
  // 跨域（含 aa.anoni.net 分析）與 scope 外的請求一律放行
```

## 為什麼刪檔案而不是放寬驗證

onion 版本來就不該帶這支檔案:

- `overrides/base.html` 用 `host === "anoni.net"` 擋著註冊,onion 主機上兩個分支都不會進
- 全站對 sw.js 的引用只有那一處,manifest 沒有引用
- 留著只是兩份各 14KB 的死重量

順帶解掉 #201 描述裡我標成「沒解釋的現象」那一條:m6 上 clearnet 產物有 sw.js、onion 沒有。
**onion 沒有才是對的**,CI 因為是乾淨環境反而把它建了出來。刪掉是回到 m6 一直以來服務的狀態。

驗證條件維持原樣不放寬,誤判來源移除之後 `aa.anoni.net` 應該歸零。

## 合併之後

一樣要把 `docs` 分支快轉上來才會跑到。IAM 對 `docs-onion/` 的寫入權限這次還沒驗到,
上一輪連 `Clean the all files` 都沒進到就被擋下,這輪才會第一次真的碰 S3。

🤖 Generated with [Claude Code](https://claude.com/claude-code)