### PR TITLE
ci(docs): 快取清除改成只清 docs/，不再波及 zone 內其他服務

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -61,6 +61,12 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      # 擺在建置與上傳之前，映射邏輯壞掉時在碰到 S3 之前就失敗。純 stdlib、不連網，
+      # 跑起來不到一秒。清除範圍算錯不會讓建置變紅燈，只能靠這裡擋。
+      - name: Test cache purge script
+        if: matrix.variant == 'standard'
+        run: python3 ../tools/test_cf_purge.py
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
       - name: Sync Packages
@@ -180,10 +186,10 @@ jobs:
       # 只在 standard 這格跑。onion 是 m6 上的獨立 server block，走 .onion 位址，
       # 不經過 Cloudflare，沒有可清的 edge 快取。
       #
-      # 用 purge_everything 而不是逐 URL：overrides 的改動（置頂公告、footer、分析
-      # 區塊）會同時影響每一頁，挑幾個 URL 清一定會漏。purge by prefix 與 by hostname
-      # 都是 Enterprise 功能，本 zone 是 Pro，逐 URL 又有單次 30 條的上限，湊不齊
-      # 整個 docs 站。清整個 zone 的代價是主站與其他子網域一起回源重抓，量很小。
+      # 清除範圍限這次產出的 /docs/ 網址，不用 purge_everything：同一個 zone 底下還有
+      # 主站、pad、form、search，沒有理由為了換 docs 的內容把它們一起清掉。
+      # purge by prefix 與 by hostname 是 Enterprise 功能，本 zone 是 Pro，所以由
+      # tools/cf_purge.py 把產物映射回網址逐批清（每批 30 條，約 48 次呼叫）。
       #
       # 沒設 secret 時只警告不失敗，讓還沒配 token 的環境（例如 fork）照樣能部署。
       # 設了但 API 回錯就要 fail，否則會安靜地留下舊內容，跟沒清一樣難發現。
@@ -192,20 +198,4 @@ jobs:
         env:
           CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
           CF_PURGE_TOKEN: ${{ secrets.CF_PURGE_TOKEN }}
-        run: |
-          if [ -z "$CF_ZONE_ID" ] || [ -z "$CF_PURGE_TOKEN" ]; then
-            echo "::warning::CF_ZONE_ID 或 CF_PURGE_TOKEN 未設定，略過快取清除。S3 已更新，但站上可能還是舊內容。"
-            exit 0
-          fi
-          resp=$(curl -sS -X POST \
-            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
-            -H "Authorization: Bearer ${CF_PURGE_TOKEN}" \
-            -H "Content-Type: application/json" \
-            --data '{"purge_everything":true}')
-          if echo "$resp" | jq -e '.success == true' > /dev/null 2>&1; then
-            echo "Cloudflare 快取已清除（zone 全清）"
-          else
-            echo "::error::Cloudflare 快取清除失敗，站上可能仍是舊內容"
-            echo "$resp" | jq -c '.errors // .' 2>/dev/null || echo "$resp"
-            exit 1
-          fi
+        run: python3 ../tools/cf_purge.py --output ./output

