### PR TITLE
ci(docs): 部署完自動清 Cloudflare 快取

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -171,3 +171,41 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOC_S3_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_S3_KEY }}
         run: source ./.venv/bin/activate; aws s3 sync ./output "s3://${{ secrets.DOC_BUCKET }}/${S3_PREFIX}/" --acl public-read
+
+      # S3 換好之後 Cloudflare edge 還是握著舊的 HTML，站上看到的仍是上一版。origin
+      # 送的是 `max-age=14400, must-revalidate`，但實測 age 超過 45000 秒依然回 HIT，
+      # 表示 zone 上有 Edge Cache TTL 蓋過 origin 標頭，等它自然過期不可靠。
+      # 2026-08-07 的 COSCUP 置頂公告就是這樣，部署成功但站上整整半天還是舊公告。
+      #
+      # 只在 standard 這格跑。onion 是 m6 上的獨立 server block，走 .onion 位址，
+      # 不經過 Cloudflare，沒有可清的 edge 快取。
+      #
+      # 用 purge_everything 而不是逐 URL：overrides 的改動（置頂公告、footer、分析
+      # 區塊）會同時影響每一頁，挑幾個 URL 清一定會漏。purge by prefix 與 by hostname
+      # 都是 Enterprise 功能，本 zone 是 Pro，逐 URL 又有單次 30 條的上限，湊不齊
+      # 整個 docs 站。清整個 zone 的代價是主站與其他子網域一起回源重抓，量很小。
+      #
+      # 沒設 secret 時只警告不失敗，讓還沒配 token 的環境（例如 fork）照樣能部署。
+      # 設了但 API 回錯就要 fail，否則會安靜地留下舊內容，跟沒清一樣難發現。
+      - name: Purge Cloudflare cache
+        if: matrix.variant == 'standard'
+        env:
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+          CF_PURGE_TOKEN: ${{ secrets.CF_PURGE_TOKEN }}
+        run: |
+          if [ -z "$CF_ZONE_ID" ] || [ -z "$CF_PURGE_TOKEN" ]; then
+            echo "::warning::CF_ZONE_ID 或 CF_PURGE_TOKEN 未設定，略過快取清除。S3 已更新，但站上可能還是舊內容。"
+            exit 0
+          fi
+          resp=$(curl -sS -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+            -H "Authorization: Bearer ${CF_PURGE_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}')
+          if echo "$resp" | jq -e '.success == true' > /dev/null 2>&1; then
+            echo "Cloudflare 快取已清除（zone 全清）"
+          else
+            echo "::error::Cloudflare 快取清除失敗，站上可能仍是舊內容"
+            echo "$resp" | jq -c '.errors // .' 2>/dev/null || echo "$resp"
+            exit 1
+          fi


### PR DESCRIPTION
## 問題

#204 合併、`docs` 分支快轉、BuildDocs 跑成功之後，站上仍然看到舊的停機維護公告。追下去發現 S3 與 nginx 都對，卡在 Cloudflare edge：

| 層 | 內容 |
|---|---|
| S3 origin (`ooni-research/docs/`) | 新（COSCUP 公告）|
| nginx (`anoni.net/docs/?cb=...` 繞過 CF) | 新，`last-modified: 07 Aug 00:19:12` |
| Cloudflare edge (`anoni.net/docs/`) | **舊**，`cf-cache-status: HIT`、`age=45500`、`last-modified: 06 Aug 08:08` |

origin 送的是 `max-age=14400, must-revalidate`（4 小時），但 age 已經 45000 秒還在 HIT，表示 zone 上有 Edge Cache TTL 蓋過 origin 標頭。等它自然過期不可靠，這次是活動前一天才發現公告沒換上去。

受影響的不只首頁，抽查 `/docs/`、`/docs/activity/coscup-2026/`、`/docs/zh-cn/`、`/docs/en/`、`/docs/help/`、`/docs/tools/` 全是 HIT 加舊內容。

## 做法

在 `Upload to S3` 之後補一步 `Purge Cloudflare cache`：

- **只在 `standard` 那格跑**。onion 是 m6 上的獨立 server block、走 .onion 位址，不經過 Cloudflare
- **用 `purge_everything`**。overrides 的改動（置頂公告、footer、分析區塊）會同時影響每一頁，挑幾個 URL 清一定會漏。purge by prefix 與 by hostname 都是 Enterprise 功能，本 zone 是 Pro Website（已用 API 確認），逐 URL 又有單次 30 條上限，湊不齊整個 docs 站
- **secret 沒設時只警告不失敗**，fork 或還沒配 token 的環境照樣能部署
- **設了但 API 回錯就 fail**，否則會安靜地留下舊內容，跟沒清一樣難發現

## 需要新增的 repository secret

| Secret | 值 |
|---|---|
| `CF_ZONE_ID` | anoni.net 的 zone ID |
| `CF_PURGE_TOKEN` | 權限只需 `Zone` → `Cache Purge` → `Purge`，範圍限 anoni.net |

沒加之前這一步會 warning 並略過，不會擋住部署。

## 驗證

- [x] YAML 可解析，步驟數 22，`Purge Cloudflare cache` 排在 `Upload to S3` 之後
- [x] 步驟 `if: matrix.variant == 'standard'`、env 只有 `CF_ZONE_ID` 與 `CF_PURGE_TOKEN`
- [x] shell 邏輯以 stub 回應跑過五種情境（curl 未實際發出）：secret 缺漏 → warning + exit 0；API success → exit 0；auth error → error + exit 1；非 JSON 回應（502 頁面）→ error + exit 1；只設 token 缺 zone id → warning + exit 0
- [x] zone 方案以 Cloudflare API 確認為 Pro Website，purge by prefix/hostname 不可用

🤖 Generated with [Claude Code](https://claude.com/claude-code)