### PR TITLE
feat(docs): 置頂公告改為 COSCUP 2026 活動宣傳（三語）

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{# 維護公告：8/13 18:00（台灣時間）過後移除，屆時另開 PR #}
+{# 活動公告：COSCUP 2026 結束（2026/8/9）後移除，屆時另開 PR #}
 {% block announce %}
-  公告：因基礎設施維護，本站與社群自架服務（Matrix、Cryptpad、Etherpad、SearXNG、Send、Formbricks）將於台灣時間 2026/8/12 22:00 至 8/13 18:00 停機，這段時間可能無法連線。可改用 <a href="https://anoni-net.ipns.dweb.link/" target="_blank">IPFS 鏡像</a> 暫時閱讀，或參考<a href="{{ 'help/' | url }}#趁有網路時把文件站裝成離線-App">如何把本站裝成離線 App</a>。
+  COSCUP 2026 匿名網路社群議程軌 8/08、8/09 在臺灣科技大學 <code>TR-510</code> 開講，免報名，當天到場即可參與。<a href="{{ 'activity/coscup-2026/' | url }}">看兩天完整議程</a>。現場網路壅塞時不好查資料，建議先<a href="{{ 'help/' | url }}#趁有網路時把文件站裝成離線-App">把文件站裝成離線 App</a>，收訊不好也能翻議程表。
 {% endblock %}
 
 {% block site_meta %}

--- a/docs/overrides_cn/main.html
+++ b/docs/overrides_cn/main.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{# 维护公告：8/13 18:00（台湾时间）过后移除，届时另开 PR #}
+{# 活动公告：COSCUP 2026 结束（2026/8/9）后移除，届时另开 PR #}
 {% block announce %}
-  公告：因基础设施维护，本站与社群自架服务（Matrix、Cryptpad、Etherpad、SearXNG、Send、Formbricks）将于台湾时间 2026/8/12 22:00 至 8/13 18:00 停机，这段时间可能无法连线。可改用 <a href="https://anoni-net.ipns.dweb.link/" target="_blank">IPFS 镜像</a> 暂时阅读，或参考<a href="{{ 'help/' | url }}#趁有网络时把文档站装成离线-App">如何把本站装成离线 App</a>。
+  COSCUP 2026 匿名网络社群议程轨 8/08、8/09 在台湾科技大学 <code>TR-510</code> 开讲，免报名，当天到场即可参与。<a href="{{ 'activity/coscup-2026/' | url }}">看两天完整议程</a>。现场网络壅塞时不好查资料，建议先<a href="{{ 'help/' | url }}#趁有网络时把文档站装成离线-App">把文档站装成离线 App</a>，信号不好也能翻议程表。
 {% endblock %}
 
 {% block site_meta %}

--- a/docs/overrides_en/main.html
+++ b/docs/overrides_en/main.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{# Maintenance notice: remove after 2026-08-13 18:00 Taiwan time, via a follow-up PR #}
+{# Event notice: remove after COSCUP 2026 ends (2026-08-09), via a follow-up PR #}
 {% block announce %}
-  Notice: due to infrastructure maintenance, this site and our self-hosted services (Matrix, Cryptpad, Etherpad, SearXNG, Send, Formbricks) will be down from 2026-08-12 22:00 to 2026-08-13 18:00 (Taiwan time) and may be unreachable during this window. You can use the <a href="https://anoni-net.ipns.dweb.link/" target="_blank">IPFS mirror</a> in the meantime, or see how to <a href="{{ 'offline-install/' | url }}">install this site for offline use</a>.
+  Our Anonymity Networks Community track at COSCUP 2026 runs on 8 and 9 August at NTUST in Taipei, room <code>TR-510</code>. Entry is free and no registration is needed. <a href="{{ 'activity/coscup-2026/' | url }}">See the two-day schedule</a>, and <a href="{{ 'offline-install/' | url }}">install this site for offline use</a> so you can still read the schedule when the venue network is congested.
 {% endblock %}
 
 {% block site_meta %}


### PR DESCRIPTION
## 內容

明後兩天（8/08、8/09）是 COSCUP 2026 匿名網路社群議程軌，站上卻還掛著 [#178](https://github.com/anoni-net/docs/pull/178) 的自架服務停機維護公告。這個 PR 把三語系的置頂公告換成活動宣傳。

**zh-TW**

> COSCUP 2026 匿名網路社群議程軌 8/08、8/09 在臺灣科技大學 `TR-510` 開講，免報名，當天到場即可參與。[看兩天完整議程](https://anoni.net/docs/activity/coscup-2026/)。現場網路壅塞時不好查資料，建議先[把文件站裝成離線 App](https://anoni.net/docs/help/#趁有網路時把文件站裝成離線-App)，收訊不好也能翻議程表。

zh-CN、en 為對應版本。

## 決策

- **主連結指向 `activity/coscup-2026`**：三語系都有這頁，且都在 nav 內
- **附帶推離線版**：會場網路不見得穩，PWA 裝好後議程表隨時查得到。zh-TW、zh-CN 連 `help/` 的離線 App 章節，en 連獨立的 `offline-install/` 頁（各語系現有結構不同）
- **維持不可關閉**：沿用 #178 的做法，沒加 `announce.dismiss`
- **註解的移除時機改成 COSCUP 結束（2026-08-09）之後**，屆時另開 PR 拿掉

## 驗證

- [x] 三語系 `mkdocs build` 皆 exit 0（cairo 警告為既有已知狀況，非新增）
- [x] 三語輸出 HTML 的 `data-md-component="announce"` 區塊文字與連結正確
- [x] 目標頁確實產出：`activity/coscup-2026/`（三語）、`en/offline-install/`
- [x] `help/` 的離線 App 錨點在 zh-TW（`#趁有網路時把文件站裝成離線-App`）與 zh-CN（`#趁有网络时把文档站装成离线-App`）輸出中都存在
- [x] 從巢狀頁面（如 `tools/index.html`）檢查相對連結解析為 `../activity/coscup-2026/`，深度正確
- [x] 三個檔案已無停機維護相關文字

🤖 Generated with [Claude Code](https://claude.com/claude-code)