--- a/tools/cf_purge.py
+++ b/tools/cf_purge.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""部署後清除 Cloudflare edge 快取，範圍限這次建置產出的 /docs/ 網址。
+
+anoni.net 這個 zone 底下還有主站、pad、form、search 等服務，`purge_everything`
+會把它們一起清掉，只是為了換 docs 的內容並不划算。Cloudflare 的 purge by prefix
+與 purge by hostname 都是 Enterprise 功能，本 zone 是 Pro，所以改成逐 URL 清：
+把建置產物的每個檔案映射回對外網址，每批 30 條送一次（Pro 的單次上限）。
+
+映射規則：
+
+    output/index.html            -> {base}/
+    output/basics/index.html     -> {base}/basics/
+    output/404.html              -> {base}/404.html
+    output/stylesheets/extra.css -> {base}/stylesheets/extra.css
+
+只清目錄式網址，不另外清 `.../index.html`。站上是 MkDocs 的
+`use_directory_urls`，訪客與爬蟲要到的都是帶結尾斜線的那個形式，那才是實際被
+快取的 key。
+
+資產也一起清。Material 自己的 bundle 檔名帶 content hash（`main.<hash>.min.css`）
+本來就不會殘留，但 `stylesheets/extra.css`、`sw.js`、`sitemap.xml`、RSS feed
+這些沒有 hash，改了就必須清，逐一挑選容易漏，整份清掉才 48 次呼叫。
+
+用法：
+    python3 tools/cf_purge.py --output docs/output
+    python3 tools/cf_purge.py --output docs/output --dry-run   # 只印，不呼叫 API
+
+需要環境變數 CF_ZONE_ID 與 CF_PURGE_TOKEN，token 權限只需 Zone -> Cache Purge。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from urllib.parse import quote
+
+# Pro 方案 purge by URL 的單次上限。Enterprise 是 500，改方案時記得一起調。
+BATCH_SIZE = 30
+API = "https://api.cloudflare.com/client/v4/zones/{zone}/purge_cache"
+DEFAULT_BASE_URL = "https://anoni.net/docs"
+
+
+def to_url(rel_path: Path, base_url: str) -> str:
+    """把產物的相對路徑映射成對外網址。"""
+    parts = list(rel_path.parts)
+    if parts and parts[-1] == "index.html":
+        parts = parts[:-1]
+        tail = "/".join(quote(p, safe="") for p in parts)
+        return f"{base_url}/{tail}/" if tail else f"{base_url}/"
+    tail = "/".join(quote(p, safe="") for p in parts)
+    return f"{base_url}/{tail}"
+
+
+def collect_urls(output_dir: Path, base_url: str) -> list[str]:
+    """列出這份產物對應的所有網址，含不帶結尾斜線的站台根路徑。"""
+    base_url = base_url.rstrip("/")
+    urls = {
+        to_url(p.relative_to(output_dir), base_url)
+        for p in output_dir.rglob("*")
+        if p.is_file()
+    }
+    # nginx 對 `/docs`（無結尾斜線）自己發 301，那個回應也會進 edge 快取。
+    urls.add(base_url)
+    return sorted(urls)
+
+
+def batched(items: list[str], size: int):
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
+
+def purge_batch(zone: str, token: str, urls: list[str], attempts: int = 3) -> None:
+    """送出一批 purge，失敗時重試。全部失敗就丟 RuntimeError。"""
+    body = json.dumps({"files": urls}).encode("utf-8")
+    req = urllib.request.Request(
+        API.format(zone=zone),
+        data=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    last_err = ""
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+            if payload.get("success") is True:
+                return
+            last_err = json.dumps(payload.get("errors", payload), ensure_ascii=False)
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")[:500]
+            last_err = f"HTTP {exc.code}: {detail}"
+            # 認證與權限錯誤重試幾次也不會變，直接放棄。
+            if exc.code in (400, 401, 403):
+                break
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            last_err = f"{type(exc).__name__}: {exc}"
+        if attempt < attempts:
+            time.sleep(2 * attempt)
+    raise RuntimeError(last_err or "unknown error")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, help="建置產物目錄（例如 docs/output）")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL, help="對外網址前綴")
+    parser.add_argument("--dry-run", action="store_true", help="只印出網址，不呼叫 API")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output)
+    if not output_dir.is_dir():
+        print(f"::error::找不到產物目錄 {output_dir}", file=sys.stderr)
+        return 1
+
+    urls = collect_urls(output_dir, args.base_url)
+    # 產物是空的代表前面的建置或搬移出了問題，清空快取只會讓狀況更糟。
+    if len(urls) <= 1:
+        print(f"::error::{output_dir} 幾乎沒有檔案，中止清除", file=sys.stderr)
+        return 1
+
+    batches = list(batched(urls, BATCH_SIZE))
+    print(f"準備清除 {len(urls)} 個網址，分 {len(batches)} 批（每批最多 {BATCH_SIZE} 條）")
+
+    if args.dry_run:
+        for u in urls:
+            print(u)
+        return 0
+
+    zone = os.environ.get("CF_ZONE_ID", "")
+    token = os.environ.get("CF_PURGE_TOKEN", "")
+    if not zone or not token:
+        print(
+            "::warning::CF_ZONE_ID 或 CF_PURGE_TOKEN 未設定，略過快取清除。"
+            "S3 已更新，但站上可能還是舊內容。",
+        )
+        return 0
+
+    for i, chunk in enumerate(batches, 1):
+        try:
+            purge_batch(zone, token, chunk)
+        except RuntimeError as exc:
+            print(f"::error::第 {i}/{len(batches)} 批清除失敗：{exc}", file=sys.stderr)
+            return 1
+        print(f"  第 {i}/{len(batches)} 批完成（{len(chunk)} 條）")
+
+    print(f"Cloudflare 快取已清除，共 {len(urls)} 個 {args.base_url} 底下的網址")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_cf_purge.py
+++ b/tools/test_cf_purge.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""cf_purge.py 的回歸測試。
+
+這支腳本決定「部署後哪些網址會被清掉」，錯了不會有人立刻發現：漏清就是訪客看到
+舊內容（2026-08-07 的 COSCUP 置頂公告就是這樣，部署成功但站上半天沒換），多清則
+是把 zone 底下其他服務一起波及。兩種都不會讓建置變紅燈，只能靠測試守住。
+
+映射規則改動時，請一併在這裡補上對應案例。不呼叫網路，只測純函式。
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from cf_purge import BATCH_SIZE, batched, collect_urls, to_url  # noqa: E402
+
+BASE = "https://anoni.net/docs"
+
+failures: list[str] = []
+
+
+def check(label: str, got, want) -> None:
+    if got != want:
+        failures.append(f"{label}\n    got:  {got!r}\n    want: {want!r}")
+
+
+def test_to_url() -> None:
+    cases = [
+        # 首頁的 index.html 收斂成站台根路徑，不是 /docs//
+        ("index.html", f"{BASE}/"),
+        # 一般頁面用目錄式網址，結尾要有斜線
+        ("basics/index.html", f"{BASE}/basics/"),
+        ("zh-cn/activity/coscup-2026/index.html", f"{BASE}/zh-cn/activity/coscup-2026/"),
+        ("en/offline-install/index.html", f"{BASE}/en/offline-install/"),
+        # 非 index 的 HTML 保留檔名
+        ("404.html", f"{BASE}/404.html"),
+        # 沒有 content hash、改了就必須清的那幾支
+        ("stylesheets/extra.css", f"{BASE}/stylesheets/extra.css"),
+        ("sw.js", f"{BASE}/sw.js"),
+        ("sitemap.xml", f"{BASE}/sitemap.xml"),
+        ("manifest.webmanifest", f"{BASE}/manifest.webmanifest"),
+        # 一般資產
+        ("assets/images/logo-tonal.svg", f"{BASE}/assets/images/logo-tonal.svg"),
+    ]
+    for rel, want in cases:
+        check(f"to_url({rel})", to_url(pathlib.Path(rel), BASE), want)
+
+
+def test_to_url_encodes_special_chars() -> None:
+    # 檔名含空白或非 ASCII 時要送出百分比編碼的形式，否則清到的不是實際的快取 key
+    check(
+        "to_url(空白)",
+        to_url(pathlib.Path("assets/a b.png"), BASE),
+        f"{BASE}/assets/a%20b.png",
+    )
+    check(
+        "to_url(中文)",
+        to_url(pathlib.Path("assets/圖.png"), BASE),
+        f"{BASE}/assets/%E5%9C%96.png",
+    )
+    check(
+        "to_url(中文目錄頁)",
+        to_url(pathlib.Path("測試/index.html"), BASE),
+        f"{BASE}/%E6%B8%AC%E8%A9%A6/",
+    )
+
+
+def test_collect_urls() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        for rel in [
+            "index.html",
+            "basics/index.html",
+            "zh-cn/index.html",
+            "en/index.html",
+            "404.html",
+            "stylesheets/extra.css",
+            "assets/stylesheets/main.484c7ddc.min.css",
+        ]:
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("x", encoding="utf-8")
+        # 空目錄不該產生網址
+        (root / "emptydir").mkdir()
+
+        urls = collect_urls(root, BASE)
+
+        want = sorted(
+            {
+                BASE,  # 無結尾斜線的 301
+                f"{BASE}/",
+                f"{BASE}/basics/",
+                f"{BASE}/zh-cn/",
+                f"{BASE}/en/",
+                f"{BASE}/404.html",
+                f"{BASE}/stylesheets/extra.css",
+                f"{BASE}/assets/stylesheets/main.484c7ddc.min.css",
+            }
+        )
+        check("collect_urls", urls, want)
+
+        # 只清 base 底下，不會外溢到 zone 的其他服務
+        stray = [u for u in urls if not u.startswith(BASE)]
+        check("collect_urls 不外溢", stray, [])
+
+        # 結尾斜線的 base 應該得到同樣結果，不會出現 //
+        check("collect_urls(base 帶斜線)", collect_urls(root, BASE + "/"), want)
+
+
+def test_batched() -> None:
+    items = [str(i) for i in range(70)]
+    chunks = list(batched(items, BATCH_SIZE))
+    check("batched 批數", len(chunks), 3)
+    check("batched 每批上限", max(len(c) for c in chunks), BATCH_SIZE)
+    check("batched 不漏件", [x for c in chunks for x in c], items)
+    check("batched 空清單", list(batched([], BATCH_SIZE)), [])
+
+
+def main() -> int:
+    for fn in [
+        test_to_url,
+        test_to_url_encodes_special_chars,
+        test_collect_urls,
+        test_batched,
+    ]:
+        fn()
+    if failures:
+        print(f"FAILED ({len(failures)})")
+        for f in failures:
+            print("  " + f)
+        return 1
+    print("cf_purge tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 問題

#205 用的是 `purge_everything`，會把 `anoni.net` 這個 zone 底下的主站、pad、form、search 一起清掉。為了換 docs 的內容清整個 zone 沒有必要。

## 為什麼不能用 prefix

Cloudflare 的 purge by prefix 與 purge by hostname 都是 Enterprise 功能，本 zone 是 Pro Website（已用 API 確認）。Pro 能用的是 purge by URL，單次上限 30 條。

所以改成逐 URL 清：`tools/cf_purge.py` 把建置產物映射回對外網址，分批送出。實測目前產物是 **1430 個網址、48 批**，48 次 API 呼叫遠低於 zone 的 purge 速率上限。

## 映射規則

```
output/index.html            -> /docs/
output/basics/index.html     -> /docs/basics/
output/404.html              -> /docs/404.html
output/stylesheets/extra.css -> /docs/stylesheets/extra.css
```

只清目錄式網址，不另外清 `.../index.html`。站上是 MkDocs 的 `use_directory_urls`，訪客要到的是帶結尾斜線的形式，那才是實際被快取的 key。另外補上不帶結尾斜線的 `/docs`（nginx 自己發的 301 也會進快取）。

資產一併清，不做挑選。Material 自己的 bundle 檔名帶 content hash（`main.484c7ddc.min.css`）本來就不會殘留，但 `stylesheets/extra.css`、`sw.js`、`sitemap.xml`、RSS feed 這幾支沒有 hash，改了就必須清。逐一挑選容易漏，整份清掉也才 48 次呼叫。

## 測試

清除範圍算錯不會讓建置變紅燈（漏清是訪客看到舊內容，多清是波及其他服務），只能靠測試守住。補 `tools/test_cf_purge.py`，並在 workflow 的建置步驟**之前**跑，映射邏輯壞掉時在碰到 S3 之前就失敗。

## 驗證

- [x] `python3 tools/test_cf_purge.py` 通過：目錄式網址收斂、404.html 保留檔名、無 hash 的資產、百分比編碼（空白、中文、中文目錄頁）、分批不漏件、base 帶不帶結尾斜線結果一致
- [x] 對真實產物 dry-run：1430 個網址、48 批、exit 0，`grep -vc "^https://anoni.net/docs"` 為 **0**，沒有一條落在 `/docs/` 之外
- [x] 從 workflow 的 working-directory（`./docs`）實跑相對路徑呼叫，兩支腳本都正常
- [x] 保護分支：secret 未設定 → warning + exit 0 且不發任何請求；產物目錄不存在 → error + exit 1；產物目錄是空的 → error + exit 1（避免建置壞掉時還去清快取）
- [x] YAML 可解析，測試步驟排在 `Install uv` 之前、purge 排在 `Upload to S3` 之後，兩者都 `if: matrix.variant == 'standard'`

以上測試都沒有實際呼叫 Cloudflare API。

🤖 Generated with [Claude Code](https://claude.com/claude-code)